### PR TITLE
feat(translate): polish editor ux and tag handling

### DIFF
--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -13,6 +13,7 @@ import {
 } from '../services/deepl.service'
 import { logError } from '../services/log.service'
 import { translateText as translateOpenAI } from '../services/openai.service'
+import { decodeEntities } from '../services/xml-entities.service'
 import { getActiveWindow } from '../utils/window'
 
 export type TranslationProvider = 'openai' | 'deepl' | 'manual'
@@ -119,8 +120,10 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
       try {
         const { provider, text, sourceLang, targetLang } = payload
         const apiKey = requireStoredApiKey(provider)
-        if (provider === 'deepl') return translateDeepL(text, sourceLang, targetLang, apiKey)
-        return translateOpenAI(text, sourceLang, targetLang, apiKey)
+        if (provider === 'deepl') {
+          return decodeEntities(await translateDeepL(text, sourceLang, targetLang, apiKey))
+        }
+        return decodeEntities(await translateOpenAI(text, sourceLang, targetLang, apiKey))
       } catch (err) {
         logError('translation.single', err, {
           provider: payload.provider,
@@ -292,7 +295,7 @@ async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Pr
     )
 
     let roundSuccesses = 0
-    const nextPending: BatchPayload['entries'] = []
+    const nextPending: Array<{ entry: BatchPayload['entries'][number]; error?: string }> = []
 
     for (const result of results) {
       const entry = pendingEntries[result.index]
@@ -304,12 +307,14 @@ async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Pr
         emitBatchProgress(ctx.getWindow, {
           jobId: ctx.jobId,
           uid: entry.uid,
-          target: result.translated
+          completed: summary.translated + summary.failed,
+          total: summary.total,
+          target: decodeEntities(result.translated)
         })
         continue
       }
 
-      nextPending.push(entry)
+      nextPending.push({ entry, error: result.error })
     }
 
     if (nextPending.length === 0) {
@@ -318,11 +323,21 @@ async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Pr
     }
 
     if (roundSuccesses === 0) {
-      summary.failed = nextPending.length
+      for (const pending of nextPending) {
+        summary.failed++
+        emitBatchProgress(ctx.getWindow, {
+          jobId: ctx.jobId,
+          uid: pending.entry.uid,
+          completed: summary.translated + summary.failed,
+          total: summary.total,
+          target: null,
+          error: pending.error
+        })
+      }
       return
     }
 
-    pendingEntries = nextPending
+    pendingEntries = nextPending.map((pending) => pending.entry)
   }
 }
 
@@ -347,12 +362,22 @@ async function runOpenAIBatchJob(ctx: BatchJobContext, summary: BatchSummary): P
         emitBatchProgress(ctx.getWindow, {
           jobId: ctx.jobId,
           uid: entry.uid,
-          target: translated
+          completed: summary.translated + summary.failed,
+          total: summary.total,
+          target: decodeEntities(translated)
         })
       } catch (err) {
         if (isAbortError(err) || ctx.signal.aborted) throw err
 
         summary.failed++
+        emitBatchProgress(ctx.getWindow, {
+          jobId: ctx.jobId,
+          uid: entry.uid,
+          completed: summary.translated + summary.failed,
+          total: summary.total,
+          target: null,
+          error: err instanceof Error ? err.message : String(err)
+        })
         logError('translation.batch.openai.entry', err, {
           uid: entry.uid,
           sourceLang: ctx.sourceLang,
@@ -366,7 +391,14 @@ async function runOpenAIBatchJob(ctx: BatchJobContext, summary: BatchSummary): P
 
 function emitBatchProgress(
   getWindow: () => BrowserWindow | null,
-  payload: { jobId: string; uid: string; target: string | null; error?: string }
+  payload: {
+    jobId: string
+    uid: string
+    completed: number
+    total: number
+    target: string | null
+    error?: string
+  }
 ): void {
   const win = getActiveWindow(getWindow)
   if (win) {

--- a/src/main/ipc/xml.ipc.ts
+++ b/src/main/ipc/xml.ipc.ts
@@ -5,10 +5,12 @@ import { DictionaryRepository } from '../database/repositories/dictionary.repo'
 import type { DictionaryEntry } from '../database/schema'
 import { unpackMod } from '../services/lslib.service'
 import {
+  type LocalizationEntry,
   findLocalizationXmls,
   parseLocalizationXml,
   writeLocalizationXml
 } from '../services/xml-parser.service'
+import { decodeEntities, encodeEntities } from '../services/xml-entities.service'
 import { extract } from '../services/zip.service'
 import { findPakFiles } from '../utils/findPakFiles'
 import { cleanupTempDir, createTempDir } from '../utils/tempDir'
@@ -34,6 +36,14 @@ interface ExportPayload {
 
 function extractTargetText(row: DictionaryEntry, sourceLang: string, targetLang: string): string {
   return sourceLang < targetLang ? (row.textLanguage2 ?? '') : (row.textLanguage1 ?? '')
+}
+
+function toUiEntry(entry: LocalizationEntry): Pick<XmlEntry, 'uid' | 'version' | 'source'> {
+  return {
+    uid: entry.contentuid,
+    version: entry.version,
+    source: decodeEntities(entry.text)
+  }
 }
 
 async function loadXml(payload: LoadPayload): Promise<XmlEntry[]> {
@@ -74,14 +84,13 @@ async function loadXml(payload: LoadPayload): Promise<XmlEntry[]> {
     const repo = new DictionaryRepository(db)
 
     return locEntries.map((entry) => {
+      const uiEntry = toUiEntry(entry)
       if (entry.contentuid) {
         const byUid = repo.findByUid(entry.contentuid, sourceLang, targetLang)
         if (byUid) {
           return {
-            uid: entry.contentuid,
-            version: entry.version,
-            source: entry.text,
-            target: extractTargetText(byUid, sourceLang, targetLang),
+            ...uiEntry,
+            target: decodeEntities(extractTargetText(byUid, sourceLang, targetLang)),
             matchType: 'uid' as const
           }
         }
@@ -90,18 +99,14 @@ async function loadXml(payload: LoadPayload): Promise<XmlEntry[]> {
       const byText = repo.findByText(sourceLang, targetLang, entry.text)
       if (byText) {
         return {
-          uid: entry.contentuid,
-          version: entry.version,
-          source: entry.text,
-          target: extractTargetText(byText, sourceLang, targetLang),
+          ...uiEntry,
+          target: decodeEntities(extractTargetText(byText, sourceLang, targetLang)),
           matchType: 'text' as const
         }
       }
 
       return {
-        uid: entry.contentuid,
-        version: entry.version,
-        source: entry.text,
+        ...uiEntry,
         target: '',
         matchType: 'none' as const
       }
@@ -118,7 +123,7 @@ function exportXml(payload: ExportPayload): void {
   const locEntries = entries.map((e) => ({
     contentuid: e.uid,
     version: e.version,
-    text: e.target || e.source
+    text: encodeEntities(e.target || e.source)
   }))
   writeLocalizationXml(locEntries, outputPath)
 }

--- a/src/main/services/translation-import.service.ts
+++ b/src/main/services/translation-import.service.ts
@@ -18,6 +18,7 @@ import {
   sanitizeMetaFolder,
   writeMeta
 } from './lsx-parser.service'
+import { encodeEntities } from './xml-entities.service'
 import { parseLocalizationXml, writeLocalizationXml } from './xml-parser.service'
 import { createZip, extract } from './zip.service'
 
@@ -239,7 +240,7 @@ export async function exportTranslatedPackage(
     const locEntries = payload.entries.map((entry) => ({
       contentuid: entry.uid,
       version: entry.version,
-      text: entry.target || entry.source
+      text: encodeEntities(entry.target || entry.source)
     }))
     writeLocalizationXml(locEntries, exportXmlPath)
     writeMeta({

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -35,6 +35,8 @@ export interface TranslationErrorEvent {
 export interface TranslationBatchProgressEvent {
   jobId: string
   uid: string
+  completed: number
+  total: number
   target: string | null
   error?: string
 }

--- a/src/renderer/src/components/shared/HighlightedTextarea.tsx
+++ b/src/renderer/src/components/shared/HighlightedTextarea.tsx
@@ -1,0 +1,81 @@
+import { forwardRef, useEffect, useState } from 'react'
+import { cn } from '@/lib/utils'
+import { renderSource } from '@/utils/renderSource'
+
+interface HighlightedTextareaProps
+  extends Omit<React.TextareaHTMLAttributes<HTMLTextAreaElement>, 'value'> {
+  value: string
+  containerClassName?: string
+  overlayClassName?: string
+}
+
+export const HighlightedTextarea = forwardRef<HTMLTextAreaElement, HighlightedTextareaProps>(
+  function HighlightedTextarea(
+    {
+      value,
+      onChange,
+      onFocus,
+      onBlur,
+      className,
+      containerClassName,
+      overlayClassName,
+      placeholder,
+      ...props
+    },
+    ref
+  ) {
+    const [draft, setDraft] = useState(value)
+    const [focused, setFocused] = useState(false)
+
+    useEffect(() => {
+      if (!focused) setDraft(value)
+    }, [value, focused])
+
+    return (
+      <div
+        className={cn(
+          'relative overflow-hidden rounded-md border border-[#1f2329] bg-[#131518] transition-[border-color,box-shadow] focus-within:border-amber-500/60 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.18)]',
+          containerClassName
+        )}
+      >
+        <div
+          aria-hidden="true"
+          className={cn(
+            'pointer-events-none absolute inset-0 overflow-hidden px-2.5 py-2 text-[13px] leading-[1.55] text-neutral-200 whitespace-pre-wrap wrap-break-word',
+            overlayClassName
+          )}
+        >
+          {draft ? (
+            renderSource(draft, { variant: 'editor' })
+          ) : (
+            <span className="italic text-neutral-600">{placeholder}</span>
+          )}
+        </div>
+
+        <textarea
+          {...props}
+          ref={ref}
+          value={draft}
+          spellCheck={false}
+          onFocus={(event) => {
+            setFocused(true)
+            onFocus?.(event)
+          }}
+          onBlur={(event) => {
+            setFocused(false)
+            onBlur?.(event)
+          }}
+          onChange={(event) => {
+            setDraft(event.target.value)
+            onChange?.(event)
+          }}
+          placeholder={placeholder}
+          className={cn(
+            'relative z-10 w-full resize-none bg-transparent px-2.5 py-2 text-[13px] leading-[1.55] text-transparent caret-neutral-200 placeholder:text-transparent focus:outline-none',
+            className
+          )}
+        />
+      </div>
+    )
+  }
+)

--- a/src/renderer/src/components/shared/LanguageSelect.tsx
+++ b/src/renderer/src/components/shared/LanguageSelect.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react'
-import { cn } from '@/lib/utils'
+import { ThemedSelect } from '@/components/shared/ThemedSelect'
 import type { Language } from '@/types'
 
 interface LanguageSelectProps {
@@ -22,20 +22,21 @@ export function LanguageSelect({
   }, [])
 
   return (
-    <div className={cn('flex flex-col gap-1', className)}>
-      {label && <label className="text-xs text-neutral-400">{label}</label>}
-      <select
-        value={value}
-        onChange={(e) => onChange(e.target.value)}
-        className="rounded-md border border-neutral-700 bg-neutral-900 px-3 py-2 text-sm text-neutral-200 focus:border-neutral-500 focus:outline-none"
-      >
-        <option value="">Select language</option>
-        {languages.map((lang) => (
-          <option key={lang.code} value={lang.code}>
-            {lang.name}
-          </option>
-        ))}
-      </select>
-    </div>
+    <ThemedSelect
+      value={value}
+      onChange={onChange}
+      label={label}
+      className={className}
+      placeholder="Select language"
+      searchable
+      searchPlaceholder="Search language..."
+      emptyLabel="No language found."
+      options={languages.map((language) => ({
+        value: language.code,
+        label: language.name,
+        badge: language.code.toUpperCase(),
+        searchText: `${language.name} ${language.code}`
+      }))}
+    />
   )
 }

--- a/src/renderer/src/components/shared/ThemedSelect.tsx
+++ b/src/renderer/src/components/shared/ThemedSelect.tsx
@@ -1,0 +1,242 @@
+import { Check, ChevronDown, Search } from 'lucide-react'
+import { useEffect, useId, useMemo, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+export interface ThemedSelectOption {
+  value: string
+  label: string
+  badge?: string
+  searchText?: string
+}
+
+interface MenuPosition {
+  top: number
+  left: number
+  width: number
+}
+
+interface ThemedSelectProps {
+  value: string
+  onChange: (value: string) => void
+  options: ThemedSelectOption[]
+  placeholder?: string
+  emptyLabel?: string
+  searchable?: boolean
+  searchPlaceholder?: string
+  label?: string
+  className?: string
+  accent?: boolean
+  triggerClassName?: string
+  menuClassName?: string
+}
+
+const MENU_GAP = 4
+const MENU_MAX_HEIGHT = 240
+
+export function ThemedSelect({
+  value,
+  onChange,
+  options,
+  placeholder = 'Selecionar',
+  emptyLabel = 'Nenhuma opcao encontrada.',
+  searchable = false,
+  searchPlaceholder = 'Buscar...',
+  label,
+  className,
+  accent = false,
+  triggerClassName,
+  menuClassName
+}: ThemedSelectProps): React.JSX.Element {
+  const [open, setOpen] = useState(false)
+  const [query, setQuery] = useState('')
+  const [menuPosition, setMenuPosition] = useState<MenuPosition | null>(null)
+  const rootRef = useRef<HTMLDivElement>(null)
+  const triggerRef = useRef<HTMLButtonElement>(null)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const searchRef = useRef<HTMLInputElement>(null)
+  const listboxId = useId()
+
+  const selected = options.find((option) => option.value === value)
+  const filteredOptions = useMemo(() => {
+    if (!searchable || !query.trim()) return options
+    const normalized = query.toLowerCase()
+    return options.filter((option) => {
+      const haystack = `${option.label} ${option.badge ?? ''} ${option.searchText ?? ''}`
+      return haystack.toLowerCase().includes(normalized)
+    })
+  }, [options, query, searchable])
+
+  useEffect(() => {
+    if (!open) return
+
+    const updatePosition = () => {
+      const rect = triggerRef.current?.getBoundingClientRect()
+      if (!rect) return
+
+      const spaceBelow = window.innerHeight - rect.bottom - MENU_GAP
+      const spaceAbove = rect.top - MENU_GAP
+      const shouldOpenAbove = spaceBelow < MENU_MAX_HEIGHT && spaceAbove > spaceBelow
+      const height = Math.min(MENU_MAX_HEIGHT, shouldOpenAbove ? spaceAbove : spaceBelow)
+
+      setMenuPosition({
+        top: shouldOpenAbove
+          ? Math.max(MENU_GAP, rect.top - MENU_GAP - Math.max(180, height))
+          : rect.bottom + MENU_GAP,
+        left: rect.left,
+        width: rect.width
+      })
+    }
+
+    updatePosition()
+    window.addEventListener('resize', updatePosition)
+    window.addEventListener('scroll', updatePosition, true)
+    return () => {
+      window.removeEventListener('resize', updatePosition)
+      window.removeEventListener('scroll', updatePosition, true)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open) return
+
+    const onPointerDown = (event: MouseEvent) => {
+      const target = event.target as Node
+      if (rootRef.current?.contains(target)) return
+      if (menuRef.current?.contains(target)) return
+      setOpen(false)
+      setQuery('')
+    }
+
+    const onKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        setOpen(false)
+        setQuery('')
+        triggerRef.current?.focus()
+      }
+    }
+
+    document.addEventListener('mousedown', onPointerDown)
+    document.addEventListener('keydown', onKeyDown)
+    return () => {
+      document.removeEventListener('mousedown', onPointerDown)
+      document.removeEventListener('keydown', onKeyDown)
+    }
+  }, [open])
+
+  useEffect(() => {
+    if (!open || !searchable) return
+    const handle = window.setTimeout(() => searchRef.current?.focus(), 0)
+    return () => window.clearTimeout(handle)
+  }, [open, searchable])
+
+  const closeMenu = () => {
+    setOpen(false)
+    setQuery('')
+  }
+
+  const menu = open && menuPosition
+    ? createPortal(
+        <div
+          ref={menuRef}
+          role="listbox"
+          id={listboxId}
+          className={cn(
+            'fixed z-[80] overflow-hidden rounded-lg border border-neutral-600 bg-[#131518] shadow-2xl',
+            menuClassName
+          )}
+          style={{
+            top: menuPosition.top,
+            left: menuPosition.left,
+            width: menuPosition.width
+          }}
+        >
+          {searchable && (
+            <div className="flex items-center gap-2 border-b border-[#1f2329] px-3 py-2.5 text-neutral-500">
+              <Search size={14} />
+              <input
+                ref={searchRef}
+                value={query}
+                onChange={(event) => setQuery(event.target.value)}
+                placeholder={searchPlaceholder}
+                className="flex-1 bg-transparent text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none"
+              />
+            </div>
+          )}
+
+          <div className="icosa-scroll max-h-60 overflow-y-auto p-1">
+            {filteredOptions.length > 0 ? (
+              filteredOptions.map((option) => {
+                const active = option.value === value
+                return (
+                  <button
+                    key={option.value}
+                    type="button"
+                    onClick={() => {
+                      onChange(option.value)
+                      closeMenu()
+                    }}
+                    className={cn(
+                      'flex w-full cursor-pointer items-center gap-2.5 rounded-md px-2.5 py-2 text-left text-xs transition-all',
+                      active
+                        ? 'bg-amber-400/10 text-amber-400'
+                        : 'text-neutral-300 hover:bg-neutral-800'
+                    )}
+                  >
+                    <span className="flex-1 truncate">{option.label}</span>
+                    {option.badge && (
+                      <span className="font-mono text-[10px] text-neutral-500">
+                        {option.badge}
+                      </span>
+                    )}
+                    {active && <Check size={12} />}
+                  </button>
+                )
+              })
+            ) : (
+              <div className="px-2.5 py-3 text-xs text-neutral-500">{emptyLabel}</div>
+            )}
+          </div>
+        </div>,
+        document.body
+      )
+    : null
+
+  return (
+    <div ref={rootRef} className={cn('flex flex-col gap-1', className)}>
+      {label && <label className="text-xs text-neutral-400">{label}</label>}
+      <button
+        ref={triggerRef}
+        type="button"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-controls={listboxId}
+        onClick={() => setOpen((current) => !current)}
+        className={cn(
+          'flex h-9.5 w-full cursor-pointer items-center gap-2.5 rounded-md border px-3 text-left text-sm transition-all disabled:cursor-not-allowed disabled:opacity-50',
+          open
+            ? 'border-amber-500 bg-[#0f1114] shadow-[0_0_0_3px_rgba(245,158,11,0.15)]'
+            : 'border-[#1f2329] bg-[#0f1114] hover:border-neutral-600',
+          accent ? 'text-amber-400' : 'text-neutral-200',
+          triggerClassName
+        )}
+      >
+        <span className="flex-1 truncate font-medium">{selected?.label ?? placeholder}</span>
+        {selected?.badge && (
+          <span
+            className={cn(
+              'shrink-0 rounded border border-[#1f2329] bg-neutral-900 px-1.5 py-0.5 font-mono text-[10px]',
+              accent ? 'text-amber-400' : 'text-neutral-500'
+            )}
+          >
+            {selected.badge}
+          </span>
+        )}
+        <span className={cn('shrink-0', accent ? 'text-amber-500' : 'text-neutral-500')}>
+          <ChevronDown size={16} />
+        </span>
+      </button>
+      {menu}
+    </div>
+  )
+}

--- a/src/renderer/src/components/translation/BatchActionBar.tsx
+++ b/src/renderer/src/components/translation/BatchActionBar.tsx
@@ -2,6 +2,8 @@ import { Loader2 } from 'lucide-react'
 
 interface BatchActionBarProps {
   selectedCount: number
+  batchCompleted: number
+  batchTotal: number
   onTranslateDeepL: () => void
   onTranslateGPT: () => void
   onCancelTranslation: () => void
@@ -11,6 +13,8 @@ interface BatchActionBarProps {
 
 export function BatchActionBar({
   selectedCount,
+  batchCompleted,
+  batchTotal,
   onTranslateDeepL,
   onTranslateGPT,
   onCancelTranslation,
@@ -20,8 +24,8 @@ export function BatchActionBar({
   if (selectedCount === 0 && !isTranslating) return null
 
   return (
-    <div className="flex items-center gap-3 border-t border-neutral-700 bg-neutral-900 px-4 py-3 shrink-0">
-      <span className="text-sm text-neutral-400 shrink-0">
+    <div className="flex shrink-0 items-center gap-3 border-t border-neutral-700 bg-neutral-900 px-4 py-3">
+      <span className="shrink-0 text-sm text-neutral-400">
         {selectedCount}{' '}
         {selectedCount === 1 ? 'entrada selecionada' : 'entradas selecionadas'}
       </span>
@@ -30,12 +34,12 @@ export function BatchActionBar({
         <>
           <div className="flex items-center gap-2 text-sm text-neutral-400">
             <Loader2 size={14} className="animate-spin" />
-            Traduzindo
+            Traduzindo {batchCompleted} / {batchTotal || selectedCount}
           </div>
           <button
             type="button"
             onClick={onCancelTranslation}
-            className="rounded-md border border-red-500/60 px-3 py-1.5 text-sm font-medium text-red-200 transition-colors hover:bg-red-500/10"
+            className="cursor-pointer rounded-md border border-red-500/60 px-3 py-1.5 text-sm font-medium text-red-200 transition-colors hover:bg-red-500/10"
           >
             Parar
           </button>
@@ -45,14 +49,14 @@ export function BatchActionBar({
           <button
             type="button"
             onClick={onTranslateDeepL}
-            className="rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
+            className="cursor-pointer rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
           >
             Traduzir via DeepL
           </button>
           <button
             type="button"
             onClick={onTranslateGPT}
-            className="rounded-md bg-emerald-700 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-600"
+            className="cursor-pointer rounded-md bg-emerald-700 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-emerald-600"
           >
             Traduzir via GPT
           </button>
@@ -63,9 +67,9 @@ export function BatchActionBar({
         type="button"
         onClick={onClearSelection}
         disabled={isTranslating}
-        className="ml-auto text-xs text-neutral-500 hover:text-neutral-300 transition-colors disabled:opacity-50"
+        className="ml-auto cursor-pointer text-xs text-neutral-500 transition-colors hover:text-neutral-300 disabled:cursor-not-allowed disabled:opacity-50"
       >
-        Limpar seleção
+        Limpar selecao
       </button>
     </div>
   )

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -1,9 +1,10 @@
 import { AlertTriangle, BookOpen, Check, Search, Sparkles, X } from 'lucide-react'
-import { useMemo, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import {
   type TranslationSessionEntry,
   useTranslationSession
 } from '@/context/TranslationSession'
+import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
 import { cn } from '@/lib/utils'
 import { renderSource } from '@/utils/renderSource'
 
@@ -31,21 +32,20 @@ function hasXmlTags(entry: TranslationSessionEntry): boolean {
 
 function KbdHint({ children }: { children: React.ReactNode }) {
   return (
-    <span className="inline-flex items-center justify-center h-4.5 min-w-4.5 px-1 rounded bg-[#181b1f] border border-[#2a2f37] border-b-2 font-mono text-[10px] text-neutral-400">
+    <span className="inline-flex h-4.5 min-w-4.5 items-center justify-center rounded border border-[#2a2f37] border-b-2 bg-[#181b1f] px-1 font-mono text-[10px] text-neutral-400">
       {children}
     </span>
   )
 }
 
-// ── Tag pill (EN / PT-BR labels in cards) ─────────────────────────────────
 function LangTag({ children, accent }: { children: React.ReactNode; accent?: boolean }) {
   return (
     <span
       className={cn(
-        'inline-flex items-center h-5 px-2 rounded font-mono text-[10px] font-bold tracking-[0.06em]',
+        'inline-flex h-5 items-center rounded px-2 font-mono text-[10px] font-bold tracking-[0.06em]',
         accent
           ? 'bg-amber-500/14 text-amber-400'
-          : 'bg-[#131518] border border-[#1f2329] text-neutral-400'
+          : 'border border-[#1f2329] bg-[#131518] text-neutral-400'
       )}
     >
       {children}
@@ -63,10 +63,8 @@ export function TranslationGrid({
   const { selectedUids, selectEntry, selectEntries } = useTranslationSession()
   const [search, setSearch] = useState('')
   const [filter, setFilter] = useState<FilterMode>('all')
-
-  // Maps uid → textarea DOM element so Enter can jump to the next row
+  const searchInputRef = useRef<HTMLInputElement>(null)
   const textareaRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map())
-  // Tracks which entries were saved via Enter to skip the subsequent onBlur save
   const savedByEnterRef = useRef<Set<string>>(new Set())
 
   const counts = useMemo(() => {
@@ -86,25 +84,53 @@ export function TranslationGrid({
   }, [entries])
 
   const filteredEntries = useMemo(() => {
-    return entries.filter((e) => {
-      if (filter === 'untranslated' && e.target.trim()) return false
-      if (filter === 'translated' && !e.target.trim()) return false
-      if (filter === 'dictionary' && getCategory(e) !== 'dictionary') return false
-      if (filter === 'tags' && !hasXmlTags(e)) return false
+    return entries.filter((entry) => {
+      if (filter === 'untranslated' && entry.target.trim()) return false
+      if (filter === 'translated' && !entry.target.trim()) return false
+      if (filter === 'dictionary' && getCategory(entry) !== 'dictionary') return false
+      if (filter === 'tags' && !hasXmlTags(entry)) return false
       if (search) {
-        const q = search.toLowerCase()
-        return e.source.toLowerCase().includes(q) || e.target.toLowerCase().includes(q)
+        const query = search.toLowerCase()
+        return (
+          entry.source.toLowerCase().includes(query) || entry.target.toLowerCase().includes(query)
+        )
       }
       return true
     })
   }, [entries, filter, search])
 
+  const selectedStats = useMemo(() => {
+    let selectedStrings = 0
+    let selectedCharacters = 0
+
+    for (const entry of entries) {
+      if (!selectedUids.has(entry.rowId)) continue
+      selectedStrings += 1
+      selectedCharacters += entry.source.length
+    }
+
+    return { selectedStrings, selectedCharacters }
+  }, [entries, selectedUids])
+
   const allFiltered =
-    filteredEntries.length > 0 && filteredEntries.every((e) => selectedUids.has(e.rowId))
+    filteredEntries.length > 0 && filteredEntries.every((entry) => selectedUids.has(entry.rowId))
+
+  useEffect(() => {
+    const handleFindShortcut = (event: KeyboardEvent) => {
+      if (!event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) return
+      if (event.key.toLowerCase() !== 'f') return
+      event.preventDefault()
+      searchInputRef.current?.focus()
+      searchInputRef.current?.select()
+    }
+
+    window.addEventListener('keydown', handleFindShortcut)
+    return () => window.removeEventListener('keydown', handleFindShortcut)
+  }, [])
 
   const handleSelectAll = (checked: boolean) => {
     selectEntries(
-      filteredEntries.map((e) => e.rowId),
+      filteredEntries.map((entry) => entry.rowId),
       checked
     )
   }
@@ -121,7 +147,6 @@ export function TranslationGrid({
   }
 
   const handleEntryBlur = (entry: TranslationSessionEntry, value: string) => {
-    // Skip if Enter already persisted this entry (blur fires right after Enter navigates away)
     if (savedByEnterRef.current.has(entry.rowId)) {
       savedByEnterRef.current.delete(entry.rowId)
       return
@@ -130,37 +155,34 @@ export function TranslationGrid({
   }
 
   const handleEnterKey = (
-    e: React.KeyboardEvent<HTMLTextAreaElement>,
+    event: React.KeyboardEvent<HTMLTextAreaElement>,
     entry: TranslationSessionEntry
   ) => {
-    if (e.key !== 'Enter' || e.shiftKey) return
-    e.preventDefault()
+    if (event.key !== 'Enter' || event.shiftKey) return
+    event.preventDefault()
 
-    const value = e.currentTarget.value
+    const value = event.currentTarget.value
     updateEntryTarget(entry, value)
     savedByEnterRef.current.add(entry.rowId)
 
-    // Persist to database only if value is non-empty
     if (value.trim()) onEntrySave(entry.rowId, value)
 
-    const nextIdx = filteredEntries.findIndex((fe) => fe.rowId === entry.rowId) + 1
-    const nextEntry = filteredEntries[nextIdx]
-    if (nextEntry) {
-      const nextTextarea = textareaRefs.current.get(nextEntry.rowId)
-      if (nextTextarea) {
-        nextTextarea.focus()
-        nextTextarea.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
-      }
-    }
+    const nextIndex = filteredEntries.findIndex((item) => item.rowId === entry.rowId) + 1
+    const nextEntry = filteredEntries[nextIndex]
+    if (!nextEntry) return
+
+    const nextTextarea = textareaRefs.current.get(nextEntry.rowId)
+    if (!nextTextarea) return
+    nextTextarea.focus()
+    nextTextarea.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
   }
 
-  // ── IDE Pro search + filter bar ──────────────────────────────────────────
-  const filterItems: {
+  const filterItems: Array<{
     mode: FilterMode
     label: string
     count: number
     dot?: string
-  }[] = [
+  }> = [
     {
       mode: 'untranslated',
       label: 'Nao traduzidas',
@@ -169,30 +191,35 @@ export function TranslationGrid({
     },
     { mode: 'translated', label: 'Traduzidas', count: counts.translated, dot: 'bg-amber-400' },
     { mode: 'dictionary', label: 'Com dicionario', count: counts.dictionary, dot: 'bg-blue-500' },
-    { mode: 'tags', label: 'Com tags XML', count: counts.tags, dot: 'bg-amber-500' }
+    { mode: 'tags', label: 'Com tags XML', count: counts.tags, dot: 'bg-purple-400' }
   ]
 
   const searchBar = (
-    <div className="flex items-center gap-3 border-b border-[#1f2329] bg-[#0c0d0f] px-5 py-1 shrink-0">
-      <div className="flex h-8 w-[292px] min-w-45 items-center gap-2 rounded-md border border-[#1f2329] bg-[#131518] px-3 focus-within:border-neutral-600 transition-colors">
-        <Search size={13} className="text-neutral-500 shrink-0" />
+    <div className="flex shrink-0 items-center gap-3 border-b border-[#1f2329] bg-[#0c0d0f] px-5 py-1">
+      <div className="flex h-8 w-[292px] min-w-45 items-center gap-2 rounded-md border border-[#1f2329] bg-[#131518] px-3 transition-colors focus-within:border-neutral-600">
+        <Search size={13} className="shrink-0 text-neutral-500" />
         <input
+          ref={searchInputRef}
           value={search}
-          onChange={(e) => setSearch(e.target.value)}
+          onChange={(event) => setSearch(event.target.value)}
           placeholder="Buscar em strings..."
-          className="flex-1 min-w-0 bg-transparent text-xs font-medium text-neutral-300 placeholder:text-neutral-600 focus:outline-none"
+          className="min-w-0 flex-1 bg-transparent text-xs font-medium text-neutral-300 placeholder:text-neutral-600 focus:outline-none"
         />
         {search && (
-          <button type="button" onClick={() => setSearch('')} className="shrink-0">
-            <X size={13} className="text-neutral-500 hover:text-neutral-300 transition-colors" />
+          <button
+            type="button"
+            onClick={() => setSearch('')}
+            className="shrink-0 cursor-pointer"
+          >
+            <X size={13} className="text-neutral-500 transition-colors hover:text-neutral-300" />
           </button>
         )}
-        <span className="inline-flex items-center justify-center h-5 min-w-6 rounded border border-[#252a32] bg-[#0f1114] px-1 font-mono text-[10px] text-neutral-500">
-          ⌘F
+        <span className="inline-flex h-5 min-w-6 items-center justify-center rounded border border-[#252a32] bg-[#0f1114] px-1 font-mono text-[10px] text-neutral-500">
+          Ctrl F
         </span>
       </div>
 
-      <div className="flex items-center gap-3 shrink-0">
+      <div className="flex shrink-0 items-center gap-3">
         <button
           type="button"
           onClick={() => setFilter('all')}
@@ -204,7 +231,7 @@ export function TranslationGrid({
           )}
         >
           Todas
-          <span className="rounded-full bg-[#181b1f] px-1.5 py-0.5 text-[11px] text-neutral-500 tabular-nums">
+          <span className="rounded-full bg-[#181b1f] px-1.5 py-0.5 text-[11px] tabular-nums text-neutral-500">
             {entries.length}
           </span>
         </button>
@@ -223,9 +250,9 @@ export function TranslationGrid({
                   : 'border-transparent text-neutral-400 hover:border-[#2a2f37] hover:bg-[#181b1f] hover:text-neutral-200'
               )}
             >
-              <span className={cn('inline-block h-1.5 w-1.5 rounded-full shrink-0', item.dot)} />
+              <span className={cn('inline-block h-1.5 w-1.5 shrink-0 rounded-full', item.dot)} />
               {item.label}
-              <span className="rounded-full bg-[#181b1f] px-1.5 py-0.5 text-[11px] text-neutral-600 tabular-nums">
+              <span className="rounded-full bg-[#181b1f] px-1.5 py-0.5 text-[11px] tabular-nums text-neutral-600">
                 {item.count}
               </span>
             </button>
@@ -233,47 +260,47 @@ export function TranslationGrid({
         })}
       </div>
 
-      <div className="ml-auto flex items-center gap-1.5 text-xs font-semibold text-neutral-400">
-        <span className="font-mono text-neutral-500">⌘</span>
+      <div className="ml-auto flex items-center gap-3 text-xs font-semibold text-neutral-400">
+        <span className="font-mono tabular-nums text-neutral-500">
+          {selectedStats.selectedStrings} strings • {selectedStats.selectedCharacters} characters
+        </span>
+        <span className="font-mono text-neutral-500">Ctrl</span>
         Atalhos
       </div>
     </div>
   )
 
-  // ── Side-by-side view (Direction A — IDE Pro) ────────────────────────────
   if (viewMode === 'side') {
     return (
-      <div className="flex flex-col h-full min-h-0">
+      <div className="flex h-full min-h-0 flex-col">
         {searchBar}
 
-        {/* Column headers — pr-3 compensates for the 12px scrollbar-gutter below */}
         <div
-          className="grid shrink-0 border-b border-[#1f2329] bg-[#0f1114] select-none pr-3"
+          className="grid shrink-0 select-none border-b border-[#1f2329] bg-[#0f1114] pr-3"
           style={{ gridTemplateColumns: '80px 1fr 1fr' }}
         >
-          <div className="flex items-center justify-center px-3 py-2 border-r border-[#1f2329]">
+          <div className="flex items-center justify-center border-r border-[#1f2329] px-3 py-2">
             <input
               type="checkbox"
               checked={allFiltered}
-              onChange={(e) => handleSelectAll(e.target.checked)}
-              className="accent-amber-500 cursor-pointer"
+              onChange={(event) => handleSelectAll(event.target.checked)}
+              className="cursor-pointer accent-amber-500"
             />
           </div>
-          <div className="px-4 py-2 font-semibold text-[10px] uppercase tracking-[0.08em] text-neutral-500">
+          <div className="px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
             Origem · EN
           </div>
-          <div className="px-4 py-2 font-semibold text-[10px] uppercase tracking-[0.08em] text-neutral-500 border-l border-[#1f2329]">
-            Tradução · PT-BR
+          <div className="border-l border-[#1f2329] px-4 py-2 text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
+            Traducao · PT-BR
           </div>
         </div>
 
-        {/* Single scroll container — scrollbar-gutter:stable always reserves 12px for the scrollbar */}
-        <div className="flex-1 min-h-0 overflow-y-auto icosa-scroll [scrollbar-gutter:stable]">
-          {filteredEntries.map((entry, idx) => {
-            const cat = getCategory(entry)
+        <div className="icosa-scroll flex-1 min-h-0 overflow-y-auto [scrollbar-gutter:stable]">
+          {filteredEntries.map((entry, index) => {
+            const category = getCategory(entry)
             const isDone = entry.target.trim() !== ''
             const isSelected = selectedUids.has(entry.rowId)
-            const isDict = cat === 'dictionary'
+            const isDictionary = category === 'dictionary'
             const charCount = entry.source.length
 
             return (
@@ -285,88 +312,86 @@ export function TranslationGrid({
                 )}
                 style={{ gridTemplateColumns: '80px 1fr 1fr' }}
               >
-                {/* Gutter */}
                 <div
-                  className="flex flex-col items-center gap-2 py-3 px-3 border-r border-[#1f2329] bg-[#0f1114] cursor-pointer"
+                  className="flex cursor-pointer flex-col items-center gap-2 border-r border-[#1f2329] bg-[#0f1114] px-3 py-3"
                   onClick={() => focusEntry(entry.rowId)}
                 >
                   <input
                     type="checkbox"
                     checked={isSelected}
-                    onChange={(e) => selectEntry(entry.rowId, e.target.checked)}
-                    onClick={(e) => e.stopPropagation()}
-                    className="accent-amber-500 cursor-pointer"
+                    onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                    onClick={(event) => event.stopPropagation()}
+                    className="cursor-pointer accent-amber-500"
                   />
-                  <span className="font-mono text-[11px] text-neutral-600 tabular-nums">
-                    {String(idx + 1).padStart(3, '0')}
+                  <span className="font-mono text-[11px] tabular-nums text-neutral-600">
+                    {String(index + 1).padStart(3, '0')}
                   </span>
                   <span
                     className={cn(
-                      'w-1.5 h-1.5 rounded-full mt-auto transition-colors',
+                      'mt-auto h-1.5 w-1.5 rounded-full transition-colors',
                       isDone ? 'bg-amber-500' : 'bg-neutral-700'
                     )}
                   />
                 </div>
 
-                {/* Source */}
                 <div
-                  className="flex flex-col gap-2 py-3 px-4 min-w-0 cursor-pointer"
+                  className="flex min-w-0 cursor-pointer flex-col gap-2 px-4 py-3"
                   onClick={() => focusEntry(entry.rowId)}
                 >
-                  <div className="font-mono text-[13px] text-neutral-200 leading-[1.6] whitespace-pre-wrap wrap-break-word">
-                    {entry.source ? (
-                      renderSource(entry.source)
-                    ) : (
-                      <span className="text-neutral-600 italic">vazio</span>
+                  <div className="font-mono text-[13px] leading-[1.6] text-neutral-200 whitespace-pre-wrap wrap-break-word">
+                    {entry.source ? renderSource(entry.source) : (
+                      <span className="italic text-neutral-600">vazio</span>
                     )}
                   </div>
-                  <div className="flex items-center gap-1.5 flex-wrap">
-                    {isDict && (
-                      <span className="inline-flex items-center gap-1 px-1.5 py-0.5 rounded text-[10px] font-mono font-semibold bg-blue-500/12 text-blue-400">
+                  <div className="flex flex-wrap items-center gap-1.5">
+                    {isDictionary && (
+                      <span className="inline-flex items-center gap-1 rounded bg-blue-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-blue-400">
                         <BookOpen size={10} /> D <span className="text-blue-500/70">1</span>
                       </span>
                     )}
-                    <span className="text-[10px] font-mono text-neutral-600">{charCount} c</span>
+                    <span className="font-mono text-[10px] text-neutral-600">
+                      {charCount} characters
+                    </span>
                   </div>
                 </div>
 
-                {/* Target */}
                 <div
-                  className="flex flex-col gap-2 py-3 px-4 border-l border-[#1f2329] min-w-0"
-                  onClick={(e) => e.stopPropagation()}
+                  className="flex min-w-0 flex-col gap-2 border-l border-[#1f2329] px-4 py-3"
+                  onClick={(event) => event.stopPropagation()}
                 >
-                  <textarea
-                    ref={(el) => {
-                      if (el) textareaRefs.current.set(entry.rowId, el)
+                  <HighlightedTextarea
+                    ref={(element) => {
+                      if (element) textareaRefs.current.set(entry.rowId, element)
                       else textareaRefs.current.delete(entry.rowId)
                     }}
-                    key={`${entry.rowId}:${entry.target}`}
-                    defaultValue={entry.target}
-                    onBlur={(e) => handleEntryBlur(entry, e.target.value)}
-                    onKeyDown={(e) => handleEnterKey(e, entry)}
+                    value={entry.target}
+                    onBlur={(event) => handleEntryBlur(entry, event.target.value)}
+                    onChange={() => {}}
+                    onKeyDown={(event) => handleEnterKey(event, entry)}
                     rows={1}
-                    placeholder="Tradução..."
-                    className="w-full resize-none field-sizing-content bg-[#131518] border border-[#1f2329] rounded-md px-2.5 py-2 text-[13px] text-neutral-200 leading-[1.55] placeholder:text-neutral-600 placeholder:italic focus:outline-none focus:border-amber-500/60 focus:shadow-[0_0_0_3px_rgba(245,158,11,0.18)] transition-[border-color,box-shadow]"
+                    placeholder="Traducao..."
+                    containerClassName="rounded-md"
+                    className="field-sizing-content"
                   />
                   <div
                     className={cn(
-                      'flex items-center gap-1.5 opacity-0 pointer-events-none transition-opacity duration-150 group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
+                      'pointer-events-none flex items-center gap-1.5 opacity-0 transition-opacity duration-150 group-focus-within:pointer-events-auto group-focus-within:opacity-100'
                     )}
                   >
                     <button
                       type="button"
-                      className="inline-flex items-center gap-1 h-6 px-2 rounded bg-transparent text-[11px] text-neutral-400 hover:bg-[#1c1f24] hover:text-neutral-200 cursor-pointer transition-colors"
+                      className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
                     >
                       <Sparkles size={11} /> Sugerir IA
                     </button>
                     <button
                       type="button"
-                      className="inline-flex items-center gap-1 h-6 px-2 rounded bg-transparent text-[11px] text-neutral-400 hover:bg-[#1c1f24] hover:text-neutral-200 cursor-pointer transition-colors"
+                      className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
                     >
-                      <BookOpen size={11} /> Aplicar dicionário
+                      <BookOpen size={11} /> Aplicar dicionario
                     </button>
                     <span className="ml-auto flex items-center gap-1 text-[11px] text-neutral-500">
-                      <KbdHint>↵</KbdHint> próximo
+                      <KbdHint>↵</KbdHint> proximo
                       <span className="mx-1 text-neutral-700">·</span>
                       <KbdHint>⇧↵</KbdHint> nova linha
                     </span>
@@ -380,33 +405,30 @@ export function TranslationGrid({
     )
   }
 
-  // ── Stacked view (Direction B — Focus Stack) ─────────────────────────────
   return (
-    <div className="flex flex-col h-full min-h-0">
+    <div className="flex h-full min-h-0 flex-col">
       {searchBar}
 
-      {/* Thin select-all bar */}
-      <div className="flex items-center gap-2 border-b border-[#1f2329] bg-[#0f1114] px-7 py-2 shrink-0 select-none">
+      <div className="flex shrink-0 items-center gap-2 border-b border-[#1f2329] bg-[#0f1114] px-7 py-2 select-none">
         <input
           type="checkbox"
           checked={allFiltered}
-          onChange={(e) => handleSelectAll(e.target.checked)}
-          className="accent-amber-500 cursor-pointer"
+          onChange={(event) => handleSelectAll(event.target.checked)}
+          className="cursor-pointer accent-amber-500"
         />
-        <span className="text-[11px] text-neutral-500 font-medium tabular-nums">
+        <span className="text-[11px] font-medium tabular-nums text-neutral-500">
           {filteredEntries.length} entradas
         </span>
       </div>
 
-      {/* Card list */}
-      <div className="flex-1 min-h-0 overflow-y-auto icosa-scroll">
-        <div className="px-7 pt-5 pb-20">
-          <div className="flex flex-col gap-3.5 max-w-275 mx-auto">
-            {filteredEntries.map((entry, idx) => {
-              const cat = getCategory(entry)
+      <div className="icosa-scroll flex-1 min-h-0 overflow-y-auto">
+        <div className="px-7 pb-20 pt-5">
+          <div className="mx-auto flex max-w-275 flex-col gap-3.5">
+            {filteredEntries.map((entry, index) => {
+              const category = getCategory(entry)
               const isDone = entry.target.trim() !== ''
               const isSelected = selectedUids.has(entry.rowId)
-              const isDict = cat === 'dictionary'
+              const isDictionary = category === 'dictionary'
               const hasTags = hasXmlTags(entry)
               const wordCount = entry.source.split(/\s+/).filter(Boolean).length
               const charCount = entry.source.length
@@ -416,97 +438,84 @@ export function TranslationGrid({
                 <div
                   key={entry.rowId}
                   className={cn(
-                    'group grid overflow-hidden rounded-xl border cursor-pointer transition-all duration-120',
-                    // base
-                    'bg-[#0f1114] border-[#1f2329]',
-                    // hover
-                    'hover:border-[#2a2f37] hover:-translate-y-px hover:shadow-[0_4px_16px_rgba(0,0,0,0.18)]',
-                    // focused via textarea focus
+                    'group grid cursor-pointer overflow-hidden rounded-xl border transition-all duration-120',
+                    'border-[#1f2329] bg-[#0f1114]',
+                    'hover:-translate-y-px hover:border-[#2a2f37] hover:shadow-[0_4px_16px_rgba(0,0,0,0.18)]',
                     'focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25),0_8px_24px_rgba(0,0,0,0.24)]',
-                    // selected tint
                     isSelected && 'border-blue-700/40 bg-blue-950/10'
                   )}
                   style={{ gridTemplateColumns: '56px 1fr' }}
                   onClick={() => focusEntry(entry.rowId)}
                 >
-                  {/* Side column — checkbox, vertical number, status circle */}
-                  <div className="flex flex-col items-center gap-3 py-4.5 border-r border-[#1f2329] bg-[#0c0d0f]">
+                  <div className="flex flex-col items-center gap-3 border-r border-[#1f2329] bg-[#0c0d0f] py-4.5">
                     <input
                       type="checkbox"
                       checked={isSelected}
-                      onChange={(e) => selectEntry(entry.rowId, e.target.checked)}
-                      onClick={(e) => e.stopPropagation()}
-                      className="accent-amber-500 cursor-pointer"
+                      onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                      onClick={(event) => event.stopPropagation()}
+                      className="cursor-pointer accent-amber-500"
                     />
 
-                    {/* Vertical line number */}
                     <span
-                      className="font-mono text-[11px] text-neutral-600 tracking-widest mt-auto"
+                      className="mt-auto font-mono text-[11px] tracking-widest text-neutral-600"
                       style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
                     >
-                      #{String(idx + 1).padStart(3, '0')}
+                      #{String(index + 1).padStart(3, '0')}
                     </span>
 
-                    {/* Status circle */}
                     <div
                       className={cn(
-                        'w-5.5 h-5.5 rounded-full border flex items-center justify-center transition-colors',
+                        'flex h-5.5 w-5.5 items-center justify-center rounded-full border transition-colors',
                         isDone
-                          ? 'bg-amber-500 border-amber-500 text-white'
-                          : 'bg-[#131518] border-[#1f2329]'
+                          ? 'border-amber-500 bg-amber-500 text-white'
+                          : 'border-[#1f2329] bg-[#131518]'
                       )}
                     >
                       {isDone ? (
                         <Check size={11} strokeWidth={2.5} />
                       ) : (
-                        <span className="w-1.5 h-1.5 rounded-full bg-neutral-600" />
+                        <span className="h-1.5 w-1.5 rounded-full bg-neutral-600" />
                       )}
                     </div>
                   </div>
 
-                  {/* Card body */}
                   <div
-                    className="flex flex-col gap-3 py-4.5 px-5.5"
-                    onClick={(e) => e.stopPropagation()}
+                    className="flex flex-col gap-3 px-5.5 py-4.5"
+                    onClick={(event) => event.stopPropagation()}
                   >
-                    {/* Header row: EN tag + meta + badges */}
                     <div className="flex items-center gap-2.5">
                       <LangTag>EN</LangTag>
-                      <span className="font-mono text-[10px] text-neutral-600 tracking-[0.02em]">
-                        {charCount} caracteres · {wordCount} palavras
+                      <span className="font-mono text-[10px] tracking-[0.02em] text-neutral-600">
+                        {charCount} characters · {wordCount} palavras
                       </span>
                       <span className="flex-1" />
-                      {isDict && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium bg-blue-500/12 text-blue-400">
+                      {isDictionary && (
+                        <span className="inline-flex items-center gap-1 rounded bg-blue-500/12 px-2 py-0.5 text-[11px] font-medium text-blue-400">
                           <BookOpen size={11} />
                           {entry.matchType === 'uid' ? '1 termo (uid)' : '1 termo'}
                         </span>
                       )}
                       {hasTags && (
-                        <span className="inline-flex items-center gap-1 px-2 py-0.5 rounded text-[11px] font-medium bg-amber-500/12 text-amber-400">
-                          <AlertTriangle size={11} /> contém tags
+                        <span className="inline-flex items-center gap-1 rounded bg-purple-500/14 px-2 py-0.5 text-[11px] font-medium text-purple-300">
+                          <AlertTriangle size={11} /> contem tags
                         </span>
                       )}
                     </div>
 
-                    {/* Source text */}
                     <div className="font-mono text-[14px] leading-[1.65] text-neutral-200 whitespace-pre-wrap wrap-break-word">
-                      {entry.source ? (
-                        renderSource(entry.source)
-                      ) : (
-                        <span className="text-neutral-600 italic">vazio</span>
+                      {entry.source ? renderSource(entry.source) : (
+                        <span className="italic text-neutral-600">vazio</span>
                       )}
                     </div>
 
-                    {/* Dict strip — shown when focused and is a dict match */}
-                    {isDict && (
-                      <div className="hidden items-center gap-2 px-3 py-2 bg-[#0c0d0f] border border-dashed border-[#2a2f37] rounded-lg flex-wrap group-focus-within:flex">
-                        <span className="text-[11px] font-semibold text-neutral-500 uppercase tracking-[0.08em]">
-                          Dicionário sugere:
+                    {isDictionary && (
+                      <div className="hidden flex-wrap items-center gap-2 rounded-lg border border-dashed border-[#2a2f37] bg-[#0c0d0f] px-3 py-2 group-focus-within:flex">
+                        <span className="text-[11px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
+                          Dicionario sugere:
                         </span>
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1.5 px-2.5 py-0.5 bg-[#0f1114] border border-[#1f2329] rounded-full text-[12px] cursor-pointer hover:border-amber-500 hover:bg-amber-500/10 transition-colors"
+                          className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-[#1f2329] bg-[#0f1114] px-2.5 py-0.5 text-[12px] transition-colors hover:border-amber-500 hover:bg-amber-500/10"
                           onClick={() => {
                             onEntryChange(entry.rowId, entry.target)
                           }}
@@ -516,55 +525,53 @@ export function TranslationGrid({
                             {entry.source.length > 24 ? '…' : ''}
                           </span>
                           <span className="text-neutral-600">→</span>
-                          <span className="text-neutral-200 font-medium">
-                            {entry.target || '—'}
-                          </span>
+                          <span className="font-medium text-neutral-200">{entry.target || '—'}</span>
                         </button>
                       </div>
                     )}
 
-                    {/* PT-BR tag row + action bar */}
-                    <div className="flex items-center gap-2.5 pt-1 border-t border-dashed border-[#1f2329] mt-1">
+                    <div className="mt-1 flex items-center gap-2.5 border-t border-dashed border-[#1f2329] pt-1">
                       <LangTag accent>PT-BR</LangTag>
                       <div
                         className={cn(
-                          'flex-1 flex items-center gap-1.5 opacity-0 pointer-events-none transition-opacity duration-150 group-focus-within:opacity-100 group-focus-within:pointer-events-auto'
+                          'pointer-events-none flex flex-1 items-center gap-1.5 opacity-0 transition-opacity duration-150 group-focus-within:pointer-events-auto group-focus-within:opacity-100'
                         )}
                       >
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1 h-6 px-2 rounded bg-transparent text-[11px] text-neutral-400 hover:bg-[#1c1f24] hover:text-neutral-200 cursor-pointer transition-colors"
+                          className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
                         >
                           <Sparkles size={11} /> Sugerir IA
                         </button>
                         <button
                           type="button"
-                          className="inline-flex items-center gap-1 h-6 px-2 rounded bg-transparent text-[11px] text-neutral-400 hover:bg-[#1c1f24] hover:text-neutral-200 cursor-pointer transition-colors"
+                          className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
                         >
                           <Check size={11} /> Marcar como traduzida
                         </button>
                         <span className="flex-1" />
                         <span className="flex items-center gap-1 text-[11px] text-neutral-500">
-                          <KbdHint>↵</KbdHint> próximo
+                          <KbdHint>↵</KbdHint> proximo
                           <span className="mx-0.5 text-neutral-700">·</span>
                           <KbdHint>⇧↵</KbdHint> nova linha
                         </span>
                       </div>
                     </div>
 
-                    {/* Translation textarea */}
-                    <textarea
-                      ref={(el) => {
-                        if (el) textareaRefs.current.set(entry.rowId, el)
+                    <HighlightedTextarea
+                      ref={(element) => {
+                        if (element) textareaRefs.current.set(entry.rowId, element)
                         else textareaRefs.current.delete(entry.rowId)
                       }}
-                      key={`${entry.rowId}:${entry.target}`}
-                      defaultValue={entry.target}
-                      onBlur={(e) => handleEntryBlur(entry, e.target.value)}
-                      onKeyDown={(e) => handleEnterKey(e, entry)}
+                      value={entry.target}
+                      onBlur={(event) => handleEntryBlur(entry, event.target.value)}
+                      onChange={() => {}}
+                      onKeyDown={(event) => handleEnterKey(event, entry)}
                       rows={rows}
-                      placeholder={isDone ? '' : 'Comece a digitar a tradução...'}
-                      className="w-full resize-none bg-[#0c0d0f] border border-[#1f2329] rounded-lg px-3.5 py-3 text-[13px] text-neutral-200 leading-[1.6] placeholder:text-neutral-600 placeholder:italic focus:outline-none focus:border-amber-500 focus:shadow-[0_0_0_3px_rgba(245,158,11,0.25)] min-h-11 transition-[border-color,box-shadow]"
+                      placeholder={isDone ? '' : 'Comece a digitar a traducao...'}
+                      containerClassName="min-h-11 rounded-lg border-[#1f2329] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25)]"
+                      overlayClassName="px-3.5 py-3 text-[13px] leading-[1.6]"
+                      className="min-h-11 px-3.5 py-3 text-[13px] leading-[1.6]"
                     />
                   </div>
                 </div>

--- a/src/renderer/src/features/translate/components/EditorHeader.tsx
+++ b/src/renderer/src/features/translate/components/EditorHeader.tsx
@@ -27,6 +27,8 @@ interface EditorHeaderProps {
   untranslatedCount: number
   total: number
   pct: number
+  batchCompleted: number
+  batchTotal: number
   exportFormat: ExportFormat
   onViewModeChange: (mode: 'side' | 'stacked') => void
   onFocusModeChange: (value: boolean) => void
@@ -46,6 +48,8 @@ export function EditorHeader({
   untranslatedCount,
   total,
   pct,
+  batchCompleted,
+  batchTotal,
   exportFormat,
   onViewModeChange,
   onFocusModeChange,
@@ -56,13 +60,15 @@ export function EditorHeader({
   return (
     <div className="bg-[#0f1114] border-b border-[#1f2329] px-7 pt-5 pb-4 shrink-0">
       <div className="flex items-center gap-3 mb-4">
-        <div className="flex items-center gap-2 text-sm text-neutral-500 min-w-0">
-          <input
-            value={session.modName}
-            onChange={(event) => session.setModName(event.target.value)}
-            placeholder="Nome do mod"
-            className="bg-transparent text-neutral-300 font-medium text-sm focus:outline-none placeholder:text-neutral-600 min-w-0 max-w-50"
-          />
+        <button type="button" className={btnBase} onClick={session.resetSession}>
+          <ArrowLeft />
+          Voltar
+        </button>
+
+        <div className="flex items-center gap-1.5 text-sm text-neutral-500 min-w-0">
+          <span className="max-w-50 truncate font-medium text-sm text-neutral-300">
+            {session.modName}
+          </span>
           <span className="text-neutral-700 shrink-0">
             <ChevronRight />
           </span>
@@ -120,11 +126,6 @@ export function EditorHeader({
             </span>
           </button>
 
-          <button type="button" className={btnBase} onClick={session.resetSession}>
-            <ArrowLeft />
-            Voltar
-          </button>
-
           <button
             type="button"
             className={cn(btnBase, isSaving && 'opacity-60 cursor-not-allowed')}
@@ -169,7 +170,13 @@ export function EditorHeader({
           </div>
         </div>
 
-        <TranslationStats translatedCount={translatedCount} total={total} pct={pct} />
+        <TranslationStats
+          translatedCount={translatedCount}
+          total={total}
+          pct={pct}
+          batchCompleted={batchCompleted}
+          batchTotal={batchTotal}
+        />
       </div>
     </div>
   )

--- a/src/renderer/src/features/translate/components/ExportControls.tsx
+++ b/src/renderer/src/features/translate/components/ExportControls.tsx
@@ -1,4 +1,5 @@
 import { Download } from 'lucide-react'
+import { ThemedSelect } from '@/components/shared/ThemedSelect'
 import type { ExportFormat } from '../types'
 import { btnPrimary } from './styles'
 
@@ -15,15 +16,17 @@ export function ExportControls({
 }: ExportControlsProps): React.JSX.Element {
   return (
     <div className="flex items-center gap-1.5">
-      <select
+      <ThemedSelect
         value={exportFormat}
-        onChange={(event) => onFormatChange(event.target.value as ExportFormat)}
-        className="h-[30px] rounded-md border border-neutral-700 bg-[#131518] px-2 text-xs text-neutral-200 focus:outline-none focus:border-amber-500"
-      >
-        <option value="xml">xml</option>
-        <option value="pak">pak</option>
-        <option value="zip">zip</option>
-      </select>
+        onChange={(value) => onFormatChange(value as ExportFormat)}
+        className="w-24"
+        triggerClassName="h-[30px] px-2 text-xs"
+        options={[
+          { value: 'xml', label: 'xml' },
+          { value: 'pak', label: 'pak' },
+          { value: 'zip', label: 'zip' }
+        ]}
+      />
       <button type="button" className={btnPrimary} onClick={onExport}>
         <Download />
         Exportar

--- a/src/renderer/src/features/translate/components/LanguagePicker.tsx
+++ b/src/renderer/src/features/translate/components/LanguagePicker.tsx
@@ -1,7 +1,5 @@
-import { Check, ChevronDown, Search } from 'lucide-react'
-import { useRef, useState } from 'react'
-import { useClickOutside } from '@/hooks/useClickOutside'
-import { cn } from '@/lib/utils'
+import { useMemo } from 'react'
+import { ThemedSelect } from '@/components/shared/ThemedSelect'
 import type { Language } from '@/types'
 
 interface LanguagePickerProps {
@@ -17,91 +15,27 @@ export function LanguagePicker({
   languages,
   accent
 }: LanguagePickerProps): React.JSX.Element {
-  const [open, setOpen] = useState(false)
-  const [query, setQuery] = useState('')
-  const ref = useRef<HTMLDivElement>(null)
-
-  const selected = languages.find((language) => language.code === value)
-  const filtered = languages.filter(
-    (language) =>
-      language.name.toLowerCase().includes(query.toLowerCase()) ||
-      language.code.toLowerCase().includes(query.toLowerCase())
-  )
-
-  useClickOutside(
-    ref,
-    () => {
-      setOpen(false)
-      setQuery('')
-    },
-    open
+  const options = useMemo(
+    () =>
+      languages.map((language) => ({
+        value: language.code,
+        label: language.name,
+        badge: language.code.toUpperCase(),
+        searchText: `${language.name} ${language.code}`
+      })),
+    [languages]
   )
 
   return (
-    <div ref={ref} className="relative">
-      <button
-        type="button"
-        onClick={() => setOpen((current) => !current)}
-        className={cn(
-          'flex items-center gap-2.5 w-full h-9.5 px-3 rounded-md border text-sm cursor-pointer transition-all text-left',
-          open
-            ? 'border-amber-500 bg-[#0f1114] shadow-[0_0_0_3px_rgba(245,158,11,0.15)]'
-            : 'bg-[#0f1114] border-[#1f2329] hover:border-neutral-600',
-          accent ? 'text-amber-400' : 'text-neutral-200'
-        )}
-      >
-        <span className="flex-1 font-medium truncate">{selected?.name ?? 'Selecionar'}</span>
-        <span
-          className={cn(
-            'font-mono text-[10px] px-1.5 py-0.5 rounded bg-neutral-900 border border-[#1f2329] shrink-0',
-            accent ? 'text-amber-400' : 'text-neutral-500'
-          )}
-        >
-          {(selected?.code ?? '-').toUpperCase()}
-        </span>
-        <span className={cn('shrink-0', accent ? 'text-amber-500' : 'text-neutral-500')}>
-          <ChevronDown />
-        </span>
-      </button>
-
-      {open && (
-        <div className="absolute top-[calc(100%+4px)] left-0 right-0 z-50 bg-[#131518] border border-neutral-600 rounded-lg shadow-2xl overflow-hidden">
-          <div className="flex items-center gap-2 px-3 py-2.5 border-b border-[#1f2329] text-neutral-500">
-            <Search />
-            <input
-              className="flex-1 bg-transparent border-0 outline-none text-neutral-200 text-xs placeholder:text-neutral-600"
-              placeholder="Buscar idioma..."
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-            />
-          </div>
-          <div className="max-h-60 overflow-y-auto p-1">
-            {filtered.map((language) => (
-              <button
-                key={language.code}
-                type="button"
-                onClick={() => {
-                  onChange(language.code)
-                  setOpen(false)
-                  setQuery('')
-                }}
-                className={cn(
-                  'flex items-center gap-2.5 w-full px-2.5 py-2 rounded-md text-xs cursor-pointer transition-all text-left',
-                  language.code === value
-                    ? 'bg-amber-400/10 text-amber-400'
-                    : 'text-neutral-300 hover:bg-neutral-800'
-                )}
-              >
-                <span className="flex-1">{language.name}</span>
-                <span className="font-mono text-[10px] text-neutral-500">
-                  {language.code.toUpperCase()}
-                </span>
-                {language.code === value && <Check size={12} />}
-              </button>
-            ))}
-          </div>
-        </div>
-      )}
-    </div>
+    <ThemedSelect
+      value={value}
+      onChange={onChange}
+      options={options}
+      placeholder="Selecionar"
+      searchable
+      searchPlaceholder="Buscar idioma..."
+      emptyLabel="Nenhum idioma encontrado."
+      accent={accent}
+    />
   )
 }

--- a/src/renderer/src/features/translate/components/ModSelectionCard.tsx
+++ b/src/renderer/src/features/translate/components/ModSelectionCard.tsx
@@ -38,6 +38,8 @@ export function ModSelectionCard({
   onModSelect,
   onPageChange
 }: ModSelectionCardProps): React.JSX.Element {
+  const shouldHighlightNewMode = mods.length === 0 && isNewMod
+
   return (
     <>
       <div className="flex items-start gap-3">
@@ -64,10 +66,11 @@ export function ModSelectionCard({
             type="button"
             onClick={onNewMode}
             className={cn(
-              'px-3 h-6 rounded text-xs cursor-pointer transition-all',
+              'px-3 h-6 rounded text-xs cursor-pointer transition-all focus:outline-none focus-visible:ring-2 focus-visible:ring-amber-500/40',
               isNewMod
                 ? 'bg-[#1f2329] text-neutral-200'
-                : 'bg-transparent text-neutral-500 hover:text-neutral-300'
+                : 'bg-transparent text-neutral-500 hover:text-neutral-300',
+              shouldHighlightNewMode && 'ring-2 ring-amber-500/40'
             )}
           >
             + Novo
@@ -142,6 +145,7 @@ export function ModSelectionCard({
             placeholder="ex: Order of the Dracolich"
             value={newModName}
             onChange={(event) => onNewModNameChange(event.target.value)}
+            autoFocus={mods.length === 0}
           />
         </div>
       )}

--- a/src/renderer/src/features/translate/components/PackageExportModal.tsx
+++ b/src/renderer/src/features/translate/components/PackageExportModal.tsx
@@ -1,5 +1,6 @@
 import { Download, Loader2, Package, X } from 'lucide-react'
 import { useState } from 'react'
+import { ThemedSelect } from '@/components/shared/ThemedSelect'
 import { cn } from '@/lib/utils'
 import type { Language, ModMeta } from '@/types'
 import { languageToBg3Folder } from '../utils/exportNames'
@@ -11,7 +12,6 @@ interface PackageExportModalProps {
   meta: ModMeta
   languages: Language[]
   selectedLanguageFolder: string
-  targetLang: string
   isExporting: boolean
   onCancel: () => void
   onSubmit: (meta: ModMeta, languageFolder: string) => Promise<void>
@@ -21,7 +21,6 @@ export function PackageExportModal({
   meta,
   languages,
   selectedLanguageFolder,
-  targetLang,
   isExporting,
   onCancel,
   onSubmit
@@ -108,30 +107,32 @@ export function PackageExportModal({
             <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
               Pasta de idioma BG3
             </span>
-            <select
+            <ThemedSelect
               value={languageFolder}
-              onChange={(event) => setLanguageFolder(event.target.value)}
+              onChange={setLanguageFolder}
               className={cn(
-                'h-9 px-3 rounded-md border bg-[#0f1114] text-sm text-neutral-200 focus:outline-none',
+                'w-full',
                 languageFolderValid
-                  ? 'border-[#1f2329] focus:border-amber-500'
-                  : 'border-red-500 focus:border-red-400'
+                  ? ''
+                  : '[&_button]:border-red-500 [&_button]:focus:border-red-400'
               )}
-            >
-              {languages.map((language) => (
-                <option key={language.code} value={languageToBg3Folder(language, language.code)}>
-                  {languageToBg3Folder(language, language.code)}
-                </option>
-              ))}
-              {!languages.some(
-                (language) =>
-                  languageToBg3Folder(language, language.code) === selectedLanguageFolder
-              ) && (
-                <option value={selectedLanguageFolder}>
-                  {selectedLanguageFolder || targetLang}
-                </option>
-              )}
-            </select>
+              options={[
+                ...languages.map((language) => ({
+                  value: languageToBg3Folder(language, language.code),
+                  label: languageToBg3Folder(language, language.code),
+                  searchText: `${language.name} ${language.code}`
+                })),
+                ...(!languages.some(
+                  (language) =>
+                    languageToBg3Folder(language, language.code) === selectedLanguageFolder
+                ) && selectedLanguageFolder
+                  ? [{ value: selectedLanguageFolder, label: selectedLanguageFolder }]
+                  : [])
+              ]}
+              searchable
+              searchPlaceholder="Buscar pasta..."
+              emptyLabel="Nenhuma pasta encontrada."
+            />
           </div>
         </div>
 

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -56,6 +56,8 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
         untranslatedCount={untranslatedCount}
         total={total}
         pct={pct}
+        batchCompleted={batch.batchCompleted}
+        batchTotal={batch.batchTotal}
         exportFormat={exportFlow.exportFormat}
         onViewModeChange={setViewMode}
         onFocusModeChange={setFocusMode}
@@ -76,6 +78,8 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
 
       <BatchActionBar
         selectedCount={session.selectedUids.size}
+        batchCompleted={batch.batchCompleted}
+        batchTotal={batch.batchTotal}
         onTranslateDeepL={() => batch.batchTranslate('deepl')}
         onTranslateGPT={() => batch.batchTranslate('openai')}
         onCancelTranslation={batch.cancelBatch}
@@ -88,7 +92,6 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
           meta={exportFlow.exportMeta}
           languages={languages}
           selectedLanguageFolder={exportFlow.bg3LanguageFolder}
-          targetLang={session.targetLang}
           isExporting={exportFlow.isExporting}
           onCancel={exportFlow.closeExportModal}
           onSubmit={exportFlow.submitPackageExport}

--- a/src/renderer/src/features/translate/components/TranslationStats.tsx
+++ b/src/renderer/src/features/translate/components/TranslationStats.tsx
@@ -2,12 +2,16 @@ interface TranslationStatsProps {
   translatedCount: number
   total: number
   pct: number
+  batchCompleted?: number
+  batchTotal?: number
 }
 
 export function TranslationStats({
   translatedCount,
   total,
-  pct
+  pct,
+  batchCompleted = 0,
+  batchTotal = 0
 }: TranslationStatsProps): React.JSX.Element {
   return (
     <div className="flex flex-col gap-2 min-w-70">
@@ -16,6 +20,11 @@ export function TranslationStats({
           {translatedCount}
         </span>
         <span className="text-base text-neutral-500">/{total}</span>
+        {batchTotal > 0 && (
+          <span className="ml-3 text-[11px] text-neutral-500">
+            batch {batchCompleted}/{batchTotal}
+          </span>
+        )}
       </div>
       <div className="relative h-1.5 bg-[#131518] rounded overflow-hidden">
         <div

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -10,6 +10,8 @@ import type { TranslationSession } from '../types'
 export function useBatchTranslation(session: TranslationSession) {
   const [isBatchTranslating, setIsBatchTranslating] = useState(false)
   const [activeJobId, setActiveJobId] = useState<string | null>(null)
+  const [batchCompleted, setBatchCompleted] = useState(0)
+  const [batchTotal, setBatchTotal] = useState(0)
   const batchCleanupRef = useRef<(() => void) | null>(null)
   const activeJobIdRef = useRef<string | null>(null)
   const pendingUidsRef = useRef<Set<string>>(new Set())
@@ -37,6 +39,8 @@ export function useBatchTranslation(session: TranslationSession) {
       activeJobIdRef.current = null
       pendingUidsRef.current = new Set()
       setActiveJobId(null)
+      setBatchCompleted(0)
+      setBatchTotal(0)
       setIsBatchTranslating(false)
     },
     [clearListeners]
@@ -60,11 +64,21 @@ export function useBatchTranslation(session: TranslationSession) {
       }
 
       pendingUidsRef.current = new Set(selectedEntries.map((entry) => entry.uid))
+      setBatchCompleted(0)
+      setBatchTotal(selectedEntries.length)
       setIsBatchTranslating(true)
       clearListeners()
 
-      const handleBatchProgress = ({ jobId, uid, target }: TranslationBatchProgressEvent) => {
+      const handleBatchProgress = ({
+        jobId,
+        uid,
+        target,
+        completed,
+        total
+      }: TranslationBatchProgressEvent) => {
         if (jobId !== activeJobIdRef.current) return
+        setBatchCompleted(completed)
+        setBatchTotal(total)
         if (target === null) return
         pendingUidsRef.current.delete(uid)
         updateEntry(uid, target)
@@ -131,6 +145,8 @@ export function useBatchTranslation(session: TranslationSession) {
         clearListeners()
         activeJobIdRef.current = null
         setActiveJobId(null)
+        setBatchCompleted(0)
+        setBatchTotal(0)
         setIsBatchTranslating(false)
         toast.error(message)
         void window.api.log.write({
@@ -160,5 +176,12 @@ export function useBatchTranslation(session: TranslationSession) {
     await window.api.translation.cancel(activeJobId)
   }, [activeJobId])
 
-  return { isBatchTranslating, batchTranslate, cancelBatch, activeJobId }
+  return {
+    isBatchTranslating,
+    batchCompleted,
+    batchTotal,
+    batchTranslate,
+    cancelBatch,
+    activeJobId
+  }
 }

--- a/src/renderer/src/features/translate/hooks/useDictionarySave.ts
+++ b/src/renderer/src/features/translate/hooks/useDictionarySave.ts
@@ -1,5 +1,6 @@
 import { useCallback, useState } from 'react'
 import { toast } from 'sonner'
+import { encodeEntities } from '@/lib/xmlEntities'
 import type { TranslationSession } from '../types'
 
 export function useDictionarySave(session: TranslationSession) {
@@ -15,8 +16,8 @@ export function useDictionarySave(session: TranslationSession) {
         await window.api.dictionary.upsert({
           language1: sourceLang,
           language2: targetLang,
-          textLanguage1: entry.source,
-          textLanguage2: target,
+          textLanguage1: encodeEntities(entry.source),
+          textLanguage2: encodeEntities(target),
           modName: modName || null,
           uid: entry.uid || null
         })
@@ -40,8 +41,8 @@ export function useDictionarySave(session: TranslationSession) {
         await window.api.dictionary.upsert({
           language1: sourceLang,
           language2: targetLang,
-          textLanguage1: entry.source,
-          textLanguage2: entry.target,
+          textLanguage1: encodeEntities(entry.source),
+          textLanguage2: encodeEntities(entry.target),
           modName: modName || null,
           uid: entry.uid || null
         })

--- a/src/renderer/src/features/translate/hooks/useTranslateSetup.ts
+++ b/src/renderer/src/features/translate/hooks/useTranslateSetup.ts
@@ -49,6 +49,13 @@ export function useTranslateSetup(session: TranslationSession) {
     }
   }, [sourceLang, targetLang])
 
+  useEffect(() => {
+    if (mods.length === 0) {
+      setIsNewMod(true)
+      setSelectedMod(null)
+    }
+  }, [mods])
+
   const handleSourceChange = (lang: string) => {
     setSourceLangLocal(lang)
     session.setSourceLang(lang)

--- a/src/renderer/src/lib/xmlEntities.ts
+++ b/src/renderer/src/lib/xmlEntities.ts
@@ -1,0 +1,16 @@
+export function decodeEntities(text: string): string {
+  return text
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&apos;/g, "'")
+    .replace(/&amp;/g, '&')
+}
+
+export function encodeEntities(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+}

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -56,14 +56,14 @@ export function DictionaryPage(): React.JSX.Element {
         <div className="flex gap-2">
           <button
             onClick={handleImport}
-            className="rounded-md bg-neutral-800 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-700"
+            className="cursor-pointer rounded-md bg-neutral-800 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-700"
           >
             Import CSV
           </button>
           <button
             onClick={handleExport}
             disabled={!lang1 || !lang2}
-            className="rounded-md bg-neutral-800 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-700 disabled:opacity-50"
+            className="cursor-pointer rounded-md bg-neutral-800 px-3 py-1.5 text-xs text-neutral-300 hover:bg-neutral-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
             Export CSV
           </button>

--- a/src/renderer/src/pages/EntryEditPage.tsx
+++ b/src/renderer/src/pages/EntryEditPage.tsx
@@ -6,6 +6,8 @@ import {
   type TranslationSessionEntry,
   useTranslationSession
 } from '@/context/TranslationSession'
+import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
+import { renderSource } from '@/utils/renderSource'
 
 export function EntryEditPage(): React.JSX.Element {
   const { uid } = useParams<{ uid: string }>()
@@ -61,7 +63,7 @@ function EntryEditor({
         <button
           type="button"
           onClick={() => navigate(-1)}
-          className="flex items-center gap-1.5 text-sm text-neutral-400 hover:text-neutral-200 transition-colors"
+          className="flex cursor-pointer items-center gap-1.5 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
         >
           <ArrowLeft size={16} />
           Voltar
@@ -76,7 +78,7 @@ function EntryEditor({
             Texto original ({sourceLang})
           </span>
           <div className="flex-1 rounded-md border border-neutral-700 bg-neutral-900/50 p-4 text-sm text-neutral-300 leading-relaxed overflow-y-auto whitespace-pre-wrap">
-            {entry.source || <span className="text-neutral-600 italic">vazio</span>}
+            {entry.source ? renderSource(entry.source) : <span className="text-neutral-600 italic">vazio</span>}
           </div>
         </div>
 
@@ -88,11 +90,13 @@ function EntryEditor({
           >
             Tradução ({targetLang})
           </label>
-          <textarea
+          <HighlightedTextarea
             id="entry-target"
             value={target}
             onChange={(e) => setTarget(e.target.value)}
-            className="flex-1 min-h-0 resize-none rounded-md border border-neutral-700 bg-neutral-900 p-4 text-sm text-neutral-200 leading-relaxed focus:border-neutral-500 focus:outline-none"
+            containerClassName="flex-1 min-h-0 rounded-md border-neutral-700 bg-neutral-900 focus-within:border-neutral-500 focus-within:shadow-none"
+            overlayClassName="p-4 text-sm leading-relaxed"
+            className="flex-1 min-h-0 p-4 text-sm leading-relaxed"
           />
         </div>
       </div>
@@ -103,7 +107,7 @@ function EntryEditor({
           type="button"
           onClick={() => handleTranslate('deepl')}
           disabled={translating !== null}
-          className="flex items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:opacity-50"
+          className="flex cursor-pointer items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {translating === 'deepl' && <Loader2 size={14} className="animate-spin" />}
           Traduzir com DeepL
@@ -112,7 +116,7 @@ function EntryEditor({
           type="button"
           onClick={() => handleTranslate('openai')}
           disabled={translating !== null}
-          className="flex items-center gap-2 rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-600 disabled:opacity-50"
+          className="flex cursor-pointer items-center gap-2 rounded-md bg-emerald-700 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-emerald-600 disabled:cursor-not-allowed disabled:opacity-50"
         >
           {translating === 'openai' && <Loader2 size={14} className="animate-spin" />}
           Traduzir com OpenAI
@@ -122,14 +126,14 @@ function EntryEditor({
           <button
             type="button"
             onClick={() => navigate(-1)}
-            className="rounded-md bg-neutral-800 px-4 py-2 text-sm text-neutral-300 transition-colors hover:bg-neutral-700"
+            className="cursor-pointer rounded-md bg-neutral-800 px-4 py-2 text-sm text-neutral-300 transition-colors hover:bg-neutral-700"
           >
             Cancelar
           </button>
           <button
             type="button"
             onClick={handleSave}
-            className="rounded-md bg-neutral-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-500"
+            className="cursor-pointer rounded-md bg-neutral-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-500"
           >
             Salvar
           </button>

--- a/src/renderer/src/pages/ExtractPage.tsx
+++ b/src/renderer/src/pages/ExtractPage.tsx
@@ -71,7 +71,7 @@ export function ExtractPage(): React.JSX.Element {
           />
           <button
             onClick={pickOutput}
-            className="rounded-md bg-neutral-800 px-4 py-2 text-sm text-neutral-300 hover:bg-neutral-700"
+            className="cursor-pointer rounded-md bg-neutral-800 px-4 py-2 text-sm text-neutral-300 hover:bg-neutral-700"
           >
             Browse
           </button>
@@ -81,7 +81,7 @@ export function ExtractPage(): React.JSX.Element {
       <button
         onClick={handleExtract}
         disabled={running || !inputPath || !outputPath || !sourceLang}
-        className="w-fit rounded-md bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:opacity-50"
+        className="w-fit cursor-pointer rounded-md bg-blue-600 px-6 py-2 text-sm font-medium text-white hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
       >
         {running ? 'Extracting...' : 'Extract'}
       </button>

--- a/src/renderer/src/utils/renderSource.tsx
+++ b/src/renderer/src/utils/renderSource.tsx
@@ -1,4 +1,11 @@
-export function renderSource(text: string): React.ReactNode {
+interface RenderSourceOptions {
+  variant?: 'display' | 'editor'
+}
+
+export function renderSource(
+  text: string,
+  { variant = 'display' }: RenderSourceOptions = {}
+): React.ReactNode {
   const parts: React.ReactNode[] = []
   let lastIndex = 0
   const re = /(<[^>]+>|\{[^}]+\})/g
@@ -8,14 +15,18 @@ export function renderSource(text: string): React.ReactNode {
       parts.push(<span key={`t${lastIndex}`}>{text.slice(lastIndex, match.index)}</span>)
     }
     const isTag = match[0].startsWith('<')
+    const highlightClass =
+      variant === 'editor'
+        ? isTag
+          ? 'bg-purple-500/14 text-purple-300 rounded-sm'
+          : 'bg-amber-500/14 text-amber-400 rounded-sm'
+        : isTag
+          ? 'bg-purple-500/14 text-purple-300 px-1 py-px rounded-sm text-[0.92em]'
+          : 'bg-amber-500/14 text-amber-400 px-1 py-px rounded-sm text-[0.92em]'
     parts.push(
       <span
         key={`m${match.index}`}
-        className={
-          isTag
-            ? 'bg-purple-500/14 text-purple-300 px-1 py-px rounded-sm text-[0.92em]'
-            : 'bg-amber-500/14 text-amber-400 px-1 py-px rounded-sm text-[0.92em]'
-        }
+        className={highlightClass}
       >
         {match[0]}
       </span>


### PR DESCRIPTION
## Summary

This branch improves the translation editor UX, standardizes themed selects, and changes the tag/text flow so the UI works with decoded strings while persistence/export boundaries re-encode XML entities.

## What changed

- standardized selects across the translation flow, export controls, dictionary, and extract pages
- added a reusable portal-based themed select so language dropdowns are no longer clipped by their container
- defaulted the mod step to `+ Novo` when no mods exist and improved focus behavior there
- improved translation editor UX with:
  - `Ctrl+F` focusing the search bar
  - selected strings and character totals in the filter bar
  - batch progress shown as `X / Y`
  - read-only mod name in the header
  - back button moved to the left side before the breadcrumb
  - consistent pointer cursor behavior on interactive controls
- changed the editor/session flow to use decoded strings in the renderer
- re-encoded XML entities only at persistence/export boundaries:
  - dictionary save
  - XML export
  - translated package export
- updated single and batch translation responses so the UI receives decoded text
- added highlighted target editing so tags are visually styled in the destination editor too
- fixed the highlighted target editor cursor alignment bug by using an editor-safe tag highlight variant that preserves text metrics
- disabled spellcheck in destination editors to avoid false underlines on XML tags/placeholders
- aligned the `Com tags XML` visual treatment with the purple tag highlight theme

## Validation

- `pnpm typecheck`
- `pnpm build`
