### PR TITLE
fix(translation): retry partial DeepL batches with cancellable progress

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -8,10 +8,12 @@ import { registerConfigHandlers } from './ipc/config.ipc'
 import { registerDictionaryHandlers } from './ipc/dictionary.ipc'
 import { registerFsHandlers } from './ipc/fs.ipc'
 import { registerLanguageHandlers } from './ipc/language.ipc'
+import { registerLogHandlers } from './ipc/log.ipc'
 import { registerModHandlers } from './ipc/mod.ipc'
 import { registerTranslationHandlers } from './ipc/translation.ipc'
 import { registerWindowHandlers, setupWindowEvents } from './ipc/window.ipc'
 import { registerXmlHandlers } from './ipc/xml.ipc'
+import { logError } from './services/log.service'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -68,6 +70,7 @@ app.whenReady().then(() => {
   registerTranslationHandlers(getWindow)
   registerDictionaryHandlers(repos)
   registerLanguageHandlers(repos)
+  registerLogHandlers()
   registerModHandlers(repos)
   registerConfigHandlers()
   registerFsHandlers()
@@ -78,6 +81,14 @@ app.whenReady().then(() => {
   app.on('activate', () => {
     if (BrowserWindow.getAllWindows().length === 0) createWindow()
   })
+})
+
+process.on('uncaughtException', (err) => {
+  logError('main.uncaughtException', err)
+})
+
+process.on('unhandledRejection', (reason) => {
+  logError('main.unhandledRejection', reason)
 })
 
 app.on('window-all-closed', () => {

--- a/src/main/ipc/log.ipc.ts
+++ b/src/main/ipc/log.ipc.ts
@@ -1,0 +1,27 @@
+import { ipcMain } from 'electron'
+import {
+  clearLogFile,
+  getLogPath,
+  openLogFile,
+  writeLog,
+  type LogPayload
+} from '../services/log.service'
+
+export function registerLogHandlers(): void {
+  ipcMain.handle('log:getPath', () => getLogPath())
+
+  ipcMain.handle('log:open', async () => {
+    await openLogFile()
+    return { success: true }
+  })
+
+  ipcMain.handle('log:clear', () => {
+    clearLogFile()
+    return { success: true }
+  })
+
+  ipcMain.handle('log:write', (_event, payload: LogPayload) => {
+    writeLog(payload)
+    return { success: true }
+  })
+}

--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -7,7 +7,11 @@ import type { BasePipeline, PipelineOptions } from '../pipelines/base.pipeline'
 import { DeepLPipeline } from '../pipelines/deepl.pipeline'
 import { ManualPipeline } from '../pipelines/manual.pipeline'
 import { OpenAIPipeline } from '../pipelines/openai.pipeline'
-import { translateBatch as translateDeepLBatch, translateText as translateDeepL } from '../services/deepl.service'
+import {
+  translateBatchDetailed as translateDeepLBatch,
+  translateText as translateDeepL
+} from '../services/deepl.service'
+import { logError } from '../services/log.service'
 import { translateText as translateOpenAI } from '../services/openai.service'
 import { getActiveWindow } from '../utils/window'
 
@@ -19,11 +23,28 @@ export interface TranslationStartPayload extends PipelineOptions {
   model?: string
 }
 
+interface BatchSummary {
+  total: number
+  translated: number
+  failed: number
+}
+
 // Active jobs keyed by jobId - AbortController allows cancellation
 const activeJobs = new Map<string, AbortController>()
 
 export function registerTranslationHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('translation:start', async (_event, payload: TranslationStartPayload) => {
+    try {
+      requirePayloadApiKey(payload)
+    } catch (err) {
+      logError('translation.start.validation', err, {
+        provider: payload.provider,
+        sourceLang: payload.sourceLang,
+        targetLang: payload.targetLang,
+        modName: payload.modName
+      })
+      throw err
+    }
     const jobId = randomUUID()
     const controller = new AbortController()
     activeJobs.set(jobId, controller)
@@ -46,6 +67,13 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
       })
       .catch((err: Error) => {
         activeJobs.delete(jobId)
+        logError('translation.start.pipeline', err, {
+          jobId,
+          provider: payload.provider,
+          sourceLang: payload.sourceLang,
+          targetLang: payload.targetLang,
+          modName: payload.modName
+        })
         const win = getActiveWindow(getWindow)
         if (win) {
           win.webContents.send('translation:error', {
@@ -74,15 +102,19 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         targetLang: string
       }
     ): Promise<string> => {
-      const { provider, text, sourceLang, targetLang } = payload
-      const apiKey = readApiKey(provider)
-      if (!provider) throw new Error(`Unknown provider`)
-      if (!apiKey)
-        throw new Error(
-          `${provider === 'deepl' ? 'DeepL' : 'OpenAI'} API key not configured. Go to Settings.`
-        )
-      if (provider === 'deepl') return translateDeepL(text, sourceLang, targetLang, apiKey)
-      return translateOpenAI(text, sourceLang, targetLang, apiKey)
+      try {
+        const { provider, text, sourceLang, targetLang } = payload
+        const apiKey = requireStoredApiKey(provider)
+        if (provider === 'deepl') return translateDeepL(text, sourceLang, targetLang, apiKey)
+        return translateOpenAI(text, sourceLang, targetLang, apiKey)
+      } catch (err) {
+        logError('translation.single', err, {
+          provider: payload.provider,
+          sourceLang: payload.sourceLang,
+          targetLang: payload.targetLang
+        })
+        throw err
+      }
     }
   )
 
@@ -96,43 +128,42 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         sourceLang: string
         targetLang: string
       }
-    ): Promise<void> => {
+    ): Promise<BatchSummary> => {
       const { entries, provider, sourceLang, targetLang } = payload
-      const apiKey = readApiKey(provider)
-      if (!apiKey) {
-        const win = getActiveWindow(getWindow)
-        if (win) {
-          win.webContents.send('translation:batchProgress', {
-            uid: '',
-            target: null,
-            error: `${provider === 'deepl' ? 'DeepL' : 'OpenAI'} API key not configured. Go to Settings.`
-          })
-        }
-        return
+      const summary: BatchSummary = { total: entries.length, translated: 0, failed: 0 }
+      let apiKey: string
+      try {
+        apiKey = requireStoredApiKey(provider)
+      } catch (err) {
+        logError('translation.batch.validation', err, { provider, sourceLang, targetLang })
+        throw err
       }
 
       if (provider === 'deepl') {
-        // DeepL: send all texts in bulk (50 per HTTP request), preserving order
         const texts = entries.map((e) => e.source)
-        try {
-          const translated = await translateDeepLBatch(texts, sourceLang, targetLang, apiKey)
-          const win = getActiveWindow(getWindow)
-          if (win) {
-            for (let i = 0; i < entries.length; i++) {
+        const results = await translateDeepLBatch(texts, sourceLang, targetLang, apiKey)
+        const win = getActiveWindow(getWindow)
+        for (const result of results) {
+          const entry = entries[result.index]
+          if (!entry) continue
+          if (result.translated != null) {
+            summary.translated++
+            if (win) {
               win.webContents.send('translation:batchProgress', {
-                uid: entries[i].uid,
-                target: translated[i] ?? ''
+                uid: entry.uid,
+                target: result.translated
               })
             }
-          }
-        } catch (err) {
-          const win = getActiveWindow(getWindow)
-          if (win) {
-            win.webContents.send('translation:batchProgress', {
-              uid: '',
-              target: null,
-              error: err instanceof Error ? err.message : String(err)
-            })
+          } else {
+            summary.failed++
+            const error = result.error ?? 'DeepL translation failed'
+            if (win) {
+              win.webContents.send('translation:batchProgress', {
+                uid: entry.uid,
+                target: null,
+                error
+              })
+            }
           }
         }
       } else {
@@ -140,6 +171,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         await runConcurrent(entries, 10, async (entry) => {
           try {
             const translated = await translateOpenAI(entry.source, sourceLang, targetLang, apiKey)
+            summary.translated++
             const win = getActiveWindow(getWindow)
             if (win) {
               win.webContents.send('translation:batchProgress', {
@@ -148,6 +180,12 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
               })
             }
           } catch (err) {
+            summary.failed++
+            logError('translation.batch.openai.entry', err, {
+              uid: entry.uid,
+              sourceLang,
+              targetLang
+            })
             const win = getActiveWindow(getWindow)
             if (win) {
               win.webContents.send('translation:batchProgress', {
@@ -159,6 +197,8 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
           }
         })
       }
+
+      return summary
     }
   )
 }
@@ -169,7 +209,25 @@ function readApiKey(provider: 'openai' | 'deepl'): string | null {
   const row = db.select().from(config).where(eq(config.key, key)).get() as
     | { key: string; value: string | null }
     | undefined
-  return row?.value ?? null
+  const value = row?.value?.trim() ?? ''
+  return value.length > 0 ? value : null
+}
+
+function requireStoredApiKey(provider: 'openai' | 'deepl'): string {
+  const apiKey = readApiKey(provider)
+  if (!apiKey) throw new Error(`${providerLabel(provider)} API key not configured. Go to Settings.`)
+  return apiKey
+}
+
+function requirePayloadApiKey(payload: TranslationStartPayload): void {
+  if (payload.provider === 'manual') return
+  if (!payload.apiKey?.trim()) {
+    throw new Error(`${providerLabel(payload.provider)} API key is required`)
+  }
+}
+
+function providerLabel(provider: 'openai' | 'deepl'): string {
+  return provider === 'deepl' ? 'DeepL' : 'OpenAI'
 }
 
 function buildPipeline(payload: TranslationStartPayload): BasePipeline {

--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -23,10 +23,24 @@ export interface TranslationStartPayload extends PipelineOptions {
   model?: string
 }
 
+interface BatchPayload {
+  entries: { uid: string; source: string }[]
+  provider: 'openai' | 'deepl'
+  sourceLang: string
+  targetLang: string
+}
+
 interface BatchSummary {
   total: number
   translated: number
   failed: number
+}
+
+interface BatchJobContext extends BatchPayload {
+  jobId: string
+  apiKey: string
+  signal: AbortSignal
+  getWindow: () => BrowserWindow | null
 }
 
 // Active jobs keyed by jobId - AbortController allows cancellation
@@ -122,15 +136,9 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
     'translation:batch',
     async (
       _event,
-      payload: {
-        entries: { uid: string; source: string }[]
-        provider: 'openai' | 'deepl'
-        sourceLang: string
-        targetLang: string
-      }
-    ): Promise<BatchSummary> => {
-      const { entries, provider, sourceLang, targetLang } = payload
-      const summary: BatchSummary = { total: entries.length, translated: 0, failed: 0 }
+      payload: BatchPayload
+    ): Promise<{ jobId: string }> => {
+      const { provider, sourceLang, targetLang } = payload
       let apiKey: string
       try {
         apiKey = requireStoredApiKey(provider)
@@ -139,66 +147,21 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         throw err
       }
 
-      if (provider === 'deepl') {
-        const texts = entries.map((e) => e.source)
-        const results = await translateDeepLBatch(texts, sourceLang, targetLang, apiKey)
-        const win = getActiveWindow(getWindow)
-        for (const result of results) {
-          const entry = entries[result.index]
-          if (!entry) continue
-          if (result.translated != null) {
-            summary.translated++
-            if (win) {
-              win.webContents.send('translation:batchProgress', {
-                uid: entry.uid,
-                target: result.translated
-              })
-            }
-          } else {
-            summary.failed++
-            const error = result.error ?? 'DeepL translation failed'
-            if (win) {
-              win.webContents.send('translation:batchProgress', {
-                uid: entry.uid,
-                target: null,
-                error
-              })
-            }
-          }
-        }
-      } else {
-        // OpenAI: parallel worker pool (10 concurrent requests)
-        await runConcurrent(entries, 10, async (entry) => {
-          try {
-            const translated = await translateOpenAI(entry.source, sourceLang, targetLang, apiKey)
-            summary.translated++
-            const win = getActiveWindow(getWindow)
-            if (win) {
-              win.webContents.send('translation:batchProgress', {
-                uid: entry.uid,
-                target: translated
-              })
-            }
-          } catch (err) {
-            summary.failed++
-            logError('translation.batch.openai.entry', err, {
-              uid: entry.uid,
-              sourceLang,
-              targetLang
-            })
-            const win = getActiveWindow(getWindow)
-            if (win) {
-              win.webContents.send('translation:batchProgress', {
-                uid: entry.uid,
-                target: null,
-                error: err instanceof Error ? err.message : String(err)
-              })
-            }
-          }
-        })
-      }
+      const jobId = randomUUID()
+      const controller = new AbortController()
+      activeJobs.set(jobId, controller)
 
-      return summary
+      void runBatchJob({
+        ...payload,
+        jobId,
+        apiKey,
+        signal: controller.signal,
+        getWindow
+      }).finally(() => {
+        activeJobs.delete(jobId)
+      })
+
+      return { jobId }
     }
   )
 }
@@ -252,14 +215,197 @@ function buildPipeline(payload: TranslationStartPayload): BasePipeline {
 async function runConcurrent<T>(
   items: T[],
   concurrency: number,
-  fn: (item: T) => Promise<void>
+  fn: (item: T) => Promise<void>,
+  signal?: AbortSignal
 ): Promise<void> {
   let index = 0
   const workers = Array.from({ length: Math.min(concurrency, items.length) }, async () => {
     while (index < items.length) {
+      throwIfAborted(signal)
       const item = items[index++]
       await fn(item)
     }
   })
   await Promise.all(workers)
+}
+
+async function runBatchJob(ctx: BatchJobContext): Promise<void> {
+  const summary: BatchSummary = {
+    total: ctx.entries.length,
+    translated: 0,
+    failed: 0
+  }
+
+  try {
+    if (ctx.provider === 'deepl') {
+      await runDeepLBatchJob(ctx, summary)
+    } else {
+      await runOpenAIBatchJob(ctx, summary)
+    }
+
+    if (ctx.signal.aborted) {
+      summary.failed = summary.total - summary.translated
+    }
+
+    emitBatchDone(ctx.getWindow, {
+      jobId: ctx.jobId,
+      ...summary,
+      cancelled: ctx.signal.aborted
+    })
+  } catch (err) {
+    if (isAbortError(err) || ctx.signal.aborted) {
+      summary.failed = summary.total - summary.translated
+      emitBatchDone(ctx.getWindow, {
+        jobId: ctx.jobId,
+        ...summary,
+        cancelled: true
+      })
+      return
+    }
+
+    logError('translation.batch.job', err, {
+      jobId: ctx.jobId,
+      provider: ctx.provider,
+      sourceLang: ctx.sourceLang,
+      targetLang: ctx.targetLang,
+      total: ctx.entries.length
+    })
+    emitBatchError(ctx.getWindow, {
+      jobId: ctx.jobId,
+      message: err instanceof Error ? err.message : String(err)
+    })
+  }
+}
+
+async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Promise<void> {
+  let pendingEntries = [...ctx.entries]
+
+  while (pendingEntries.length > 0) {
+    throwIfAborted(ctx.signal)
+
+    const results = await translateDeepLBatch(
+      pendingEntries.map((entry) => entry.source),
+      ctx.sourceLang,
+      ctx.targetLang,
+      ctx.apiKey,
+      ctx.signal
+    )
+
+    let roundSuccesses = 0
+    const nextPending: BatchPayload['entries'] = []
+
+    for (const result of results) {
+      const entry = pendingEntries[result.index]
+      if (!entry) continue
+
+      if (result.translated != null) {
+        roundSuccesses++
+        summary.translated++
+        emitBatchProgress(ctx.getWindow, {
+          jobId: ctx.jobId,
+          uid: entry.uid,
+          target: result.translated
+        })
+        continue
+      }
+
+      nextPending.push(entry)
+    }
+
+    if (nextPending.length === 0) {
+      summary.failed = 0
+      return
+    }
+
+    if (roundSuccesses === 0) {
+      summary.failed = nextPending.length
+      return
+    }
+
+    pendingEntries = nextPending
+  }
+}
+
+async function runOpenAIBatchJob(ctx: BatchJobContext, summary: BatchSummary): Promise<void> {
+  await runConcurrent(
+    ctx.entries,
+    10,
+    async (entry) => {
+      throwIfAborted(ctx.signal)
+
+      try {
+        const translated = await translateOpenAI(
+          entry.source,
+          ctx.sourceLang,
+          ctx.targetLang,
+          ctx.apiKey,
+          [],
+          'gpt-4o-mini',
+          ctx.signal
+        )
+        summary.translated++
+        emitBatchProgress(ctx.getWindow, {
+          jobId: ctx.jobId,
+          uid: entry.uid,
+          target: translated
+        })
+      } catch (err) {
+        if (isAbortError(err) || ctx.signal.aborted) throw err
+
+        summary.failed++
+        logError('translation.batch.openai.entry', err, {
+          uid: entry.uid,
+          sourceLang: ctx.sourceLang,
+          targetLang: ctx.targetLang
+        })
+      }
+    },
+    ctx.signal
+  )
+}
+
+function emitBatchProgress(
+  getWindow: () => BrowserWindow | null,
+  payload: { jobId: string; uid: string; target: string | null; error?: string }
+): void {
+  const win = getActiveWindow(getWindow)
+  if (win) {
+    win.webContents.send('translation:batchProgress', payload)
+  }
+}
+
+function emitBatchDone(
+  getWindow: () => BrowserWindow | null,
+  payload: {
+    jobId: string
+    total: number
+    translated: number
+    failed: number
+    cancelled: boolean
+  }
+): void {
+  const win = getActiveWindow(getWindow)
+  if (win) {
+    win.webContents.send('translation:batchDone', payload)
+  }
+}
+
+function emitBatchError(
+  getWindow: () => BrowserWindow | null,
+  payload: { jobId: string; message: string }
+): void {
+  const win = getActiveWindow(getWindow)
+  if (win) {
+    win.webContents.send('translation:batchError', payload)
+  }
+}
+
+function throwIfAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw signal.reason ?? new Error('Translation cancelled')
+  }
+}
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && (err.name === 'AbortError' || err.message === 'Translation cancelled')
 }

--- a/src/main/services/deepl.service.ts
+++ b/src/main/services/deepl.service.ts
@@ -1,58 +1,93 @@
 import { decodeEntities, encodeEntities } from './xml-entities.service'
+import { logError } from './log.service'
 
 const DEEPL_API_URL = 'https://api-free.deepl.com/v2/translate'
 const DEEPL_CHUNK_SIZE = 50
+const MAX_RETRIES = 3
+
+class DeepLApiError extends Error {
+  constructor(
+    public readonly status: number,
+    detail: string
+  ) {
+    super(`DeepL API error ${status}: ${detail}`)
+  }
+}
+
+export interface BatchTranslationResult {
+  index: number
+  translated: string | null
+  error?: string
+}
 
 function toDeepLLang(code: string): string {
   return code.toUpperCase()
 }
 
-function extractTagNames(text: string): string[] {
-  const matches = text.matchAll(/<\/?([a-zA-Z][a-zA-Z0-9]*)[^>]*>/g)
-  return [...new Set([...matches].map((m) => m[1]))]
+function protectTags(text: string): {
+  protectedText: string
+  tags: string[]
+} {
+  const tags: string[] = []
+  const protectedText = decodeEntities(text).replace(
+    /<\/?[a-zA-Z][a-zA-Z0-9]*[^<>]*>/g,
+    (tag) => {
+      const index = tags.push(tag) - 1
+      return `xXxICOSA${index}TAGxXx`
+    }
+  )
+  return { protectedText, tags }
 }
 
-// Sends up to DEEPL_CHUNK_SIZE texts per request, returns translations in order
-export async function translateBatch(
+function restoreTags(text: string, tags: string[], originalText: string): string {
+  let restored = text
+  for (let i = 0; i < tags.length; i++) {
+    const placeholder = `xXxICOSA${i}TAGxXx`
+    if (!restored.includes(placeholder)) {
+      throw new Error(`DeepL response did not preserve placeholder ${placeholder}`)
+    }
+    restored = restored.replaceAll(placeholder, tags[i])
+  }
+
+  return tags.length > 0 || originalText.includes('&lt;') ? encodeEntities(restored) : restored
+}
+
+export async function translateBatchDetailed(
   texts: string[],
   sourceLang: string,
   targetLang: string,
   apiKey: string
-): Promise<string[]> {
-  const results: string[] = []
+): Promise<BatchTranslationResult[]> {
+  const results: BatchTranslationResult[] = []
 
   for (let offset = 0; offset < texts.length; offset += DEEPL_CHUNK_SIZE) {
     const chunk = texts.slice(offset, offset + DEEPL_CHUNK_SIZE)
-    const decoded = chunk.map(decodeEntities)
+    try {
+      const translated = await translateProtectedChunk(chunk, sourceLang, targetLang, apiKey)
+      translated.forEach((text, i) => results.push({ index: offset + i, translated: text }))
+    } catch (err) {
+      logError('deepl.batch.chunk', err, { offset, size: chunk.length })
+      if (isFatalBatchError(err)) {
+        const error = err instanceof Error ? err.message : String(err)
+        chunk.forEach((_text, i) =>
+          results.push({ index: offset + i, translated: null, error })
+        )
+        continue
+      }
 
-    const body = new URLSearchParams()
-    for (const t of decoded) body.append('text', t)
-    body.append('source_lang', toDeepLLang(sourceLang))
-    body.append('target_lang', toDeepLLang(targetLang))
-    body.append('tag_handling', 'xml')
-
-    const allTags = [...new Set(chunk.flatMap(extractTagNames))]
-    if (allTags.length > 0) body.append('ignore_tags', allTags.join(','))
-
-    const response = await fetch(DEEPL_API_URL, {
-      method: 'POST',
-      headers: {
-        Authorization: `DeepL-Auth-Key ${apiKey}`,
-        'Content-Type': 'application/x-www-form-urlencoded'
-      },
-      body: body.toString()
-    })
-
-    if (!response.ok) {
-      const detail = await response.text().catch(() => response.statusText)
-      throw new Error(`DeepL API error ${response.status}: ${detail}`)
-    }
-
-    const data = (await response.json()) as { translations: { text: string }[] }
-
-    for (let i = 0; i < chunk.length; i++) {
-      const raw = data.translations[i]?.text ?? ''
-      results.push(extractTagNames(chunk[i]).length > 0 ? encodeEntities(raw) : raw)
+      for (let i = 0; i < chunk.length; i++) {
+        try {
+          const translated = await translateText(chunk[i], sourceLang, targetLang, apiKey)
+          results.push({ index: offset + i, translated })
+        } catch (entryErr) {
+          logError('deepl.batch.entry', entryErr, { index: offset + i, sourceLang, targetLang })
+          results.push({
+            index: offset + i,
+            translated: null,
+            error: entryErr instanceof Error ? entryErr.message : String(entryErr)
+          })
+        }
+      }
     }
   }
 
@@ -66,33 +101,72 @@ export async function translateText(
   apiKey: string,
   context?: string
 ): Promise<string> {
-  const decoded = decodeEntities(text)
-  const tagNames = extractTagNames(decoded)
+  const { protectedText, tags } = protectTags(text)
+  const translated = await requestDeepL([protectedText], sourceLang, targetLang, apiKey, context)
+  return restoreTags(translated[0] ?? '', tags, text)
+}
 
-  const body = new URLSearchParams({
-    text: decoded,
-    source_lang: toDeepLLang(sourceLang),
-    target_lang: toDeepLLang(targetLang),
-    tag_handling: 'xml',
-    ...(tagNames.length > 0 && { ignore_tags: tagNames.join(',') }),
-    ...(context && { context }),
-  })
+async function translateProtectedChunk(
+  texts: string[],
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string
+): Promise<string[]> {
+  const protectedTexts = texts.map(protectTags)
+  const translated = await requestDeepL(
+    protectedTexts.map((item) => item.protectedText),
+    sourceLang,
+    targetLang,
+    apiKey
+  )
 
-  const response = await fetch(DEEPL_API_URL, {
-    method: 'POST',
-    headers: {
-      Authorization: `DeepL-Auth-Key ${apiKey}`,
-      'Content-Type': 'application/x-www-form-urlencoded'
-    },
-    body: body.toString()
-  })
+  return texts.map((text, index) =>
+    restoreTags(translated[index] ?? '', protectedTexts[index].tags, text)
+  )
+}
 
-  if (!response.ok) {
+async function requestDeepL(
+  texts: string[],
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string,
+  context?: string
+): Promise<string[]> {
+  const body = new URLSearchParams()
+  for (const text of texts) body.append('text', text)
+  body.append('source_lang', toDeepLLang(sourceLang))
+  body.append('target_lang', toDeepLLang(targetLang))
+  if (context) body.append('context', context)
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(DEEPL_API_URL, {
+      method: 'POST',
+      headers: {
+        Authorization: `DeepL-Auth-Key ${apiKey}`,
+        'Content-Type': 'application/x-www-form-urlencoded'
+      },
+      body: body.toString()
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as { translations: { text: string }[] }
+      return data.translations.map((item) => item.text)
+    }
+
     const detail = await response.text().catch(() => response.statusText)
-    throw new Error(`DeepL API error ${response.status}: ${detail}`)
+    const error = new DeepLApiError(response.status, detail)
+    if (response.status !== 429 || attempt === MAX_RETRIES) throw error
+    logError('deepl.rateLimit', error, { attempt, total: texts.length })
+    await delay(500 * attempt)
   }
 
-  const data = (await response.json()) as { translations: { text: string }[] }
-  const translated = data.translations[0]?.text ?? ''
-  return tagNames.length > 0 ? encodeEntities(translated) : translated
+  throw new Error('DeepL request failed')
+}
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+function isFatalBatchError(err: unknown): boolean {
+  return err instanceof DeepLApiError && [401, 403, 456].includes(err.status)
 }

--- a/src/main/services/deepl.service.ts
+++ b/src/main/services/deepl.service.ts
@@ -56,30 +56,41 @@ export async function translateBatchDetailed(
   texts: string[],
   sourceLang: string,
   targetLang: string,
-  apiKey: string
+  apiKey: string,
+  signal?: AbortSignal
 ): Promise<BatchTranslationResult[]> {
   const results: BatchTranslationResult[] = []
 
   for (let offset = 0; offset < texts.length; offset += DEEPL_CHUNK_SIZE) {
     const chunk = texts.slice(offset, offset + DEEPL_CHUNK_SIZE)
     try {
-      const translated = await translateProtectedChunk(chunk, sourceLang, targetLang, apiKey)
-      translated.forEach((text, i) => results.push({ index: offset + i, translated: text }))
+      const translated = await translateProtectedChunkDetailed(
+        chunk,
+        sourceLang,
+        targetLang,
+        apiKey,
+        signal
+      )
+      translated.forEach((result, i) => results.push({ index: offset + i, ...result }))
     } catch (err) {
       logError('deepl.batch.chunk', err, { offset, size: chunk.length })
       if (isFatalBatchError(err)) {
-        const error = err instanceof Error ? err.message : String(err)
-        chunk.forEach((_text, i) =>
-          results.push({ index: offset + i, translated: null, error })
-        )
-        continue
+        throw err
       }
 
       for (let i = 0; i < chunk.length; i++) {
         try {
-          const translated = await translateText(chunk[i], sourceLang, targetLang, apiKey)
+          const translated = await translateText(
+            chunk[i],
+            sourceLang,
+            targetLang,
+            apiKey,
+            undefined,
+            signal
+          )
           results.push({ index: offset + i, translated })
         } catch (entryErr) {
+          if (isFatalBatchError(entryErr)) throw entryErr
           logError('deepl.batch.entry', entryErr, { index: offset + i, sourceLang, targetLang })
           results.push({
             index: offset + i,
@@ -99,30 +110,62 @@ export async function translateText(
   sourceLang: string,
   targetLang: string,
   apiKey: string,
-  context?: string
+  context?: string,
+  signal?: AbortSignal
 ): Promise<string> {
   const { protectedText, tags } = protectTags(text)
-  const translated = await requestDeepL([protectedText], sourceLang, targetLang, apiKey, context)
-  return restoreTags(translated[0] ?? '', tags, text)
+  const translated = await requestDeepL(
+    [protectedText],
+    sourceLang,
+    targetLang,
+    apiKey,
+    context,
+    signal
+  )
+  const first = translated[0]
+  if (first == null) {
+    throw new Error('DeepL response did not include the translated text')
+  }
+  return restoreTags(first, tags, text)
 }
 
-async function translateProtectedChunk(
+async function translateProtectedChunkDetailed(
   texts: string[],
   sourceLang: string,
   targetLang: string,
-  apiKey: string
-): Promise<string[]> {
+  apiKey: string,
+  signal?: AbortSignal
+): Promise<Array<Omit<BatchTranslationResult, 'index'>>> {
   const protectedTexts = texts.map(protectTags)
   const translated = await requestDeepL(
     protectedTexts.map((item) => item.protectedText),
     sourceLang,
     targetLang,
-    apiKey
+    apiKey,
+    undefined,
+    signal
   )
 
-  return texts.map((text, index) =>
-    restoreTags(translated[index] ?? '', protectedTexts[index].tags, text)
-  )
+  return texts.map((text, index) => {
+    const translatedText = translated[index]
+    if (translatedText == null) {
+      return {
+        translated: null,
+        error: `DeepL returned ${translated.length} of ${texts.length} translations`
+      }
+    }
+
+    try {
+      return {
+        translated: restoreTags(translatedText, protectedTexts[index].tags, text)
+      }
+    } catch (err) {
+      return {
+        translated: null,
+        error: err instanceof Error ? err.message : String(err)
+      }
+    }
+  })
 }
 
 async function requestDeepL(
@@ -130,7 +173,8 @@ async function requestDeepL(
   sourceLang: string,
   targetLang: string,
   apiKey: string,
-  context?: string
+  context?: string,
+  signal?: AbortSignal
 ): Promise<string[]> {
   const body = new URLSearchParams()
   for (const text of texts) body.append('text', text)
@@ -145,7 +189,8 @@ async function requestDeepL(
         Authorization: `DeepL-Auth-Key ${apiKey}`,
         'Content-Type': 'application/x-www-form-urlencoded'
       },
-      body: body.toString()
+      body: body.toString(),
+      signal
     })
 
     if (response.ok) {
@@ -157,14 +202,32 @@ async function requestDeepL(
     const error = new DeepLApiError(response.status, detail)
     if (response.status !== 429 || attempt === MAX_RETRIES) throw error
     logError('deepl.rateLimit', error, { attempt, total: texts.length })
-    await delay(500 * attempt)
+    await delay(500 * attempt, signal)
   }
 
   throw new Error('DeepL request failed')
 }
 
-function delay(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms))
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
+      reject(signal?.reason ?? new Error('Translation cancelled'))
+    }
+
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
 }
 
 function isFatalBatchError(err: unknown): boolean {

--- a/src/main/services/log.service.ts
+++ b/src/main/services/log.service.ts
@@ -1,0 +1,87 @@
+import fs from 'fs'
+import { app, shell } from 'electron'
+import path from 'path'
+
+type LogLevel = 'error' | 'warn' | 'info'
+
+export interface LogPayload {
+  level?: LogLevel
+  scope: string
+  message: string
+  stack?: string
+  meta?: unknown
+}
+
+const REDACTED = '[redacted]'
+const SENSITIVE_KEY_RE = /(key|secret|token|authorization|password)/i
+
+export function getLogPath(): string {
+  return path.join(app.getPath('userData'), 'logs', 'icosa-errors.log')
+}
+
+export function writeLog(payload: LogPayload): void {
+  const logPath = getLogPath()
+  fs.mkdirSync(path.dirname(logPath), { recursive: true })
+  const record = {
+    timestamp: new Date().toISOString(),
+    level: payload.level ?? 'error',
+    scope: payload.scope,
+    message: payload.message,
+    stack: payload.stack,
+    meta: sanitize(payload.meta)
+  }
+  fs.appendFileSync(logPath, `${JSON.stringify(record)}\n`, 'utf-8')
+}
+
+export function logError(scope: string, err: unknown, meta?: unknown): void {
+  const error = normalizeError(err)
+  writeLog({
+    level: 'error',
+    scope,
+    message: error.message,
+    stack: error.stack,
+    meta
+  })
+}
+
+export async function openLogFile(): Promise<void> {
+  const logPath = getLogPath()
+  fs.mkdirSync(path.dirname(logPath), { recursive: true })
+  if (!fs.existsSync(logPath)) fs.writeFileSync(logPath, '', 'utf-8')
+  const error = await shell.openPath(logPath)
+  if (error) throw new Error(error)
+}
+
+export function clearLogFile(): void {
+  const logPath = getLogPath()
+  fs.mkdirSync(path.dirname(logPath), { recursive: true })
+  fs.writeFileSync(logPath, '', 'utf-8')
+}
+
+function normalizeError(err: unknown): { message: string; stack?: string } {
+  if (err instanceof Error) return { message: err.message, stack: err.stack }
+  return { message: String(err) }
+}
+
+function sanitize(value: unknown, depth = 0): unknown {
+  if (depth > 6) return '[max-depth]'
+  if (value == null) return value
+  if (typeof value === 'string') return redactString(value)
+  if (typeof value === 'number' || typeof value === 'boolean') return value
+  if (Array.isArray(value)) return value.map((item) => sanitize(item, depth + 1))
+  if (typeof value !== 'object') return String(value)
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, item]) => [
+      key,
+      SENSITIVE_KEY_RE.test(key) ? REDACTED : sanitize(item, depth + 1)
+    ])
+  )
+}
+
+function redactString(value: string): string {
+  return value
+    .replace(/DeepL-Auth-Key\s+[^\s"']+/gi, `DeepL-Auth-Key ${REDACTED}`)
+    .replace(/Bearer\s+[^\s"']+/gi, `Bearer ${REDACTED}`)
+    .replace(/sk-[A-Za-z0-9_-]+/g, REDACTED)
+}

--- a/src/main/services/openai.service.ts
+++ b/src/main/services/openai.service.ts
@@ -43,7 +43,8 @@ export async function translateText(
   targetLang: string,
   apiKey: string,
   context: SimilarEntry[] = [],
-  model = 'gpt-4o-mini'
+  model = 'gpt-4o-mini',
+  signal?: AbortSignal
 ): Promise<string> {
   const response = await fetch(OPENAI_API_URL, {
     method: 'POST',
@@ -51,6 +52,7 @@ export async function translateText(
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json'
     },
+    signal,
     body: JSON.stringify({
       model,
       temperature: 0.3,

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -33,15 +33,23 @@ export interface TranslationErrorEvent {
 }
 
 export interface TranslationBatchProgressEvent {
+  jobId: string
   uid: string
   target: string | null
   error?: string
 }
 
-export interface TranslationBatchSummary {
+export interface TranslationBatchDoneEvent {
+  jobId: string
   total: number
   translated: number
   failed: number
+  cancelled: boolean
+}
+
+export interface TranslationBatchErrorEvent {
+  jobId: string
+  message: string
 }
 
 export interface LogPayload {
@@ -165,8 +173,10 @@ export interface TranslationApi {
     provider: 'openai' | 'deepl'
     sourceLang: string
     targetLang: string
-  }): Promise<TranslationBatchSummary>
+  }): Promise<{ jobId: string }>
   onBatchProgress(cb: (data: TranslationBatchProgressEvent) => void): UnsubscribeFn
+  onBatchDone(cb: (data: TranslationBatchDoneEvent) => void): UnsubscribeFn
+  onBatchError(cb: (data: TranslationBatchErrorEvent) => void): UnsubscribeFn
 }
 
 export interface DictionaryApi {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -38,6 +38,20 @@ export interface TranslationBatchProgressEvent {
   error?: string
 }
 
+export interface TranslationBatchSummary {
+  total: number
+  translated: number
+  failed: number
+}
+
+export interface LogPayload {
+  level?: 'error' | 'warn' | 'info'
+  scope: string
+  message: string
+  stack?: string
+  meta?: unknown
+}
+
 export interface DictionaryEntry {
   id: number
   language1: string
@@ -151,7 +165,7 @@ export interface TranslationApi {
     provider: 'openai' | 'deepl'
     sourceLang: string
     targetLang: string
-  }): Promise<void>
+  }): Promise<TranslationBatchSummary>
   onBatchProgress(cb: (data: TranslationBatchProgressEvent) => void): UnsubscribeFn
 }
 
@@ -245,6 +259,13 @@ export interface FsApi {
   getPathForFile(file: File): string
 }
 
+export interface LogApi {
+  getPath(): Promise<string>
+  open(): Promise<{ success: boolean }>
+  clear(): Promise<{ success: boolean }>
+  write(payload: LogPayload): Promise<{ success: boolean }>
+}
+
 export interface AppApi {
   translation: TranslationApi
   dictionary: DictionaryApi
@@ -252,6 +273,7 @@ export interface AppApi {
   mod: ModApi
   config: ConfigApi
   fs: FsApi
+  log: LogApi
   xml: XmlApi
   window: WindowApi
 }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -51,7 +51,8 @@ const api: AppApi = {
       provider: 'openai' | 'deepl'
       sourceLang: string
       targetLang: string
-    }): Promise<void> => ipcRenderer.invoke('translation:batch', payload),
+    }): Promise<{ total: number; translated: number; failed: number }> =>
+      ipcRenderer.invoke('translation:batch', payload),
 
     onBatchProgress: (
       cb: (data: { uid: string; target: string | null; error?: string }) => void
@@ -240,6 +241,19 @@ const api: AppApi = {
 
     // Replaces the deprecated file.path property (removed in Electron 32+)
     getPathForFile: (file: File): string => webUtils.getPathForFile(file)
+  },
+
+  log: {
+    getPath: (): Promise<string> => ipcRenderer.invoke('log:getPath'),
+    open: (): Promise<{ success: boolean }> => ipcRenderer.invoke('log:open'),
+    clear: (): Promise<{ success: boolean }> => ipcRenderer.invoke('log:clear'),
+    write: (payload: {
+      level?: 'error' | 'warn' | 'info'
+      scope: string
+      message: string
+      stack?: string
+      meta?: unknown
+    }): Promise<{ success: boolean }> => ipcRenderer.invoke('log:write', payload)
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1,7 +1,13 @@
 import { electronAPI } from '@electron-toolkit/preload'
 import type { IpcRendererEvent } from 'electron'
 import { contextBridge, ipcRenderer, webUtils } from 'electron'
-import type { AppApi, UnsubscribeFn } from './api-types'
+import type {
+  AppApi,
+  TranslationBatchDoneEvent,
+  TranslationBatchErrorEvent,
+  TranslationBatchProgressEvent,
+  UnsubscribeFn
+} from './api-types'
 
 function on<T>(channel: string, cb: (data: T) => void): UnsubscribeFn {
   const handler = (_: IpcRendererEvent, data: T): void => cb(data)
@@ -51,12 +57,18 @@ const api: AppApi = {
       provider: 'openai' | 'deepl'
       sourceLang: string
       targetLang: string
-    }): Promise<{ total: number; translated: number; failed: number }> =>
+    }): Promise<{ jobId: string }> =>
       ipcRenderer.invoke('translation:batch', payload),
 
     onBatchProgress: (
-      cb: (data: { uid: string; target: string | null; error?: string }) => void
-    ): UnsubscribeFn => on('translation:batchProgress', cb)
+      cb: (data: TranslationBatchProgressEvent) => void
+    ): UnsubscribeFn => on('translation:batchProgress', cb),
+
+    onBatchDone: (cb: (data: TranslationBatchDoneEvent) => void): UnsubscribeFn =>
+      on('translation:batchDone', cb),
+
+    onBatchError: (cb: (data: TranslationBatchErrorEvent) => void): UnsubscribeFn =>
+      on('translation:batchError', cb)
   },
 
   dictionary: {

--- a/src/renderer/src/components/translation/BatchActionBar.tsx
+++ b/src/renderer/src/components/translation/BatchActionBar.tsx
@@ -4,6 +4,7 @@ interface BatchActionBarProps {
   selectedCount: number
   onTranslateDeepL: () => void
   onTranslateGPT: () => void
+  onCancelTranslation: () => void
   onClearSelection: () => void
   isTranslating: boolean
 }
@@ -12,22 +13,33 @@ export function BatchActionBar({
   selectedCount,
   onTranslateDeepL,
   onTranslateGPT,
+  onCancelTranslation,
   onClearSelection,
   isTranslating
 }: BatchActionBarProps): React.JSX.Element | null {
-  if (selectedCount === 0) return null
+  if (selectedCount === 0 && !isTranslating) return null
 
   return (
     <div className="flex items-center gap-3 border-t border-neutral-700 bg-neutral-900 px-4 py-3 shrink-0">
       <span className="text-sm text-neutral-400 shrink-0">
-        {selectedCount} {selectedCount === 1 ? 'entrada selecionada' : 'entradas selecionadas'}
+        {selectedCount}{' '}
+        {selectedCount === 1 ? 'entrada selecionada' : 'entradas selecionadas'}
       </span>
 
       {isTranslating ? (
-        <div className="flex items-center gap-2 text-sm text-neutral-400">
-          <Loader2 size={14} className="animate-spin" />
-          Traduzindo...
-        </div>
+        <>
+          <div className="flex items-center gap-2 text-sm text-neutral-400">
+            <Loader2 size={14} className="animate-spin" />
+            Traduzindo
+          </div>
+          <button
+            type="button"
+            onClick={onCancelTranslation}
+            className="rounded-md border border-red-500/60 px-3 py-1.5 text-sm font-medium text-red-200 transition-colors hover:bg-red-500/10"
+          >
+            Parar
+          </button>
+        </>
       ) : (
         <>
           <button

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -78,6 +78,7 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
         selectedCount={session.selectedUids.size}
         onTranslateDeepL={() => batch.batchTranslate('deepl')}
         onTranslateGPT={() => batch.batchTranslate('openai')}
+        onCancelTranslation={batch.cancelBatch}
         onClearSelection={session.clearSelection}
         isTranslating={batch.isBatchTranslating}
       />

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -1,21 +1,55 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import type {
+  TranslationBatchDoneEvent,
+  TranslationBatchErrorEvent,
+  TranslationBatchProgressEvent
+} from '@/types'
 import type { TranslationSession } from '../types'
 
 export function useBatchTranslation(session: TranslationSession) {
   const [isBatchTranslating, setIsBatchTranslating] = useState(false)
-  const batchUnsubRef = useRef<(() => void) | null>(null)
-  const { entries, selectedUids, sourceLang, targetLang, updateEntry, clearSelection } = session
+  const [activeJobId, setActiveJobId] = useState<string | null>(null)
+  const batchCleanupRef = useRef<(() => void) | null>(null)
+  const activeJobIdRef = useRef<string | null>(null)
+  const pendingUidsRef = useRef<Set<string>>(new Set())
+  const { entries, selectedUids, sourceLang, targetLang, updateEntry, clearSelection, selectEntries } =
+    session
+
+  const clearListeners = useCallback(() => {
+    batchCleanupRef.current?.()
+    batchCleanupRef.current = null
+  }, [])
+
+  const restorePendingSelection = useCallback(() => {
+    const pendingUids = Array.from(pendingUidsRef.current)
+    clearSelection()
+    if (pendingUids.length > 0) {
+      selectEntries(pendingUids, true)
+    }
+  }, [clearSelection, selectEntries])
+
+  const finishBatchJob = useCallback(
+    (jobId: string) => {
+      if (activeJobIdRef.current !== jobId) return
+
+      clearListeners()
+      activeJobIdRef.current = null
+      pendingUidsRef.current = new Set()
+      setActiveJobId(null)
+      setIsBatchTranslating(false)
+    },
+    [clearListeners]
+  )
 
   useEffect(() => {
-    return () => {
-      batchUnsubRef.current?.()
-      batchUnsubRef.current = null
-    }
-  }, [])
+    return () => clearListeners()
+  }, [clearListeners])
 
   const batchTranslate = useCallback(
     async (provider: 'openai' | 'deepl') => {
+      if (isBatchTranslating) return
+
       const selectedEntries = entries
         .filter((entry) => selectedUids.has(entry.rowId))
         .map((entry) => ({ uid: entry.rowId, source: entry.source }))
@@ -25,33 +59,79 @@ export function useBatchTranslation(session: TranslationSession) {
         return
       }
 
+      pendingUidsRef.current = new Set(selectedEntries.map((entry) => entry.uid))
       setIsBatchTranslating(true)
-      batchUnsubRef.current?.()
-      batchUnsubRef.current = window.api.translation.onBatchProgress(({ uid, target, error }) => {
-        if (error) {
-          if (uid) toast.error(`Erro em #${uid.slice(0, 8)}: ${error}`)
-          else toast.error(error)
-          return
+      clearListeners()
+
+      const handleBatchProgress = ({ jobId, uid, target }: TranslationBatchProgressEvent) => {
+        if (jobId !== activeJobIdRef.current) return
+        if (target === null) return
+        pendingUidsRef.current.delete(uid)
+        updateEntry(uid, target)
+      }
+
+      const handleBatchDone = ({
+        jobId,
+        total,
+        translated,
+        failed,
+        cancelled
+      }: TranslationBatchDoneEvent) => {
+        if (jobId !== activeJobIdRef.current) return
+
+        if (cancelled) {
+          restorePendingSelection()
+          toast.info(`${translated} de ${total} entradas traduzidas antes do cancelamento`)
+        } else if (failed > 0) {
+          restorePendingSelection()
+          toast.warning(
+            `${translated} de ${total} entradas traduzidas; ${failed} permanecem pendentes`
+          )
+        } else {
+          clearSelection()
+          toast.success(`${translated} entradas traduzidas`)
         }
-        if (target !== null) updateEntry(uid, target)
-      })
+
+        finishBatchJob(jobId)
+      }
+
+      const handleBatchError = ({ jobId, message }: TranslationBatchErrorEvent) => {
+        if (jobId !== activeJobIdRef.current) return
+
+        restorePendingSelection()
+        toast.error(message)
+        void window.api.log.write({
+          scope: 'renderer.batchTranslation',
+          message,
+          meta: { provider, sourceLang, targetLang, total: selectedEntries.length }
+        })
+        finishBatchJob(jobId)
+      }
+
+      const offProgress = window.api.translation.onBatchProgress(handleBatchProgress)
+      const offDone = window.api.translation.onBatchDone(handleBatchDone)
+      const offError = window.api.translation.onBatchError(handleBatchError)
+      batchCleanupRef.current = () => {
+        offProgress()
+        offDone()
+        offError()
+      }
 
       try {
-        const summary = await window.api.translation.batch({
+        const { jobId } = await window.api.translation.batch({
           entries: selectedEntries,
           provider,
           sourceLang,
           targetLang
         })
-        if (summary.failed > 0) {
-          toast.warning(
-            `${summary.translated} de ${summary.total} entradas traduzidas; ${summary.failed} falharam`
-          )
-        } else {
-          toast.success(`${summary.translated} entradas traduzidas`)
-        }
+        activeJobIdRef.current = jobId
+        setActiveJobId(jobId)
       } catch (err) {
         const message = err instanceof Error ? err.message : 'Erro na traducao em lote'
+        clearListeners()
+        activeJobIdRef.current = null
+        setActiveJobId(null)
+        setIsBatchTranslating(false)
         toast.error(message)
         void window.api.log.write({
           scope: 'renderer.batchTranslation',
@@ -59,15 +139,26 @@ export function useBatchTranslation(session: TranslationSession) {
           stack: err instanceof Error ? err.stack : undefined,
           meta: { provider, sourceLang, targetLang, total: selectedEntries.length }
         })
-      } finally {
-        batchUnsubRef.current?.()
-        batchUnsubRef.current = null
-        setIsBatchTranslating(false)
-        clearSelection()
       }
     },
-    [clearSelection, entries, selectedUids, sourceLang, targetLang, updateEntry]
+    [
+      clearListeners,
+      clearSelection,
+      entries,
+      finishBatchJob,
+      isBatchTranslating,
+      restorePendingSelection,
+      selectedUids,
+      sourceLang,
+      targetLang,
+      updateEntry
+    ]
   )
 
-  return { isBatchTranslating, batchTranslate }
+  const cancelBatch = useCallback(async () => {
+    if (!activeJobId) return
+    await window.api.translation.cancel(activeJobId)
+  }, [activeJobId])
+
+  return { isBatchTranslating, batchTranslate, cancelBatch, activeJobId }
 }

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -20,6 +20,11 @@ export function useBatchTranslation(session: TranslationSession) {
         .filter((entry) => selectedUids.has(entry.rowId))
         .map((entry) => ({ uid: entry.rowId, source: entry.source }))
 
+      if (selectedEntries.length === 0) {
+        toast.info('Nenhuma entrada selecionada')
+        return
+      }
+
       setIsBatchTranslating(true)
       batchUnsubRef.current?.()
       batchUnsubRef.current = window.api.translation.onBatchProgress(({ uid, target, error }) => {
@@ -28,19 +33,32 @@ export function useBatchTranslation(session: TranslationSession) {
           else toast.error(error)
           return
         }
-        if (target) updateEntry(uid, target)
+        if (target !== null) updateEntry(uid, target)
       })
 
       try {
-        await window.api.translation.batch({
+        const summary = await window.api.translation.batch({
           entries: selectedEntries,
           provider,
           sourceLang,
           targetLang
         })
-        toast.success(`${selectedEntries.length} entradas traduzidas`)
+        if (summary.failed > 0) {
+          toast.warning(
+            `${summary.translated} de ${summary.total} entradas traduzidas; ${summary.failed} falharam`
+          )
+        } else {
+          toast.success(`${summary.translated} entradas traduzidas`)
+        }
       } catch (err) {
-        toast.error(err instanceof Error ? err.message : 'Erro na traducao em lote')
+        const message = err instanceof Error ? err.message : 'Erro na traducao em lote'
+        toast.error(message)
+        void window.api.log.write({
+          scope: 'renderer.batchTranslation',
+          message,
+          stack: err instanceof Error ? err.stack : undefined,
+          meta: { provider, sourceLang, targetLang, total: selectedEntries.length }
+        })
       } finally {
         batchUnsubRef.current?.()
         batchUnsubRef.current = null

--- a/src/renderer/src/main.tsx
+++ b/src/renderer/src/main.tsx
@@ -4,6 +4,24 @@ import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import App from './App'
 
+window.addEventListener('error', (event) => {
+  void window.api.log.write({
+    scope: 'renderer.error',
+    message: event.message,
+    stack: event.error instanceof Error ? event.error.stack : undefined,
+    meta: { filename: event.filename, lineno: event.lineno, colno: event.colno }
+  })
+})
+
+window.addEventListener('unhandledrejection', (event) => {
+  const reason = event.reason
+  void window.api.log.write({
+    scope: 'renderer.unhandledRejection',
+    message: reason instanceof Error ? reason.message : String(reason),
+    stack: reason instanceof Error ? reason.stack : undefined
+  })
+})
+
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
     <App />

--- a/src/renderer/src/pages/SettingsPage.tsx
+++ b/src/renderer/src/pages/SettingsPage.tsx
@@ -1,4 +1,5 @@
-import { useState } from 'react'
+import { useEffect, useState } from 'react'
+import { Copy, FolderOpen, Trash2 } from 'lucide-react'
 import { toast } from 'sonner'
 import { useConfig } from '@/hooks/useConfig'
 import type { ConfigKey } from '@/types'
@@ -57,6 +58,37 @@ function SettingField({
 
 export function SettingsPage(): React.JSX.Element {
   const { config, loading, set } = useConfig()
+  const [logPath, setLogPath] = useState('')
+
+  useEffect(() => {
+    window.api.log.getPath().then(setLogPath)
+  }, [])
+
+  const handleOpenLog = async () => {
+    try {
+      await window.api.log.open()
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erro ao abrir log')
+    }
+  }
+
+  const handleCopyLogPath = async () => {
+    try {
+      await navigator.clipboard.writeText(logPath)
+      toast.success('Caminho do log copiado')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erro ao copiar caminho')
+    }
+  }
+
+  const handleClearLog = async () => {
+    try {
+      await window.api.log.clear()
+      toast.success('Log limpo')
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Erro ao limpar log')
+    }
+  }
 
   if (loading) {
     return <div className="p-6 text-sm text-neutral-500">Loading...</div>
@@ -120,6 +152,39 @@ export function SettingsPage(): React.JSX.Element {
           onSave={set}
           placeholder="C:\path\to\Divine.exe"
         />
+      </section>
+
+      <section className="flex flex-col gap-3">
+        <h2 className="text-sm font-medium text-neutral-300">Debug logs</h2>
+        <div className="rounded-md border border-neutral-800 bg-neutral-900/60 p-3">
+          <p className="font-mono text-xs text-neutral-400 break-all">{logPath}</p>
+          <div className="mt-3 flex flex-wrap gap-2">
+            <button
+              type="button"
+              onClick={handleOpenLog}
+              className="inline-flex items-center gap-2 rounded-md bg-neutral-800 px-3 py-2 text-sm text-neutral-300 hover:bg-neutral-700"
+            >
+              <FolderOpen size={15} />
+              Abrir
+            </button>
+            <button
+              type="button"
+              onClick={handleCopyLogPath}
+              className="inline-flex items-center gap-2 rounded-md bg-neutral-800 px-3 py-2 text-sm text-neutral-300 hover:bg-neutral-700"
+            >
+              <Copy size={15} />
+              Copiar caminho
+            </button>
+            <button
+              type="button"
+              onClick={handleClearLog}
+              className="inline-flex items-center gap-2 rounded-md border border-red-900/70 bg-red-950/40 px-3 py-2 text-sm text-red-300 hover:bg-red-950"
+            >
+              <Trash2 size={15} />
+              Limpar
+            </button>
+          </div>
+        </div>
       </section>
     </div>
   )


### PR DESCRIPTION
## Summary

This PR reworks batch translation into an event-driven job flow and fixes the DeepL partial-batch failure case.

When DeepL only translates part of a batch, the app now applies the successful translations immediately and retries only the remaining entries until it finishes, the user cancels, or a round makes no progress.

## What changed

- changed `translation.batch()` to return `{ jobId }` instead of a final summary
- added `translation:batchDone` and `translation:batchError` events
- reused `translation.cancel(jobId)` for batch jobs
- added incremental retry logic for partial DeepL batch results
- stopped retrying on fatal DeepL credential/quota errors
- propagated `AbortSignal` into DeepL and OpenAI fetches
- updated the renderer batch flow to track jobs by events instead of awaiting a summary
- kept the bottom bar visible in `Traduzindo` state during the full batch loop
- added a `Parar` button that aborts the active batch immediately
- preserved successful translations on cancel/failure and kept only pending entries selected

## Behavior

- DeepL batch retries now resend only the entries that still failed
- successful entries are applied as soon as they arrive
- cancelling stops the in-flight request immediately
- if a retry round produces zero new successes, the batch ends instead of looping forever
- OpenAI batch now follows the same cancellable job lifecycle in the UI

## Validation

- `pnpm typecheck`
