### PR TITLE
feat(ui): refine dictionary workflows and translation editor shortcuts

### DIFF
--- a/src/renderer/src/components/dictionary/DictionaryEntryModal.tsx
+++ b/src/renderer/src/components/dictionary/DictionaryEntryModal.tsx
@@ -1,0 +1,262 @@
+import { Check, Pencil, Plus } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { toast } from 'sonner'
+import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { ThemedSelect } from '@/components/shared/ThemedSelect'
+import type { Language } from '@/types'
+import { EMPTY_ENTRY_DRAFT, type EntryDraft } from './types'
+
+const META_INPUT =
+  'h-9 w-full rounded-md border border-[#252a32] bg-[#0c0d0f] px-3 text-sm text-neutral-200 outline-none transition-colors placeholder:text-neutral-600 focus:border-amber-500'
+
+interface DictionaryEntryModalProps {
+  open: boolean
+  mode: 'create' | 'edit'
+  entryId?: number
+  initialDraft: EntryDraft
+  languages: Language[]
+  mods: string[]
+  onClose: () => void
+  onSubmit: (draft: EntryDraft) => Promise<boolean>
+}
+
+export function DictionaryEntryModal({
+  open,
+  mode,
+  entryId,
+  initialDraft,
+  languages,
+  mods,
+  onClose,
+  onSubmit
+}: DictionaryEntryModalProps): React.JSX.Element | null {
+  const [draft, setDraft] = useState<EntryDraft>(initialDraft)
+  const [saving, setSaving] = useState(false)
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setDraft(initialDraft)
+      setSaving(false)
+      setConfirmDiscardOpen(false)
+      return
+    }
+
+    setDraft(initialDraft)
+  }, [initialDraft, open])
+
+  const languageOptions = useMemo(
+    () =>
+      languages.map((language) => ({
+        value: language.code,
+        label: language.name,
+        badge: language.code.toUpperCase(),
+        searchText: `${language.name} ${language.code}`
+      })),
+    [languages]
+  )
+
+  const isDirty = isDraftDirty(draft, initialDraft)
+
+  const requestClose = () => {
+    if (saving) return
+    if (isDirty) {
+      setConfirmDiscardOpen(true)
+      return
+    }
+    onClose()
+  }
+
+  const handleSave = async () => {
+    if (!isDraftValid(draft)) {
+      toast.error('Preencha idioma 1, idioma 2 e os dois textos')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const didSave = await onSubmit(draft)
+      if (didSave) onClose()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <ModalShell
+        open={open}
+        title={mode === 'create' ? 'Nova entrada' : `Editar entrada #${entryId ?? ''}`}
+        description={
+          mode === 'create'
+            ? 'Crie uma nova entrada de dicionario para o par de idiomas atual.'
+            : 'Atualize os textos, idiomas e metadados desta entrada.'
+        }
+        icon={mode === 'create' ? <Plus size={16} /> : <Pencil size={16} />}
+        sizeClassName="max-w-4xl"
+        onClose={requestClose}
+        footer={
+          <>
+            <button
+              type="button"
+              onClick={requestClose}
+              className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Check size={13} />
+              {saving ? 'Salvando...' : 'Salvar'}
+            </button>
+          </>
+        }
+      >
+        <div className="grid gap-4 lg:grid-cols-[minmax(0,1fr)_280px]">
+          <div className="space-y-4">
+            <Field label="Texto idioma 1">
+              <HighlightedTextarea
+                autoFocus
+                value={draft.sourceText}
+                onChange={(event) => setDraft({ ...draft, sourceText: event.target.value })}
+                rows={6}
+                containerClassName="rounded-lg border-[#2a2f37] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.22)]"
+                overlayClassName="px-3 py-2.5 text-[13px] leading-[1.6]"
+                className="min-h-38 px-3 py-2.5 text-[13px] leading-[1.6]"
+                placeholder="Texto do idioma 1..."
+              />
+            </Field>
+
+            <Field label="Texto idioma 2">
+              <HighlightedTextarea
+                value={draft.targetText}
+                onChange={(event) => setDraft({ ...draft, targetText: event.target.value })}
+                rows={6}
+                containerClassName="rounded-lg border-[#2a2f37] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.22)]"
+                overlayClassName="px-3 py-2.5 text-[13px] leading-[1.6]"
+                className="min-h-38 px-3 py-2.5 text-[13px] leading-[1.6]"
+                placeholder="Texto do idioma 2..."
+              />
+            </Field>
+          </div>
+
+          <div className="space-y-4">
+            {mode === 'edit' && (
+              <div className="rounded-lg border border-[#1f2329] bg-[#0f1114] px-3 py-2">
+                <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
+                  ID
+                </div>
+                <div className="mt-1 font-mono text-sm text-neutral-200">{entryId}</div>
+              </div>
+            )}
+
+            <Field label="Idioma 1">
+              <ThemedSelect
+                value={draft.sourceLang}
+                onChange={(value) => setDraft({ ...draft, sourceLang: value })}
+                options={languageOptions}
+                placeholder="Selecionar idioma"
+                searchable
+                searchPlaceholder="Buscar idioma..."
+                emptyLabel="Nenhum idioma encontrado."
+              />
+            </Field>
+
+            <Field label="Idioma 2">
+              <ThemedSelect
+                value={draft.targetLang}
+                onChange={(value) => setDraft({ ...draft, targetLang: value })}
+                options={languageOptions}
+                placeholder="Selecionar idioma"
+                searchable
+                searchPlaceholder="Buscar idioma..."
+                emptyLabel="Nenhum idioma encontrado."
+              />
+            </Field>
+
+            <Field label="Mod">
+              <input
+                list="dictionary-modal-mod-options"
+                value={draft.modName}
+                onChange={(event) => setDraft({ ...draft, modName: event.target.value })}
+                className={META_INPUT}
+                placeholder="Nome do mod"
+              />
+              <datalist id="dictionary-modal-mod-options">
+                {mods.map((modName) => (
+                  <option key={modName} value={modName} />
+                ))}
+              </datalist>
+            </Field>
+
+            <Field label="UID">
+              <input
+                value={draft.uid}
+                onChange={(event) => setDraft({ ...draft, uid: event.target.value })}
+                className={META_INPUT}
+                placeholder="UID opcional"
+              />
+            </Field>
+          </div>
+        </div>
+      </ModalShell>
+
+      <ConfirmDialog
+        open={confirmDiscardOpen}
+        title="Descartar alteracoes?"
+        description="Existem alteracoes pendentes nesta entrada. Se continuar, elas serao perdidas."
+        confirmLabel="Descartar"
+        destructive
+        onClose={() => setConfirmDiscardOpen(false)}
+        onConfirm={() => {
+          setConfirmDiscardOpen(false)
+          setDraft(EMPTY_ENTRY_DRAFT)
+          onClose()
+        }}
+      />
+    </>
+  )
+}
+
+function Field({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function isDraftDirty(draft: EntryDraft, initialDraft: EntryDraft): boolean {
+  return (
+    draft.sourceLang !== initialDraft.sourceLang ||
+    draft.targetLang !== initialDraft.targetLang ||
+    draft.sourceText !== initialDraft.sourceText ||
+    draft.targetText !== initialDraft.targetText ||
+    draft.modName !== initialDraft.modName ||
+    draft.uid !== initialDraft.uid
+  )
+}
+
+function isDraftValid(draft: EntryDraft): boolean {
+  return Boolean(
+    draft.sourceLang.trim() &&
+      draft.targetLang.trim() &&
+      draft.sourceText.trim() &&
+      draft.targetText.trim()
+  )
+}

--- a/src/renderer/src/components/dictionary/DictionaryImportModal.tsx
+++ b/src/renderer/src/components/dictionary/DictionaryImportModal.tsx
@@ -131,10 +131,10 @@ export function DictionaryImportModal({
                 <thead>
                   <tr className="bg-[#131518]">
                     <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
-                      Origem
+                      Idioma 1
                     </th>
                     <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
-                      Destino
+                      Idioma 2
                     </th>
                     <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
                       Mod
@@ -151,7 +151,8 @@ export function DictionaryImportModal({
                       <td className="px-3 py-2 font-mono text-neutral-200">{row.targetText}</td>
                       <td className="px-3 py-2 text-neutral-300">{row.modName || 'Sem mod'}</td>
                       <td className="px-3 py-2 font-mono text-neutral-400">
-                        {row.sourceLang || '-'} -&gt; {row.targetLang || '-'}
+                        {(row.sourceLang || '-').toUpperCase()} -&gt;{' '}
+                        <span className="text-amber-400">{(row.targetLang || '-').toUpperCase()}</span>
                       </td>
                     </tr>
                   ))}

--- a/src/renderer/src/components/dictionary/DictionaryImportModal.tsx
+++ b/src/renderer/src/components/dictionary/DictionaryImportModal.tsx
@@ -1,0 +1,166 @@
+import { FileSpreadsheet, Upload } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { ModalShell } from '@/components/shared/ModalShell'
+import type { DictionaryImportPreview } from '@/types'
+
+interface DictionaryImportModalProps {
+  open: boolean
+  onClose: () => void
+  onImported: () => Promise<void>
+}
+
+export function DictionaryImportModal({
+  open,
+  onClose,
+  onImported
+}: DictionaryImportModalProps): React.JSX.Element | null {
+  const [filePath, setFilePath] = useState('')
+  const [preview, setPreview] = useState<DictionaryImportPreview | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [importing, setImporting] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setFilePath('')
+      setPreview(null)
+      setLoading(false)
+      setImporting(false)
+    }
+  }, [open])
+
+  const handleSelectFile = async () => {
+    const paths = await window.api.fs.openDialog({
+      filters: [{ name: 'CSV', extensions: ['csv'] }]
+    })
+    if (!paths[0]) return
+
+    setLoading(true)
+    try {
+      const nextPreview = await window.api.dictionary.previewImport({
+        filePath: paths[0],
+        format: 'csv'
+      })
+      setFilePath(paths[0])
+      setPreview(nextPreview)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Erro ao ler CSV')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const handleImport = async () => {
+    if (!filePath) return
+    setImporting(true)
+    try {
+      const result = await window.api.dictionary.import({ filePath, format: 'csv' })
+      toast.success(`${result.count} entradas importadas`)
+      await onImported()
+      onClose()
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Erro ao importar CSV')
+    } finally {
+      setImporting(false)
+    }
+  }
+
+  return (
+    <ModalShell
+      open={open}
+      title="Importar dicionario"
+      description="Compatibilidade com `language1/...` e `src/tgt/src_lang/tgt_lang`."
+      icon={<FileSpreadsheet size={16} />}
+      sizeClassName="max-w-2xl"
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            Cancelar
+          </button>
+          <button
+            type="button"
+            disabled={!preview || importing}
+            onClick={handleImport}
+            className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            <Upload size={13} />
+            {importing ? 'Importando...' : `Importar ${preview?.totalRows ?? 0} entradas`}
+          </button>
+        </>
+      }
+    >
+      <div className="flex flex-col gap-4">
+        <button
+          type="button"
+          onClick={handleSelectFile}
+          className="flex min-h-36 cursor-pointer flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-[#3a404a] bg-[#0f1114] px-6 py-6 text-center transition-colors hover:border-amber-500 hover:bg-amber-500/6"
+        >
+          <Upload size={18} className="text-neutral-300" />
+          <div className="text-sm font-semibold text-neutral-100">
+            {filePath ? filePath.split(/[\\/]/).pop() : 'Escolher arquivo CSV'}
+          </div>
+          <div className="text-xs text-neutral-500">
+            Abra um CSV para visualizar headers detectados e uma previa antes de importar.
+          </div>
+        </button>
+
+        {loading && <p className="text-sm text-neutral-500">Lendo arquivo...</p>}
+
+        {preview && (
+          <>
+            <div className="rounded-lg border border-[#1f2329] bg-[#0f1114] p-3 text-xs text-neutral-400">
+              <div className="flex flex-wrap items-center gap-3">
+                <span>{preview.totalRows} linhas detectadas</span>
+                <span className="font-mono text-neutral-500">
+                  Headers: {preview.headers.join(', ')}
+                </span>
+              </div>
+            </div>
+
+            <div className="overflow-hidden rounded-lg border border-[#1f2329] bg-[#0f1114]">
+              <div className="flex items-center justify-between border-b border-[#1f2329] px-3 py-2 text-[11px] text-neutral-500">
+                <span>Previa das primeiras {preview.rows.length} linhas</span>
+                <span className="font-mono">UTF-8 . CSV</span>
+              </div>
+              <table className="w-full border-collapse text-xs">
+                <thead>
+                  <tr className="bg-[#131518]">
+                    <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
+                      Origem
+                    </th>
+                    <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
+                      Destino
+                    </th>
+                    <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
+                      Mod
+                    </th>
+                    <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
+                      Idiomas
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {preview.rows.map((row, index) => (
+                    <tr key={`${row.uid ?? 'row'}-${index}`} className="border-t border-[#1f2329]">
+                      <td className="px-3 py-2 font-mono text-neutral-200">{row.sourceText}</td>
+                      <td className="px-3 py-2 font-mono text-neutral-200">{row.targetText}</td>
+                      <td className="px-3 py-2 text-neutral-300">{row.modName || 'Sem mod'}</td>
+                      <td className="px-3 py-2 font-mono text-neutral-400">
+                        {row.sourceLang || '-'} -&gt; {row.targetLang || '-'}
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/renderer/src/components/dictionary/DictionaryReplaceModal.tsx
+++ b/src/renderer/src/components/dictionary/DictionaryReplaceModal.tsx
@@ -1,0 +1,229 @@
+import { Replace, Search } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { cn } from '@/lib/utils'
+import { EMPTY_REPLACE_DRAFT, type ReplaceDraft } from './types'
+
+interface DictionaryReplaceModalProps {
+  open: boolean
+  selectedCount: number
+  onClose: () => void
+  onSubmit: (draft: ReplaceDraft) => Promise<boolean>
+}
+
+export function DictionaryReplaceModal({
+  open,
+  selectedCount,
+  onClose,
+  onSubmit
+}: DictionaryReplaceModalProps): React.JSX.Element | null {
+  const [draft, setDraft] = useState<ReplaceDraft>(EMPTY_REPLACE_DRAFT)
+  const [saving, setSaving] = useState(false)
+  const [confirmDiscardOpen, setConfirmDiscardOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) {
+      setDraft(EMPTY_REPLACE_DRAFT)
+      setSaving(false)
+      setConfirmDiscardOpen(false)
+    }
+  }, [open])
+
+  const isDirty =
+    draft.find !== '' ||
+    draft.replaceWith !== '' ||
+    draft.scope !== EMPTY_REPLACE_DRAFT.scope ||
+    draft.matchCase !== EMPTY_REPLACE_DRAFT.matchCase ||
+    draft.matchWholeWord !== EMPTY_REPLACE_DRAFT.matchWholeWord
+
+  const requestClose = () => {
+    if (saving) return
+    if (isDirty) {
+      setConfirmDiscardOpen(true)
+      return
+    }
+    onClose()
+  }
+
+  const handleApply = async () => {
+    if (!draft.find.trim()) {
+      toast.error('Preencha o campo Buscar')
+      return
+    }
+
+    setSaving(true)
+    try {
+      const shouldClose = await onSubmit(draft)
+      if (shouldClose) onClose()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <>
+      <ModalShell
+        open={open}
+        title="Replace em lote"
+        description={`Aplicar buscar e substituir nas ${selectedCount} entradas selecionadas.`}
+        icon={<Replace size={16} />}
+        sizeClassName="max-w-2xl"
+        onClose={requestClose}
+        footer={
+          <>
+            <button
+              type="button"
+              onClick={requestClose}
+              className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+            >
+              Cancelar
+            </button>
+            <button
+              type="button"
+              onClick={handleApply}
+              disabled={saving}
+              className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              <Search size={13} />
+              {saving ? 'Aplicando...' : 'Aplicar replace'}
+            </button>
+          </>
+        }
+      >
+        <div className="space-y-4">
+          <Field label="Buscar">
+            <input
+              autoFocus
+              value={draft.find}
+              onChange={(event) => setDraft({ ...draft, find: event.target.value })}
+              className="h-10 w-full rounded-md border border-[#252a32] bg-[#0c0d0f] px-3 text-sm text-neutral-200 outline-none transition-colors placeholder:text-neutral-600 focus:border-amber-500"
+              placeholder="Texto a procurar"
+            />
+          </Field>
+
+          <Field label="Substituir por">
+            <input
+              value={draft.replaceWith}
+              onChange={(event) => setDraft({ ...draft, replaceWith: event.target.value })}
+              className="h-10 w-full rounded-md border border-[#252a32] bg-[#0c0d0f] px-3 text-sm text-neutral-200 outline-none transition-colors placeholder:text-neutral-600 focus:border-amber-500"
+              placeholder="Novo texto"
+            />
+          </Field>
+
+          <Field label="Escopo">
+            <div className="grid grid-cols-3 gap-2">
+              <ScopeButton
+                active={draft.scope === 'source'}
+                label="Idioma 1"
+                onClick={() => setDraft({ ...draft, scope: 'source' })}
+              />
+              <ScopeButton
+                active={draft.scope === 'target'}
+                label="Idioma 2"
+                onClick={() => setDraft({ ...draft, scope: 'target' })}
+              />
+              <ScopeButton
+                active={draft.scope === 'both'}
+                label="Ambos"
+                onClick={() => setDraft({ ...draft, scope: 'both' })}
+              />
+            </div>
+          </Field>
+
+          <div className="grid gap-3 sm:grid-cols-2">
+            <CheckField
+              checked={draft.matchCase}
+              label="Match case"
+              onChange={(checked) => setDraft({ ...draft, matchCase: checked })}
+            />
+            <CheckField
+              checked={draft.matchWholeWord}
+              label="Match whole word"
+              onChange={(checked) => setDraft({ ...draft, matchWholeWord: checked })}
+            />
+          </div>
+        </div>
+      </ModalShell>
+
+      <ConfirmDialog
+        open={confirmDiscardOpen}
+        title="Descartar alteracoes?"
+        description="Existem parametros preenchidos neste replace em lote. Se continuar, eles serao perdidos."
+        confirmLabel="Descartar"
+        destructive
+        onClose={() => setConfirmDiscardOpen(false)}
+        onConfirm={() => {
+          setConfirmDiscardOpen(false)
+          setDraft(EMPTY_REPLACE_DRAFT)
+          onClose()
+        }}
+      />
+    </>
+  )
+}
+
+function Field({
+  label,
+  children
+}: {
+  label: string
+  children: React.ReactNode
+}): React.JSX.Element {
+  return (
+    <label className="flex flex-col gap-2">
+      <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
+        {label}
+      </span>
+      {children}
+    </label>
+  )
+}
+
+function ScopeButton({
+  active,
+  label,
+  onClick
+}: {
+  active: boolean
+  label: string
+  onClick: () => void
+}): React.JSX.Element {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        'inline-flex h-10 cursor-pointer items-center justify-center rounded-md border text-sm transition-colors',
+        active
+          ? 'border-amber-500 bg-amber-500/10 text-amber-400'
+          : 'border-[#252a32] bg-[#0c0d0f] text-neutral-300 hover:border-neutral-600 hover:bg-[#131518]'
+      )}
+    >
+      {label}
+    </button>
+  )
+}
+
+function CheckField({
+  checked,
+  label,
+  onChange
+}: {
+  checked: boolean
+  label: string
+  onChange: (checked: boolean) => void
+}): React.JSX.Element {
+  return (
+    <label className="flex cursor-pointer items-center gap-2 rounded-md border border-[#252a32] bg-[#0c0d0f] px-3 py-2 text-sm text-neutral-200">
+      <input
+        type="checkbox"
+        checked={checked}
+        onChange={(event) => onChange(event.target.checked)}
+        className="h-4 w-4 cursor-pointer accent-amber-500"
+      />
+      {label}
+    </label>
+  )
+}

--- a/src/renderer/src/components/dictionary/replace.ts
+++ b/src/renderer/src/components/dictionary/replace.ts
@@ -9,7 +9,14 @@ export function applyTextReplace(text: string, draft: ReplaceDraft): string {
   const flags = draft.matchCase ? 'g' : 'gi'
   const matcher = new RegExp(pattern, flags)
 
-  return text.replace(matcher, () => draft.replaceWith)
+  return text
+    .split(/(<[^>]+>)/g)
+    .map((segment) =>
+      segment.startsWith('<') && segment.endsWith('>')
+        ? segment
+        : segment.replace(matcher, () => draft.replaceWith)
+    )
+    .join('')
 }
 
 function escapeRegExp(text: string): string {

--- a/src/renderer/src/components/dictionary/replace.ts
+++ b/src/renderer/src/components/dictionary/replace.ts
@@ -1,4 +1,5 @@
 import type { ReplaceDraft } from './types'
+import { protectReplaceRegions, restoreProtectedRegions } from './text'
 
 export function applyTextReplace(text: string, draft: ReplaceDraft): string {
   if (!draft.find) return text
@@ -8,15 +9,12 @@ export function applyTextReplace(text: string, draft: ReplaceDraft): string {
     : escapeRegExp(draft.find)
   const flags = draft.matchCase ? 'g' : 'gi'
   const matcher = new RegExp(pattern, flags)
+  const { protectedText, regions } = protectReplaceRegions(text)
 
-  return text
-    .split(/(<[^>]+>)/g)
-    .map((segment) =>
-      segment.startsWith('<') && segment.endsWith('>')
-        ? segment
-        : segment.replace(matcher, () => draft.replaceWith)
-    )
-    .join('')
+  return restoreProtectedRegions(
+    protectedText.replace(matcher, () => draft.replaceWith),
+    regions
+  )
 }
 
 function escapeRegExp(text: string): string {

--- a/src/renderer/src/components/dictionary/replace.ts
+++ b/src/renderer/src/components/dictionary/replace.ts
@@ -1,0 +1,17 @@
+import type { ReplaceDraft } from './types'
+
+export function applyTextReplace(text: string, draft: ReplaceDraft): string {
+  if (!draft.find) return text
+
+  const pattern = draft.matchWholeWord
+    ? `\\b${escapeRegExp(draft.find)}\\b`
+    : escapeRegExp(draft.find)
+  const flags = draft.matchCase ? 'g' : 'gi'
+  const matcher = new RegExp(pattern, flags)
+
+  return text.replace(matcher, () => draft.replaceWith)
+}
+
+function escapeRegExp(text: string): string {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+}

--- a/src/renderer/src/components/dictionary/text.ts
+++ b/src/renderer/src/components/dictionary/text.ts
@@ -1,0 +1,35 @@
+import { decodeEntities, encodeEntities } from '@/lib/xmlEntities'
+
+const REPLACE_REGION_PATTERN = /(<[^>]+>|\{[^}]+\})/g
+const PLACEHOLDER_PREFIX = '__ICOSA_DICT_REGION_'
+
+export function decodeDictionaryTextForUi(text: string): string {
+  return decodeEntities(text)
+}
+
+export function encodeDictionaryTextForPersistence(text: string): string {
+  return encodeEntities(text)
+}
+
+export function protectReplaceRegions(text: string): {
+  protectedText: string
+  regions: string[]
+} {
+  const regions: string[] = []
+  const protectedText = text.replace(REPLACE_REGION_PATTERN, (segment) => {
+    const index = regions.push(segment) - 1
+    return `${PLACEHOLDER_PREFIX}${index}__`
+  })
+
+  return { protectedText, regions }
+}
+
+export function restoreProtectedRegions(text: string, regions: string[]): string {
+  let restored = text
+
+  for (let index = 0; index < regions.length; index++) {
+    restored = restored.replaceAll(`${PLACEHOLDER_PREFIX}${index}__`, regions[index])
+  }
+
+  return restored
+}

--- a/src/renderer/src/components/dictionary/types.ts
+++ b/src/renderer/src/components/dictionary/types.ts
@@ -1,0 +1,22 @@
+export interface EntryDraft {
+  sourceLang: string
+  targetLang: string
+  sourceText: string
+  targetText: string
+  modName: string
+  uid: string
+}
+
+export interface DisplayEntry extends EntryDraft {
+  id: number
+  updatedAt: string | null
+}
+
+export const EMPTY_ENTRY_DRAFT: EntryDraft = {
+  sourceLang: '',
+  targetLang: '',
+  sourceText: '',
+  targetText: '',
+  modName: '',
+  uid: ''
+}

--- a/src/renderer/src/components/dictionary/types.ts
+++ b/src/renderer/src/components/dictionary/types.ts
@@ -12,6 +12,16 @@ export interface DisplayEntry extends EntryDraft {
   updatedAt: string | null
 }
 
+export type ReplaceScope = 'source' | 'target' | 'both'
+
+export interface ReplaceDraft {
+  find: string
+  replaceWith: string
+  scope: ReplaceScope
+  matchCase: boolean
+  matchWholeWord: boolean
+}
+
 export const EMPTY_ENTRY_DRAFT: EntryDraft = {
   sourceLang: '',
   targetLang: '',
@@ -19,4 +29,12 @@ export const EMPTY_ENTRY_DRAFT: EntryDraft = {
   targetText: '',
   modName: '',
   uid: ''
+}
+
+export const EMPTY_REPLACE_DRAFT: ReplaceDraft = {
+  find: '',
+  replaceWith: '',
+  scope: 'target',
+  matchCase: false,
+  matchWholeWord: false
 }

--- a/src/renderer/src/components/layout/MainLayout.tsx
+++ b/src/renderer/src/components/layout/MainLayout.tsx
@@ -7,11 +7,11 @@ export function MainLayout(): React.JSX.Element {
   useKeyboardShortcuts()
 
   return (
-    <div className="flex flex-col h-screen w-screen bg-neutral-950">
-      <TitleBar />
-      <div className="flex flex-1 min-h-0">
-        <Sidebar />
-        <main className="flex flex-1 flex-col overflow-y-auto ml-14">
+    <div className="flex h-screen w-screen bg-neutral-950">
+      <Sidebar />
+      <div className="ml-14 flex min-w-0 flex-1 flex-col">
+        <TitleBar />
+        <main className="flex min-h-0 flex-1 flex-col overflow-y-auto">
           <Outlet />
         </main>
       </div>

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -2,31 +2,20 @@ import { BookOpen, Languages, Package, PackageOpen, Settings } from 'lucide-reac
 import { NavLink } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 
-// direction-a.css:
-//   .ide-nav-item         h-9, px-2, rounded-md, gap-3, text-neutral-400
-//   .ide-nav-item:hover   bg-[#1c1f24] text-neutral-200
-//   .ide-nav-item.active  bg-amber-500/14 text-amber-500
-//   .ide-nav-label        opacity-0, transition: opacity 120ms 60ms
-//   .ide-nav-kbd          opacity-0, transition: opacity 120ms 60ms, text-neutral-600
-//   .ide-sidebar:hover    width: 220px (w-55)
-
 const NAV_ITEMS = [
-  { to: '/translate', icon: Languages, label: 'Translate', kbd: '⌃1' },
-  { to: '/dictionary', icon: BookOpen, label: 'Dictionary', kbd: '⌃2' },
-  { to: '/extract', icon: PackageOpen, label: 'Extract Mod', kbd: '⌃3' },
-  { to: '/package', icon: Package, label: 'Create Package', kbd: '⌃4' },
+  { to: '/translate', icon: Languages, label: 'Translate', kbd: 'Ctrl 1' },
+  { to: '/dictionary', icon: BookOpen, label: 'Dictionary', kbd: 'Ctrl 2' },
+  { to: '/extract', icon: PackageOpen, label: 'Extract Mod', kbd: 'Ctrl 3' },
+  { to: '/package', icon: Package, label: 'Create Package', kbd: 'Ctrl 4' }
 ] as const
 
-const FOOTER_ITEMS = [
-  { to: '/settings', icon: Settings, label: 'Settings', kbd: '⌃5' },
-] as const
-
+const FOOTER_ITEMS = [{ to: '/settings', icon: Settings, label: 'Settings', kbd: 'Ctrl 5' }] as const
 
 function NavItem({
   to,
   icon: Icon,
   label,
-  kbd,
+  kbd
 }: {
   to: string
   icon: React.ElementType
@@ -39,30 +28,25 @@ function NavItem({
       title={label}
       className={({ isActive }) =>
         cn(
-          'flex items-center gap-3 h-9 px-2 rounded-md cursor-pointer transition-colors select-none w-full',
+          'flex h-9 w-full cursor-pointer select-none items-center gap-3 rounded-md px-2 transition-colors',
           isActive
             ? 'bg-amber-500/14 text-amber-500'
             : 'text-neutral-400 hover:bg-[#1c1f24] hover:text-neutral-200'
         )
       }
     >
-      {/* Fixed-width icon container — always visible */}
-      <span className="w-6 flex items-center justify-center shrink-0">
+      <span className="flex w-6 shrink-0 items-center justify-center">
         <Icon size={16} />
       </span>
-
-      {/* Label — fades in when sidebar expands */}
       <span
         style={{ transition: 'opacity 120ms 60ms' }}
-        className="flex-1 text-sm font-medium opacity-0 group-hover/sidebar:opacity-100 whitespace-nowrap"
+        className="flex-1 whitespace-nowrap text-sm font-medium opacity-0 group-hover/sidebar:opacity-100"
       >
         {label}
       </span>
-
-      {/* Kbd shortcut — fades in after label */}
       <span
         style={{ transition: 'opacity 120ms 60ms' }}
-        className="font-mono text-[10px] text-neutral-600 opacity-0 group-hover/sidebar:opacity-100 whitespace-nowrap"
+        className="whitespace-nowrap font-mono text-[10px] text-neutral-600 opacity-0 group-hover/sidebar:opacity-100"
       >
         {kbd}
       </span>
@@ -74,17 +58,15 @@ export function Sidebar(): React.JSX.Element {
   return (
     <aside
       style={{ transition: 'width 180ms cubic-bezier(0.2, 0.8, 0.2, 1)' }}
-      className="group/sidebar fixed top-9 left-0 z-40 flex h-[calc(100vh-36px)] w-14 flex-col overflow-hidden border-r border-[#1f2329] bg-[#0f1114] hover:w-55"
+      className="group/sidebar fixed top-0 left-0 z-40 flex h-screen w-14 flex-col overflow-hidden border-r border-[#1f2329] bg-[#0f1114] hover:w-55"
     >
-      {/* Main nav — direction-a: gap-2px, px-2 */}
-      <nav className="flex flex-1 flex-col gap-0.5 px-2 py-1.5">
+      <nav className="flex flex-1 flex-col gap-0.5 px-2 py-3">
         {NAV_ITEMS.map((item) => (
           <NavItem key={item.to} {...item} />
         ))}
       </nav>
 
-      {/* Footer nav — direction-a: border-top, pt-2 */}
-      <div className="px-2 py-2">
+      <div className="border-t border-[#1f2329] px-2 py-3">
         {FOOTER_ITEMS.map((item) => (
           <NavItem key={item.to} {...item} />
         ))}

--- a/src/renderer/src/components/shared/ConfirmDialog.tsx
+++ b/src/renderer/src/components/shared/ConfirmDialog.tsx
@@ -1,0 +1,59 @@
+import { AlertTriangle } from 'lucide-react'
+import { ModalShell } from './ModalShell'
+
+interface ConfirmDialogProps {
+  open: boolean
+  title: string
+  description: string
+  confirmLabel: string
+  cancelLabel?: string
+  destructive?: boolean
+  onConfirm: () => void | Promise<void>
+  onClose: () => void
+}
+
+export function ConfirmDialog({
+  open,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = 'Cancelar',
+  destructive = false,
+  onConfirm,
+  onClose
+}: ConfirmDialogProps): React.JSX.Element | null {
+  return (
+    <ModalShell
+      open={open}
+      title={title}
+      description={description}
+      sizeClassName="max-w-md"
+      icon={<AlertTriangle size={16} />}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            {cancelLabel}
+          </button>
+          <button
+            type="button"
+            onClick={onConfirm}
+            className={
+              destructive
+                ? 'inline-flex h-8 cursor-pointer items-center rounded-md border border-red-500/40 bg-red-500/10 px-3 text-xs font-semibold text-red-200 transition-colors hover:bg-red-500/20'
+                : 'inline-flex h-8 cursor-pointer items-center rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400'
+            }
+          >
+            {confirmLabel}
+          </button>
+        </>
+      }
+    >
+      <p className="text-sm leading-6 text-neutral-300">{description}</p>
+    </ModalShell>
+  )
+}

--- a/src/renderer/src/components/shared/ModalShell.tsx
+++ b/src/renderer/src/components/shared/ModalShell.tsx
@@ -1,0 +1,88 @@
+import { X } from 'lucide-react'
+import { useEffect, type ReactNode } from 'react'
+import { createPortal } from 'react-dom'
+import { cn } from '@/lib/utils'
+
+interface ModalShellProps {
+  open: boolean
+  title: string
+  description?: string
+  icon?: ReactNode
+  sizeClassName?: string
+  onClose: () => void
+  children: ReactNode
+  footer?: ReactNode
+}
+
+export function ModalShell({
+  open,
+  title,
+  description,
+  icon,
+  sizeClassName = 'max-w-3xl',
+  onClose,
+  children,
+  footer
+}: ModalShellProps): React.JSX.Element | null {
+  useEffect(() => {
+    if (!open) return
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault()
+        onClose()
+      }
+    }
+
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  return createPortal(
+    <div
+      className="fixed inset-0 z-[90] flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm"
+      onMouseDown={(event) => {
+        if (event.target === event.currentTarget) onClose()
+      }}
+    >
+      <div
+        role="dialog"
+        aria-modal="true"
+        className={cn(
+          'w-full overflow-hidden rounded-xl border border-[#303641] bg-[#131518] shadow-[0_24px_80px_rgba(0,0,0,0.45)]',
+          sizeClassName
+        )}
+      >
+        <div className="flex items-start gap-3 border-b border-[#1f2329] px-5 py-4">
+          {icon && (
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-amber-500/12 text-amber-400">
+              {icon}
+            </div>
+          )}
+          <div className="min-w-0 flex-1">
+            <div className="text-sm font-semibold text-neutral-100">{title}</div>
+            {description && <div className="mt-1 text-xs text-neutral-500">{description}</div>}
+          </div>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-[#181b1f] hover:text-neutral-200"
+          >
+            <X size={14} />
+          </button>
+        </div>
+
+        <div className="px-5 py-5">{children}</div>
+
+        {footer && (
+          <div className="flex items-center justify-end gap-2 border-t border-[#1f2329] bg-[#0f1114] px-5 py-4">
+            {footer}
+          </div>
+        )}
+      </div>
+    </div>,
+    document.body
+  )
+}

--- a/src/renderer/src/components/shared/ThemedSelect.tsx
+++ b/src/renderer/src/components/shared/ThemedSelect.tsx
@@ -29,6 +29,7 @@ interface ThemedSelectProps {
   accent?: boolean
   triggerClassName?: string
   menuClassName?: string
+  menuMinWidth?: number
 }
 
 const MENU_GAP = 4
@@ -46,7 +47,8 @@ export function ThemedSelect({
   className,
   accent = false,
   triggerClassName,
-  menuClassName
+  menuClassName,
+  menuMinWidth
 }: ThemedSelectProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -84,7 +86,7 @@ export function ThemedSelect({
           ? Math.max(MENU_GAP, rect.top - MENU_GAP - Math.max(180, height))
           : rect.bottom + MENU_GAP,
         left: rect.left,
-        width: rect.width
+        width: Math.max(rect.width, menuMinWidth ?? rect.width)
       })
     }
 
@@ -95,7 +97,7 @@ export function ThemedSelect({
       window.removeEventListener('resize', updatePosition)
       window.removeEventListener('scroll', updatePosition, true)
     }
-  }, [open])
+  }, [menuMinWidth, open])
 
   useEffect(() => {
     if (!open) return

--- a/src/renderer/src/components/shared/ThemedSelect.tsx
+++ b/src/renderer/src/components/shared/ThemedSelect.tsx
@@ -30,6 +30,7 @@ interface ThemedSelectProps {
   triggerClassName?: string
   menuClassName?: string
   menuMinWidth?: number
+  triggerAdornment?: React.ReactNode
 }
 
 const MENU_GAP = 4
@@ -48,7 +49,8 @@ export function ThemedSelect({
   accent = false,
   triggerClassName,
   menuClassName,
-  menuMinWidth
+  menuMinWidth,
+  triggerAdornment
 }: ThemedSelectProps): React.JSX.Element {
   const [open, setOpen] = useState(false)
   const [query, setQuery] = useState('')
@@ -234,6 +236,7 @@ export function ThemedSelect({
             {selected.badge}
           </span>
         )}
+        {triggerAdornment}
         <span className={cn('shrink-0', accent ? 'text-amber-500' : 'text-neutral-500')}>
           <ChevronDown size={16} />
         </span>

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -264,8 +264,6 @@ export function TranslationGrid({
         <span className="font-mono tabular-nums text-neutral-500">
           {selectedStats.selectedStrings} strings • {selectedStats.selectedCharacters} characters
         </span>
-        <span className="font-mono text-neutral-500">Ctrl</span>
-        Atalhos
       </div>
     </div>
   )

--- a/src/renderer/src/features/translate/components/EditorHeader.tsx
+++ b/src/renderer/src/features/translate/components/EditorHeader.tsx
@@ -3,7 +3,6 @@ import {
   ArrowRight,
   ChevronRight,
   Columns2,
-  Focus,
   Loader2,
   Redo2,
   Rows2,
@@ -13,14 +12,13 @@ import {
 import { cn } from '@/lib/utils'
 import type { ExportFormat, TranslationSession } from '../types'
 import { ExportControls } from './ExportControls'
-import { btnBase, btnGhostIcon, btnPrimary } from './styles'
+import { btnBase, btnGhostIcon } from './styles'
 import { TranslationStats } from './TranslationStats'
 
 interface EditorHeaderProps {
   session: TranslationSession
   fileName: string
   viewMode: 'side' | 'stacked'
-  focusMode: boolean
   isSaving: boolean
   translatedCount: number
   dictCount: number
@@ -31,7 +29,6 @@ interface EditorHeaderProps {
   batchTotal: number
   exportFormat: ExportFormat
   onViewModeChange: (mode: 'side' | 'stacked') => void
-  onFocusModeChange: (value: boolean) => void
   onSave: () => Promise<void>
   onExportFormatChange: (format: ExportFormat) => void
   onExport: () => Promise<void>
@@ -41,7 +38,6 @@ export function EditorHeader({
   session,
   fileName,
   viewMode,
-  focusMode,
   isSaving,
   translatedCount,
   dictCount,
@@ -52,7 +48,6 @@ export function EditorHeader({
   batchTotal,
   exportFormat,
   onViewModeChange,
-  onFocusModeChange,
   onSave,
   onExportFormatChange,
   onExport
@@ -116,21 +111,10 @@ export function EditorHeader({
 
           <button
             type="button"
-            onClick={() => onFocusModeChange(!focusMode)}
-            className={cn(focusMode ? btnPrimary : btnBase)}
-          >
-            <Focus />
-            Modo foco
-            <span className="inline-flex items-center justify-center h-4.5 min-w-4.5 px-1 rounded bg-[#1f2329] border border-[#1f2329] border-b-2 font-mono text-[10px] text-neutral-400">
-              F
-            </span>
-          </button>
-
-          <button
-            type="button"
             className={cn(btnBase, isSaving && 'opacity-60 cursor-not-allowed')}
             onClick={onSave}
             disabled={isSaving}
+            title="Salvar no dicionario (Ctrl+S)"
           >
             {isSaving ? <Loader2 size={13} className="animate-spin" /> : <Save />}
             Salvar

--- a/src/renderer/src/features/translate/components/EditorHeader.tsx
+++ b/src/renderer/src/features/translate/components/EditorHeader.tsx
@@ -15,6 +15,14 @@ import { ExportControls } from './ExportControls'
 import { btnBase, btnGhostIcon } from './styles'
 import { TranslationStats } from './TranslationStats'
 
+function ShortcutHint({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="inline-flex h-4.5 min-w-4.5 items-center justify-center rounded border border-[#2a2f37] border-b-2 bg-[#181b1f] px-1 font-mono text-[10px] text-neutral-400">
+      {children}
+    </span>
+  )
+}
+
 interface EditorHeaderProps {
   session: TranslationSession
   fileName: string
@@ -118,6 +126,7 @@ export function EditorHeader({
           >
             {isSaving ? <Loader2 size={13} className="animate-spin" /> : <Save />}
             Salvar
+            <ShortcutHint>Ctrl S</ShortcutHint>
           </button>
 
           <ExportControls

--- a/src/renderer/src/features/translate/components/ExportControls.tsx
+++ b/src/renderer/src/features/translate/components/ExportControls.tsx
@@ -20,14 +20,15 @@ export function ExportControls({
         value={exportFormat}
         onChange={(value) => onFormatChange(value as ExportFormat)}
         className="w-24"
-        triggerClassName="h-[30px] px-2 text-xs"
+        triggerClassName="h-[30px] border-neutral-700 bg-[#131518] px-3 text-xs text-neutral-200 hover:border-neutral-600"
+        menuClassName="border-neutral-700"
         options={[
           { value: 'xml', label: 'xml' },
           { value: 'pak', label: 'pak' },
           { value: 'zip', label: 'zip' }
         ]}
       />
-      <button type="button" className={btnPrimary} onClick={onExport}>
+      <button type="button" className={btnPrimary} onClick={onExport} title="Exportar (Ctrl+E)">
         <Download />
         Exportar
       </button>

--- a/src/renderer/src/features/translate/components/ExportControls.tsx
+++ b/src/renderer/src/features/translate/components/ExportControls.tsx
@@ -3,6 +3,14 @@ import { ThemedSelect } from '@/components/shared/ThemedSelect'
 import type { ExportFormat } from '../types'
 import { btnPrimary } from './styles'
 
+function ShortcutHint({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <span className="inline-flex h-4.5 min-w-4.5 items-center justify-center rounded border border-[#2a2f37] border-b-2 bg-[#181b1f] px-1 font-mono text-[10px] text-neutral-400">
+      {children}
+    </span>
+  )
+}
+
 interface ExportControlsProps {
   exportFormat: ExportFormat
   onFormatChange: (format: ExportFormat) => void
@@ -16,21 +24,25 @@ export function ExportControls({
 }: ExportControlsProps): React.JSX.Element {
   return (
     <div className="flex items-center gap-1.5">
-      <ThemedSelect
-        value={exportFormat}
-        onChange={(value) => onFormatChange(value as ExportFormat)}
-        className="w-24"
-        triggerClassName="h-[30px] border-neutral-700 bg-[#131518] px-3 text-xs text-neutral-200 hover:border-neutral-600"
-        menuClassName="border-neutral-700"
-        options={[
-          { value: 'xml', label: 'xml' },
-          { value: 'pak', label: 'pak' },
-          { value: 'zip', label: 'zip' }
-        ]}
-      />
+      <div className="flex items-center gap-1.5">
+        <ThemedSelect
+          value={exportFormat}
+          onChange={(value) => onFormatChange(value as ExportFormat)}
+          className="w-40"
+          triggerClassName="h-[30px] border-neutral-700 bg-[#131518] px-3 text-xs text-neutral-200 hover:border-neutral-600"
+          menuClassName="border-neutral-700"
+          options={[
+            { value: 'xml', label: 'xml' },
+            { value: 'pak', label: 'pak' },
+            { value: 'zip', label: 'zip' }
+          ]}
+        />
+        <ShortcutHint>Ctrl T</ShortcutHint>
+      </div>
       <button type="button" className={btnPrimary} onClick={onExport} title="Exportar (Ctrl+E)">
         <Download />
         Exportar
+        <ShortcutHint>Ctrl E</ShortcutHint>
       </button>
     </div>
   )

--- a/src/renderer/src/features/translate/components/ExportControls.tsx
+++ b/src/renderer/src/features/translate/components/ExportControls.tsx
@@ -3,9 +3,21 @@ import { ThemedSelect } from '@/components/shared/ThemedSelect'
 import type { ExportFormat } from '../types'
 import { btnPrimary } from './styles'
 
-function ShortcutHint({ children }: { children: React.ReactNode }): React.JSX.Element {
+function ShortcutHint({
+  children,
+  subtle = false
+}: {
+  children: React.ReactNode
+  subtle?: boolean
+}): React.JSX.Element {
   return (
-    <span className="inline-flex h-4.5 min-w-4.5 items-center justify-center rounded border border-[#2a2f37] border-b-2 bg-[#181b1f] px-1 font-mono text-[10px] text-neutral-400">
+    <span
+      className={
+        subtle
+          ? 'inline-flex items-center justify-center font-mono text-[10px] text-black/65'
+          : 'inline-flex h-4.5 min-w-4.5 items-center justify-center rounded border border-[#2a2f37] border-b-2 bg-[#181b1f] px-1 font-mono text-[10px] text-neutral-400'
+      }
+    >
       {children}
     </span>
   )
@@ -24,25 +36,23 @@ export function ExportControls({
 }: ExportControlsProps): React.JSX.Element {
   return (
     <div className="flex items-center gap-1.5">
-      <div className="flex items-center gap-1.5">
-        <ThemedSelect
-          value={exportFormat}
-          onChange={(value) => onFormatChange(value as ExportFormat)}
-          className="w-40"
-          triggerClassName="h-[30px] border-neutral-700 bg-[#131518] px-3 text-xs text-neutral-200 hover:border-neutral-600"
-          menuClassName="border-neutral-700"
-          options={[
-            { value: 'xml', label: 'xml' },
-            { value: 'pak', label: 'pak' },
-            { value: 'zip', label: 'zip' }
-          ]}
-        />
-        <ShortcutHint>Ctrl T</ShortcutHint>
-      </div>
+      <ThemedSelect
+        value={exportFormat}
+        onChange={(value) => onFormatChange(value as ExportFormat)}
+        className="w-36"
+        triggerClassName="h-[30px] border-neutral-700 bg-[#131518] px-3 text-xs text-neutral-200 hover:border-neutral-600"
+        menuClassName="border-neutral-700"
+        triggerAdornment={<ShortcutHint>Ctrl T</ShortcutHint>}
+        options={[
+          { value: 'xml', label: 'xml' },
+          { value: 'pak', label: 'pak' },
+          { value: 'zip', label: 'zip' }
+        ]}
+      />
       <button type="button" className={btnPrimary} onClick={onExport} title="Exportar (Ctrl+E)">
         <Download />
         Exportar
-        <ShortcutHint>Ctrl E</ShortcutHint>
+        <ShortcutHint subtle>Ctrl E</ShortcutHint>
       </button>
     </div>
   )

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -4,6 +4,7 @@ import { TranslationGrid } from '@/components/translation/TranslationGrid'
 import type { Language } from '@/types'
 import { useBatchTranslation } from '../hooks/useBatchTranslation'
 import { useDictionarySave } from '../hooks/useDictionarySave'
+import { useLoadedEditorShortcuts } from '../hooks/useLoadedEditorShortcuts'
 import { useTranslationExport } from '../hooks/useTranslationExport'
 import type { TranslationSession } from '../types'
 import { EditorHeader } from './EditorHeader'
@@ -15,7 +16,6 @@ interface TranslateLoadedScreenProps {
 
 export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): React.JSX.Element {
   const [viewMode, setViewMode] = useState<'side' | 'stacked'>('side')
-  const [focusMode, setFocusMode] = useState(false)
   const [languages, setLanguages] = useState<Language[]>([])
   const dictionarySave = useDictionarySave(session)
   const batch = useBatchTranslation(session)
@@ -43,13 +43,18 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
     [session]
   )
 
+  useLoadedEditorShortcuts({
+    onSave: dictionarySave.saveAll,
+    onCycleExportFormat: exportFlow.cycleExportFormat,
+    onOpenExport: exportFlow.openExport
+  })
+
   return (
     <div className="flex flex-col h-full min-h-0">
       <EditorHeader
         session={session}
         fileName={fileName}
         viewMode={viewMode}
-        focusMode={focusMode}
         isSaving={dictionarySave.isSaving}
         translatedCount={translatedCount}
         dictCount={dictCount}
@@ -60,7 +65,6 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
         batchTotal={batch.batchTotal}
         exportFormat={exportFlow.exportFormat}
         onViewModeChange={setViewMode}
-        onFocusModeChange={setFocusMode}
         onSave={dictionarySave.saveAll}
         onExportFormatChange={exportFlow.setExportFormat}
         onExport={exportFlow.openExport}

--- a/src/renderer/src/features/translate/hooks/useLoadedEditorShortcuts.ts
+++ b/src/renderer/src/features/translate/hooks/useLoadedEditorShortcuts.ts
@@ -1,0 +1,41 @@
+import { useEffect, useEffectEvent } from 'react'
+
+interface LoadedEditorShortcutsOptions {
+  onSave: () => Promise<void>
+  onCycleExportFormat: () => void
+  onOpenExport: () => Promise<void>
+}
+
+export function useLoadedEditorShortcuts({
+  onSave,
+  onCycleExportFormat,
+  onOpenExport
+}: LoadedEditorShortcutsOptions): void {
+  const handleShortcut = useEffectEvent((event: KeyboardEvent) => {
+    if (!event.ctrlKey || event.shiftKey || event.altKey || event.metaKey) return
+
+    const key = event.key.toLowerCase()
+    if (key === 's') {
+      event.preventDefault()
+      void onSave()
+      return
+    }
+
+    if (key === 't') {
+      event.preventDefault()
+      onCycleExportFormat()
+      return
+    }
+
+    if (key === 'e') {
+      event.preventDefault()
+      void onOpenExport()
+    }
+  })
+
+  useEffect(() => {
+    const listener = (event: KeyboardEvent) => handleShortcut(event)
+    window.addEventListener('keydown', listener)
+    return () => window.removeEventListener('keydown', listener)
+  }, [handleShortcut])
+}

--- a/src/renderer/src/features/translate/hooks/useTranslationExport.ts
+++ b/src/renderer/src/features/translate/hooks/useTranslationExport.ts
@@ -4,6 +4,8 @@ import type { Language, ModMeta } from '@/types'
 import type { ExportFormat, TranslationSession } from '../types'
 import { exportFileBaseName, languageToBg3Folder } from '../utils/exportNames'
 
+const EXPORT_FORMAT_ORDER: ExportFormat[] = ['xml', 'pak', 'zip']
+
 export function useTranslationExport(session: TranslationSession, languages: Language[]) {
   const [isExporting, setIsExporting] = useState(false)
   const [exportFormat, setExportFormat] = useState<ExportFormat>('xml')
@@ -71,12 +73,20 @@ export function useTranslationExport(session: TranslationSession, languages: Lan
     [entries, exportFormat, modName]
   )
 
+  const cycleExportFormat = useCallback(() => {
+    setExportFormat((current) => {
+      const index = EXPORT_FORMAT_ORDER.indexOf(current)
+      return EXPORT_FORMAT_ORDER[(index + 1) % EXPORT_FORMAT_ORDER.length]
+    })
+  }, [])
+
   return {
     isExporting,
     exportFormat,
     exportMeta,
     bg3LanguageFolder,
     setExportFormat,
+    cycleExportFormat,
     openExport,
     submitPackageExport,
     closeExportModal: () => setExportMeta(null)

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -399,8 +399,8 @@ export function DictionaryPage(): React.JSX.Element {
         </div>
       </header>
 
-      <div className="flex flex-wrap items-center gap-2 border-b border-[#1f2329] bg-[#0f1114] px-4 py-3">
-        <div className="flex h-8 min-w-70 flex-1 items-center gap-2 rounded-md border border-[#1f2329] bg-[#131518] px-3 focus-within:border-neutral-600">
+      <div className="flex flex-wrap items-end gap-x-2 gap-y-3 border-b border-[#1f2329] bg-[#0f1114] px-4 py-3">
+        <div className="flex h-8 min-w-70 flex-1 self-end items-center gap-2 rounded-md border border-[#1f2329] bg-[#131518] px-3 focus-within:border-neutral-600">
           <Search size={14} className="text-neutral-500" />
           <input
             ref={searchInputRef}
@@ -420,18 +420,29 @@ export function DictionaryPage(): React.JSX.Element {
           )}
         </div>
 
-        <FilterSelect label="Mod" value={modName} options={modSelectOptions} onChange={setModName} />
+        <FilterSelect
+          label="Mod"
+          value={modName}
+          options={modSelectOptions}
+          onChange={setModName}
+          className="w-[11.5rem]"
+          menuMinWidth={220}
+        />
         <FilterSelect
           label="Idioma 1"
           value={sourceLang}
           options={sourceSelectOptions}
           onChange={setSourceLang}
+          className="w-40"
+          menuMinWidth={176}
         />
         <FilterSelect
           label="Idioma 2"
           value={targetLang}
           options={targetSelectOptions}
           onChange={setTargetLang}
+          className="w-40"
+          menuMinWidth={176}
         />
 
         {hasFilters && (
@@ -696,12 +707,16 @@ function FilterSelect({
   label,
   value,
   options,
-  onChange
+  onChange,
+  className,
+  menuMinWidth
 }: {
   label: string
   value: string
   options: ThemedSelectOption[]
   onChange: (value: string) => void
+  className?: string
+  menuMinWidth?: number
 }): React.JSX.Element {
   return (
     <ThemedSelect
@@ -713,9 +728,10 @@ function FilterSelect({
       placeholder="Todos"
       searchPlaceholder="Filtrar..."
       emptyLabel="Nenhuma opcao encontrada."
-      className="w-36"
+      className={className ?? 'w-40'}
       triggerClassName="h-8 bg-[#131518] px-3 text-xs"
       menuClassName="border-[#303641]"
+      menuMinWidth={menuMinWidth}
     />
   )
 }

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -17,8 +17,11 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DictionaryEntryModal } from '@/components/dictionary/DictionaryEntryModal'
 import { DictionaryImportModal } from '@/components/dictionary/DictionaryImportModal'
+import { DictionaryReplaceModal } from '@/components/dictionary/DictionaryReplaceModal'
+import { applyTextReplace } from '@/components/dictionary/replace'
 import {
   EMPTY_ENTRY_DRAFT,
+  type ReplaceDraft,
   type DisplayEntry,
   type EntryDraft
 } from '@/components/dictionary/types'
@@ -29,6 +32,12 @@ import type { DictionaryEntry, DictionaryFilters, Language } from '@/types'
 import { formatRelativeDate } from '../features/translate/utils/relativeDate'
 
 type FilterMenuKey = 'mod' | 'source' | 'target' | null
+
+interface PendingDeleteState {
+  ids: number[]
+  title: string
+  description: string
+}
 
 interface FilterOption {
   value: string
@@ -53,9 +62,10 @@ export function DictionaryPage(): React.JSX.Element {
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [importOpen, setImportOpen] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
+  const [replaceOpen, setReplaceOpen] = useState(false)
   const [createSeed, setCreateSeed] = useState<EntryDraft>(EMPTY_ENTRY_DRAFT)
   const [editingEntry, setEditingEntry] = useState<DisplayEntry | null>(null)
-  const [pendingDeleteEntry, setPendingDeleteEntry] = useState<DisplayEntry | null>(null)
+  const [pendingDelete, setPendingDelete] = useState<PendingDeleteState | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const modAnchorRef = useRef<HTMLButtonElement>(null)
   const sourceAnchorRef = useRef<HTMLButtonElement>(null)
@@ -262,22 +272,6 @@ export function DictionaryPage(): React.JSX.Element {
     }
   }
 
-  const handleDelete = async (id: number) => {
-    try {
-      await window.api.dictionary.delete({ id })
-      toast.success('Entrada removida')
-      setPendingDeleteEntry(null)
-      setSelectedIds((previous) => {
-        const next = new Set(previous)
-        next.delete(id)
-        return next
-      })
-      await loadEntries(filters)
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Erro ao remover entrada')
-    }
-  }
-
   const handleExport = async () => {
     const outputPath = await window.api.fs.saveDialog({
       defaultName: buildExportName(filters),
@@ -320,6 +314,73 @@ export function DictionaryPage(): React.JSX.Element {
   const selectedModLabel = modMenuOptions.find((option) => option.value === modName)?.label
   const selectedSourceLabel = sourceLang || 'Todas'
   const selectedTargetLabel = targetLang || 'Todas'
+  const selectedCount = selectedIds.size
+
+  const handleDeleteMany = async (ids: number[]) => {
+    try {
+      for (const id of ids) {
+        await window.api.dictionary.delete({ id })
+      }
+      toast.success(ids.length === 1 ? 'Entrada removida' : `${ids.length} entradas removidas`)
+      setPendingDelete(null)
+      setSelectedIds((previous) => {
+        const next = new Set(previous)
+        for (const id of ids) next.delete(id)
+        return next
+      })
+      await loadEntries(filters)
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Erro ao remover entradas')
+    }
+  }
+
+  const handleBatchReplace = async (draft: ReplaceDraft): Promise<boolean> => {
+    const selectedEntries = displayEntries.filter((entry) => selectedIds.has(entry.id))
+    const updates = selectedEntries
+      .map((entry) => {
+        const nextSource =
+          draft.scope === 'source' || draft.scope === 'both'
+            ? applyTextReplace(entry.sourceText, draft)
+            : entry.sourceText
+        const nextTarget =
+          draft.scope === 'target' || draft.scope === 'both'
+            ? applyTextReplace(entry.targetText, draft)
+            : entry.targetText
+
+        if (nextSource === entry.sourceText && nextTarget === entry.targetText) return null
+
+        return {
+          id: entry.id,
+          entry: {
+            language1: entry.sourceLang,
+            language2: entry.targetLang,
+            textLanguage1: nextSource,
+            textLanguage2: nextTarget,
+            modName: entry.modName || null,
+            uid: entry.uid || null
+          }
+        }
+      })
+      .filter((update): update is NonNullable<typeof update> => update !== null)
+
+    if (updates.length === 0) {
+      toast.info('Nenhuma ocorrencia encontrada nas entradas selecionadas')
+      return false
+    }
+
+    try {
+      for (const update of updates) {
+        await window.api.dictionary.update(update)
+      }
+      toast.success(`Replace aplicado em ${updates.length} entradas`)
+      setReplaceOpen(false)
+      await Promise.all([loadEntries(filters), loadReferenceData()])
+      return true
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Erro ao aplicar replace em lote')
+      return false
+    }
+  }
 
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#0f1114] text-neutral-100">
@@ -437,7 +498,33 @@ export function DictionaryPage(): React.JSX.Element {
           </button>
         )}
 
-        <div className="ml-auto">
+        <div className="ml-auto flex items-center gap-2">
+          <span className="text-[11px] font-medium text-neutral-500">
+            {selectedCount > 0 ? `${selectedCount} selecionadas` : 'Nenhuma selecao'}
+          </span>
+          <button
+            type="button"
+            disabled={selectedCount === 0}
+            onClick={() =>
+              setPendingDelete({
+                ids: Array.from(selectedIds),
+                title: 'Excluir selecao?',
+                description: `${selectedCount} entradas selecionadas serao removidas do dicionario.`
+              })
+            }
+            className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-red-500/30 bg-red-500/8 px-3 text-xs font-medium text-red-200 transition-colors hover:bg-red-500/14 disabled:cursor-not-allowed disabled:border-[#252a32] disabled:bg-[#131518] disabled:text-neutral-500"
+          >
+            <Trash2 size={13} />
+            Excluir
+          </button>
+          <button
+            type="button"
+            disabled={selectedCount === 0}
+            onClick={() => setReplaceOpen(true)}
+            className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
+          >
+            Replace
+          </button>
           <button
             type="button"
             onClick={startCreate}
@@ -546,7 +633,13 @@ export function DictionaryPage(): React.JSX.Element {
                     </button>
                     <button
                       type="button"
-                      onClick={() => setPendingDeleteEntry(entry)}
+                      onClick={() =>
+                        setPendingDelete({
+                          ids: [entry.id],
+                          title: 'Excluir entrada?',
+                          description: `A entrada #${entry.id} sera removida do dicionario.`
+                        })
+                      }
                       className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-transparent text-neutral-400 transition-colors hover:border-red-500/30 hover:bg-red-500/10 hover:text-red-300"
                     >
                       <Trash2 size={13} />
@@ -619,19 +712,22 @@ export function DictionaryPage(): React.JSX.Element {
         onSubmit={handleUpdate}
       />
 
+      <DictionaryReplaceModal
+        open={replaceOpen}
+        selectedCount={selectedCount}
+        onClose={() => setReplaceOpen(false)}
+        onSubmit={handleBatchReplace}
+      />
+
       <ConfirmDialog
-        open={Boolean(pendingDeleteEntry)}
-        title="Excluir entrada?"
-        description={
-          pendingDeleteEntry
-            ? `A entrada #${pendingDeleteEntry.id} sera removida do dicionario.`
-            : ''
-        }
+        open={Boolean(pendingDelete)}
+        title={pendingDelete?.title ?? 'Excluir entrada?'}
+        description={pendingDelete?.description ?? ''}
         confirmLabel="Excluir"
         destructive
-        onClose={() => setPendingDeleteEntry(null)}
+        onClose={() => setPendingDelete(null)}
         onConfirm={() => {
-          if (pendingDeleteEntry) void handleDelete(pendingDeleteEntry.id)
+          if (pendingDelete) void handleDeleteMany(pendingDelete.ids)
         }}
       />
 

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -1,18 +1,4 @@
-import {
-  BookOpen,
-  Box,
-  Check,
-  ChevronDown,
-  Download,
-  FilterX,
-  Pencil,
-  Plus,
-  Search,
-  Trash2,
-  Upload,
-  Wifi,
-  X
-} from 'lucide-react'
+import { BookOpen, Box, Download, FilterX, Pencil, Plus, Search, Trash2, Upload, Wifi, X } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { DictionaryEntryModal } from '@/components/dictionary/DictionaryEntryModal'
@@ -21,17 +7,16 @@ import { DictionaryReplaceModal } from '@/components/dictionary/DictionaryReplac
 import { applyTextReplace } from '@/components/dictionary/replace'
 import {
   EMPTY_ENTRY_DRAFT,
-  type ReplaceDraft,
   type DisplayEntry,
-  type EntryDraft
+  type EntryDraft,
+  type ReplaceDraft
 } from '@/components/dictionary/types'
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
+import { ThemedSelect, type ThemedSelectOption } from '@/components/shared/ThemedSelect'
 import { useDebouncedFilter } from '@/hooks/useDebouncedFilter'
 import { cn } from '@/lib/utils'
 import type { DictionaryEntry, DictionaryFilters, Language } from '@/types'
 import { formatRelativeDate } from '../features/translate/utils/relativeDate'
-
-type FilterMenuKey = 'mod' | 'source' | 'target' | null
 
 interface PendingDeleteState {
   ids: number[]
@@ -42,7 +27,6 @@ interface PendingDeleteState {
 interface FilterOption {
   value: string
   label: string
-  sub?: string
   count?: number
 }
 
@@ -58,7 +42,6 @@ export function DictionaryPage(): React.JSX.Element {
   const [modName, setModName] = useState('')
   const [sourceLang, setSourceLang] = useState('')
   const [targetLang, setTargetLang] = useState('')
-  const [openMenu, setOpenMenu] = useState<FilterMenuKey>(null)
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [importOpen, setImportOpen] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
@@ -67,9 +50,6 @@ export function DictionaryPage(): React.JSX.Element {
   const [editingEntry, setEditingEntry] = useState<DisplayEntry | null>(null)
   const [pendingDelete, setPendingDelete] = useState<PendingDeleteState | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
-  const modAnchorRef = useRef<HTMLButtonElement>(null)
-  const sourceAnchorRef = useRef<HTMLButtonElement>(null)
-  const targetAnchorRef = useRef<HTMLButtonElement>(null)
   const debouncedText = useDebouncedFilter(text)
 
   const filters = useMemo<DictionaryFilters>(
@@ -144,13 +124,52 @@ export function DictionaryPage(): React.JSX.Element {
   )
 
   const sourceOptions = useMemo(
-    () => buildLanguageOptions(displayEntries, languageNames, 'source'),
-    [displayEntries, languageNames]
+    () => buildLanguageOptions(displayEntries, 'source'),
+    [displayEntries]
   )
 
   const targetOptions = useMemo(
-    () => buildLanguageOptions(displayEntries, languageNames, 'target'),
-    [displayEntries, languageNames]
+    () => buildLanguageOptions(displayEntries, 'target'),
+    [displayEntries]
+  )
+
+  const modSelectOptions = useMemo<ThemedSelectOption[]>(
+    () => [
+      { value: '', label: 'Todos os mods', badge: `${displayEntries.length}` },
+      ...modOptions.map((option) => ({
+        value: option.value,
+        label: option.label,
+        badge: `${option.count ?? 0}`,
+        searchText: option.label
+      }))
+    ],
+    [displayEntries.length, modOptions]
+  )
+
+  const sourceSelectOptions = useMemo<ThemedSelectOption[]>(
+    () => [
+      { value: '', label: 'Todos', badge: `${displayEntries.length}` },
+      ...languages.map((language) => ({
+        value: language.code,
+        label: language.code.toUpperCase(),
+        badge: `${sourceOptions.get(language.code) ?? 0}`,
+        searchText: `${languageNames.get(language.code) ?? language.code} ${language.code}`
+      }))
+    ],
+    [displayEntries.length, languageNames, languages, sourceOptions]
+  )
+
+  const targetSelectOptions = useMemo<ThemedSelectOption[]>(
+    () => [
+      { value: '', label: 'Todos', badge: `${displayEntries.length}` },
+      ...languages.map((language) => ({
+        value: language.code,
+        label: language.code.toUpperCase(),
+        badge: `${targetOptions.get(language.code) ?? 0}`,
+        searchText: `${languageNames.get(language.code) ?? language.code} ${language.code}`
+      }))
+    ],
+    [displayEntries.length, languageNames, languages, targetOptions]
   )
 
   const stats = useMemo(() => {
@@ -170,46 +189,8 @@ export function DictionaryPage(): React.JSX.Element {
 
   const allFilteredSelected =
     displayEntries.length > 0 && displayEntries.every((entry) => selectedIds.has(entry.id))
-
   const hasFilters = Boolean(text || modName || sourceLang || targetLang)
-
-  const languageOptionList = useMemo(
-    () =>
-      languages.map((language) => ({
-        value: language.code,
-        label: language.code.toUpperCase(),
-        sub: language.name
-      })),
-    [languages]
-  )
-
-  const modMenuOptions = useMemo(
-    () =>
-      modOptions.map((option) => ({
-        value: option.value,
-        label: option.label,
-        count: option.count
-      })),
-    [modOptions]
-  )
-
-  const sourceMenuOptions = useMemo(
-    () =>
-      languageOptionList.map((language) => ({
-        ...language,
-        count: sourceOptions.find((option) => option.value === language.value)?.count ?? 0
-      })),
-    [languageOptionList, sourceOptions]
-  )
-
-  const targetMenuOptions = useMemo(
-    () =>
-      languageOptionList.map((language) => ({
-        ...language,
-        count: targetOptions.find((option) => option.value === language.value)?.count ?? 0
-      })),
-    [languageOptionList, targetOptions]
-  )
+  const selectedCount = selectedIds.size
 
   const startCreate = () => {
     setCreateSeed({
@@ -221,10 +202,6 @@ export function DictionaryPage(): React.JSX.Element {
       uid: ''
     })
     setCreateOpen(true)
-  }
-
-  const startEdit = (entry: DisplayEntry) => {
-    setEditingEntry(entry)
   }
 
   const handleCreate = async (draft: EntryDraft): Promise<boolean> => {
@@ -271,50 +248,6 @@ export function DictionaryPage(): React.JSX.Element {
       return false
     }
   }
-
-  const handleExport = async () => {
-    const outputPath = await window.api.fs.saveDialog({
-      defaultName: buildExportName(filters),
-      filters: [{ name: 'CSV', extensions: ['csv'] }]
-    })
-    if (!outputPath) return
-
-    try {
-      await window.api.dictionary.export({
-        filters,
-        format: 'csv',
-        outputPath
-      })
-      toast.success('CSV exportado')
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Erro ao exportar CSV')
-    }
-  }
-
-  const toggleSelected = (id: number, checked: boolean) => {
-    setSelectedIds((previous) => {
-      const next = new Set(previous)
-      if (checked) next.add(id)
-      else next.delete(id)
-      return next
-    })
-  }
-
-  const toggleSelectAll = (checked: boolean) => {
-    setSelectedIds((previous) => {
-      const next = new Set(previous)
-      for (const entry of displayEntries) {
-        if (checked) next.add(entry.id)
-        else next.delete(entry.id)
-      }
-      return next
-    })
-  }
-
-  const selectedModLabel = modMenuOptions.find((option) => option.value === modName)?.label
-  const selectedSourceLabel = sourceLang || 'Todas'
-  const selectedTargetLabel = targetLang || 'Todas'
-  const selectedCount = selectedIds.size
 
   const handleDeleteMany = async (ids: number[]) => {
     try {
@@ -382,6 +315,45 @@ export function DictionaryPage(): React.JSX.Element {
     }
   }
 
+  const handleExport = async () => {
+    const outputPath = await window.api.fs.saveDialog({
+      defaultName: buildExportName(filters),
+      filters: [{ name: 'CSV', extensions: ['csv'] }]
+    })
+    if (!outputPath) return
+
+    try {
+      await window.api.dictionary.export({
+        filters,
+        format: 'csv',
+        outputPath
+      })
+      toast.success('CSV exportado')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Erro ao exportar CSV')
+    }
+  }
+
+  const toggleSelected = (id: number, checked: boolean) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous)
+      if (checked) next.add(id)
+      else next.delete(id)
+      return next
+    })
+  }
+
+  const toggleSelectAll = (checked: boolean) => {
+    setSelectedIds((previous) => {
+      const next = new Set(previous)
+      for (const entry of displayEntries) {
+        if (checked) next.add(entry.id)
+        else next.delete(entry.id)
+      }
+      return next
+    })
+  }
+
   return (
     <div className="flex h-full min-h-0 flex-col bg-[#0f1114] text-neutral-100">
       <header className="flex items-center justify-between border-b border-[#1f2329] px-5 py-3">
@@ -446,40 +418,20 @@ export function DictionaryPage(): React.JSX.Element {
               <X size={13} />
             </button>
           )}
-          <span className="inline-flex h-5 min-w-6 items-center justify-center rounded border border-[#252a32] bg-[#0f1114] px-1 font-mono text-[10px] text-neutral-500">
-            Ctrl F
-          </span>
         </div>
 
-        <FilterControl
-          label="Mod"
-          valueLabel={selectedModLabel ?? 'Todos os mods'}
-          value={modName}
-          menu={modMenuOptions}
-          open={openMenu === 'mod'}
-          onOpenChange={(open) => setOpenMenu(open ? 'mod' : null)}
-          onSelect={(value) => setModName(value)}
-          anchorRef={modAnchorRef}
-        />
-        <FilterControl
-          label="Origem"
-          valueLabel={selectedSourceLabel}
+        <FilterSelect label="Mod" value={modName} options={modSelectOptions} onChange={setModName} />
+        <FilterSelect
+          label="Idioma 1"
           value={sourceLang}
-          menu={sourceMenuOptions}
-          open={openMenu === 'source'}
-          onOpenChange={(open) => setOpenMenu(open ? 'source' : null)}
-          onSelect={(value) => setSourceLang(value)}
-          anchorRef={sourceAnchorRef}
+          options={sourceSelectOptions}
+          onChange={setSourceLang}
         />
-        <FilterControl
-          label="Destino"
-          valueLabel={selectedTargetLabel}
+        <FilterSelect
+          label="Idioma 2"
           value={targetLang}
-          menu={targetMenuOptions}
-          open={openMenu === 'target'}
-          onOpenChange={(open) => setOpenMenu(open ? 'target' : null)}
-          onSelect={(value) => setTargetLang(value)}
-          anchorRef={targetAnchorRef}
+          options={targetSelectOptions}
+          onChange={setTargetLang}
         />
 
         {hasFilters && (
@@ -537,7 +489,7 @@ export function DictionaryPage(): React.JSX.Element {
       </div>
 
       <div className="flex items-center gap-6 border-b border-[#1f2329] bg-[#131518] px-4 py-3">
-        <StatBlock label="Mostrando" value={`${stats.filtered}`} detail={`/ ${stats.total}`} />
+        <StatBlock label="Mostrando" value={`${stats.filtered}`} detail={`/ ${stats.total}`} accentValue />
         <StatBlock label="Mods" value={`${stats.modCount}`} />
         <StatBlock label="Pares de idiomas" value={`${stats.pairCount}`} />
         <div className="ml-auto text-right">
@@ -563,8 +515,8 @@ export function DictionaryPage(): React.JSX.Element {
                 />
               </th>
               <th className={cn(TABLE_HEADER, 'w-28 px-4 py-3 text-left')}>ID</th>
-              <th className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>Texto origem</th>
-              <th className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>Texto destino</th>
+              <th className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>Texto idioma 1</th>
+              <th className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>Texto idioma 2</th>
               <th className={cn(TABLE_HEADER, 'w-48 px-4 py-3 text-left')}>Mod</th>
               <th className={cn(TABLE_HEADER, 'w-36 px-4 py-3 text-left')}>Idiomas</th>
               <th className={cn(TABLE_HEADER, 'w-32 px-4 py-3 text-right')}>Acoes</th>
@@ -588,9 +540,7 @@ export function DictionaryPage(): React.JSX.Element {
                   />
                 </td>
                 <td className="px-4 py-3 align-top">
-                  <span className="font-mono text-[11px] text-neutral-500">
-                    DCT-{String(entry.id).padStart(4, '0')}
-                  </span>
+                  <span className="font-mono text-[11px] text-neutral-500">{entry.id}</span>
                 </td>
                 <td className="px-4 py-3 align-top">
                   <div className="whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-100">
@@ -617,16 +567,16 @@ export function DictionaryPage(): React.JSX.Element {
                 </td>
                 <td className="px-4 py-3 align-top">
                   <span className="inline-flex items-center gap-1 font-mono text-[11px] text-neutral-400">
-                    <span>{entry.sourceLang}</span>
+                    <span>{entry.sourceLang.toUpperCase()}</span>
                     <span className="text-neutral-600">-&gt;</span>
-                    <span className="text-amber-400">{entry.targetLang}</span>
+                    <span className="text-amber-400">{entry.targetLang.toUpperCase()}</span>
                   </span>
                 </td>
                 <td className="px-4 py-3 align-top">
                   <div className="flex justify-end gap-1">
                     <button
                       type="button"
-                      onClick={() => startEdit(entry)}
+                      onClick={() => setEditingEntry(entry)}
                       className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-transparent text-neutral-400 transition-colors hover:border-[#252a32] hover:bg-[#131518] hover:text-neutral-200"
                     >
                       <Pencil size={13} />
@@ -742,178 +692,52 @@ export function DictionaryPage(): React.JSX.Element {
   )
 }
 
-function FilterControl({
+function FilterSelect({
   label,
-  valueLabel,
-  value,
-  menu,
-  open,
-  onOpenChange,
-  onSelect,
-  anchorRef
-}: {
-  label: string
-  valueLabel: string
-  value: string
-  menu: FilterOption[]
-  open: boolean
-  onOpenChange: (open: boolean) => void
-  onSelect: (value: string) => void
-  anchorRef: React.RefObject<HTMLButtonElement | null>
-}) {
-  return (
-    <div className="relative">
-      <button
-        ref={anchorRef}
-        type="button"
-        onClick={() => onOpenChange(!open)}
-        className={cn(
-          'inline-flex h-8 cursor-pointer items-center gap-2 rounded-md border px-3 text-xs transition-colors',
-          open
-            ? 'border-amber-500 bg-[#181b1f] text-neutral-100 shadow-[0_0_0_3px_rgba(245,158,11,0.18)]'
-            : 'border-[#1f2329] bg-[#131518] text-neutral-200 hover:border-[#303641]'
-        )}
-      >
-        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
-          {label}
-        </span>
-        <span className={cn('font-mono', !value && 'text-neutral-400')}>{valueLabel}</span>
-        <ChevronDown size={12} className="text-neutral-500" />
-      </button>
-      <FilterMenu
-        open={open}
-        value={value}
-        options={menu}
-        anchorRef={anchorRef}
-        onClose={() => onOpenChange(false)}
-        onSelect={(nextValue) => {
-          onSelect(nextValue)
-          onOpenChange(false)
-        }}
-      />
-    </div>
-  )
-}
-
-function FilterMenu({
-  open,
   value,
   options,
-  anchorRef,
-  onClose,
-  onSelect
+  onChange
 }: {
-  open: boolean
+  label: string
   value: string
-  options: FilterOption[]
-  anchorRef: React.RefObject<HTMLButtonElement | null>
-  onClose: () => void
-  onSelect: (value: string) => void
-}) {
-  const [query, setQuery] = useState('')
-  const menuRef = useRef<HTMLDivElement>(null)
-
-  useEffect(() => {
-    if (!open) return
-
-    const handler = (event: MouseEvent) => {
-      const target = event.target as Node
-      if (menuRef.current?.contains(target)) return
-      if (anchorRef.current?.contains(target)) return
-      onClose()
-    }
-
-    document.addEventListener('mousedown', handler)
-    return () => document.removeEventListener('mousedown', handler)
-  }, [anchorRef, onClose, open])
-
-  useEffect(() => {
-    if (!open) setQuery('')
-  }, [open])
-
-  if (!open) return null
-
-  const filtered = query
-    ? options.filter((option) => {
-        const haystack = `${option.label} ${option.sub ?? ''}`.toLowerCase()
-        return haystack.includes(query.toLowerCase())
-      })
-    : options
-
+  options: ThemedSelectOption[]
+  onChange: (value: string) => void
+}): React.JSX.Element {
   return (
-    <div
-      ref={menuRef}
-      className="absolute left-0 top-[calc(100%+6px)] z-20 min-w-60 rounded-lg border border-[#303641] bg-[#131518] p-1 shadow-[0_12px_32px_rgba(0,0,0,0.35)]"
-    >
-      {options.some((option) => option.sub) && (
-        <div className="mb-1 flex items-center gap-2 border-b border-[#1f2329] px-2 py-2 text-neutral-400">
-          <Search size={12} />
-          <input
-            autoFocus
-            value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            placeholder="Filtrar..."
-            className="w-full bg-transparent text-xs text-neutral-200 placeholder:text-neutral-600 focus:outline-none"
-          />
-        </div>
-      )}
-
-      <button
-        type="button"
-        onClick={() => onSelect('')}
-        className={cn(
-          'flex h-8 w-full cursor-pointer items-center rounded-md px-2 text-left text-xs transition-colors',
-          !value ? 'bg-amber-500/12 text-amber-400' : 'text-neutral-200 hover:bg-[#181b1f]'
-        )}
-      >
-        <span>Todos</span>
-        {!value && <Check size={12} className="ml-auto" />}
-      </button>
-
-      {filtered.map((option) => (
-        <button
-          key={option.value}
-          type="button"
-          onClick={() => onSelect(option.value)}
-          className={cn(
-            'flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-md px-2 text-left text-xs transition-colors',
-            value === option.value
-              ? 'bg-amber-500/12 text-amber-400'
-              : 'text-neutral-200 hover:bg-[#181b1f]'
-          )}
-        >
-          <div className="flex min-w-0 flex-col">
-            <span>{option.label}</span>
-            {option.sub && <span className="text-[11px] text-neutral-500">{option.sub}</span>}
-          </div>
-          <span className="ml-auto flex items-center gap-2">
-            {typeof option.count === 'number' && (
-              <span className="font-mono text-[10px] text-neutral-500">{option.count}</span>
-            )}
-            {value === option.value && <Check size={12} />}
-          </span>
-        </button>
-      ))}
-    </div>
+    <ThemedSelect
+      label={label}
+      value={value}
+      onChange={onChange}
+      options={options}
+      searchable
+      placeholder="Todos"
+      searchPlaceholder="Filtrar..."
+      emptyLabel="Nenhuma opcao encontrada."
+      className="w-36"
+      triggerClassName="h-8 bg-[#131518] px-3 text-xs"
+      menuClassName="border-[#303641]"
+    />
   )
 }
 
 function StatBlock({
   label,
   value,
-  detail
+  detail,
+  accentValue = false
 }: {
   label: string
   value: string
   detail?: string
+  accentValue?: boolean
 }) {
   return (
     <div className="flex flex-col gap-1">
       <div className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
         {label}
       </div>
-      <div className="text-lg font-semibold text-neutral-100">
-        <span>{value}</span>
+      <div className="text-lg font-semibold">
+        <span className={accentValue ? 'text-amber-400' : 'text-neutral-100'}>{value}</span>
         {detail && <span className="ml-1 text-sm font-normal text-neutral-500">{detail}</span>}
       </div>
     </div>
@@ -947,21 +771,16 @@ function buildModOptions(entries: DisplayEntry[], knownMods: string[]): FilterOp
 
 function buildLanguageOptions(
   entries: DisplayEntry[],
-  languageNames: Map<string, string>,
   side: 'source' | 'target'
-): FilterOption[] {
+): Map<string, number> {
   const counts = new Map<string, number>()
+
   for (const entry of entries) {
     const code = side === 'source' ? entry.sourceLang : entry.targetLang
     counts.set(code, (counts.get(code) ?? 0) + 1)
   }
 
-  return [...counts.keys()].sort((left, right) => left.localeCompare(right)).map((value) => ({
-    value,
-    label: value.toUpperCase(),
-    sub: languageNames.get(value) ?? value,
-    count: counts.get(value) ?? 0
-  }))
+  return counts
 }
 
 function toDisplayEntry(entry: DictionaryEntry, filters: DictionaryFilters): DisplayEntry {

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -4,7 +4,6 @@ import {
   Check,
   ChevronDown,
   Download,
-  FileSpreadsheet,
   FilterX,
   Pencil,
   Plus,
@@ -16,32 +15,20 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { toast } from 'sonner'
-import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
+import { DictionaryEntryModal } from '@/components/dictionary/DictionaryEntryModal'
+import { DictionaryImportModal } from '@/components/dictionary/DictionaryImportModal'
+import {
+  EMPTY_ENTRY_DRAFT,
+  type DisplayEntry,
+  type EntryDraft
+} from '@/components/dictionary/types'
+import { ConfirmDialog } from '@/components/shared/ConfirmDialog'
 import { useDebouncedFilter } from '@/hooks/useDebouncedFilter'
 import { cn } from '@/lib/utils'
-import type {
-  DictionaryEntry,
-  DictionaryFilters,
-  DictionaryImportPreview,
-  Language
-} from '@/types'
+import type { DictionaryEntry, DictionaryFilters, Language } from '@/types'
 import { formatRelativeDate } from '../features/translate/utils/relativeDate'
 
 type FilterMenuKey = 'mod' | 'source' | 'target' | null
-
-interface EntryDraft {
-  sourceLang: string
-  targetLang: string
-  sourceText: string
-  targetText: string
-  modName: string
-  uid: string
-}
-
-interface DisplayEntry extends EntryDraft {
-  id: number
-  updatedAt: string | null
-}
 
 interface FilterOption {
   value: string
@@ -51,22 +38,7 @@ interface FilterOption {
 }
 
 const TABLE_HEADER =
-  'text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500 select-none'
-
-const FIELD_SELECT =
-  'rounded-md border border-neutral-700 bg-[#0c0d0f] px-3 py-2 text-sm text-neutral-100 outline-none focus:border-amber-500'
-
-const META_INPUT =
-  'h-8 w-full rounded-md border border-[#252a32] bg-[#0c0d0f] px-2.5 text-[12px] text-neutral-200 outline-none transition-colors placeholder:text-neutral-600 focus:border-amber-500'
-
-const EMPTY_DRAFT: EntryDraft = {
-  sourceLang: '',
-  targetLang: '',
-  sourceText: '',
-  targetText: '',
-  modName: '',
-  uid: ''
-}
+  'select-none text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500'
 
 export function DictionaryPage(): React.JSX.Element {
   const [entries, setEntries] = useState<DictionaryEntry[]>([])
@@ -78,13 +50,12 @@ export function DictionaryPage(): React.JSX.Element {
   const [sourceLang, setSourceLang] = useState('')
   const [targetLang, setTargetLang] = useState('')
   const [openMenu, setOpenMenu] = useState<FilterMenuKey>(null)
-  const [editingId, setEditingId] = useState<number | null>(null)
-  const [draft, setDraft] = useState<EntryDraft>(EMPTY_DRAFT)
-  const [creating, setCreating] = useState(false)
-  const [newDraft, setNewDraft] = useState<EntryDraft>(EMPTY_DRAFT)
-  const [pendingDeleteId, setPendingDeleteId] = useState<number | null>(null)
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
   const [importOpen, setImportOpen] = useState(false)
+  const [createOpen, setCreateOpen] = useState(false)
+  const [createSeed, setCreateSeed] = useState<EntryDraft>(EMPTY_ENTRY_DRAFT)
+  const [editingEntry, setEditingEntry] = useState<DisplayEntry | null>(null)
+  const [pendingDeleteEntry, setPendingDeleteEntry] = useState<DisplayEntry | null>(null)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const modAnchorRef = useRef<HTMLButtonElement>(null)
   const sourceAnchorRef = useRef<HTMLButtonElement>(null)
@@ -231,10 +202,7 @@ export function DictionaryPage(): React.JSX.Element {
   )
 
   const startCreate = () => {
-    setCreating(true)
-    setEditingId(null)
-    setPendingDeleteId(null)
-    setNewDraft({
+    setCreateSeed({
       sourceLang: sourceLang || 'en',
       targetLang: targetLang || 'pt-BR',
       sourceText: '',
@@ -242,64 +210,39 @@ export function DictionaryPage(): React.JSX.Element {
       modName,
       uid: ''
     })
+    setCreateOpen(true)
   }
 
   const startEdit = (entry: DisplayEntry) => {
-    setCreating(false)
-    setPendingDeleteId(null)
-    setEditingId(entry.id)
-    setDraft({
-      sourceLang: entry.sourceLang,
-      targetLang: entry.targetLang,
-      sourceText: entry.sourceText,
-      targetText: entry.targetText,
-      modName: entry.modName,
-      uid: entry.uid
-    })
+    setEditingEntry(entry)
   }
 
-  const resetEditing = () => {
-    setEditingId(null)
-    setDraft(EMPTY_DRAFT)
-  }
-
-  const resetCreate = () => {
-    setCreating(false)
-    setNewDraft(EMPTY_DRAFT)
-  }
-
-  const handleCreate = async () => {
-    if (!isDraftValid(newDraft)) {
-      toast.error('Preencha origem, destino e os dois idiomas')
-      return
-    }
-
+  const handleCreate = async (draft: EntryDraft): Promise<boolean> => {
     try {
       await window.api.dictionary.create({
-        language1: newDraft.sourceLang,
-        language2: newDraft.targetLang,
-        textLanguage1: newDraft.sourceText,
-        textLanguage2: newDraft.targetText,
-        modName: newDraft.modName || null,
-        uid: newDraft.uid || null
+        language1: draft.sourceLang,
+        language2: draft.targetLang,
+        textLanguage1: draft.sourceText,
+        textLanguage2: draft.targetText,
+        modName: draft.modName || null,
+        uid: draft.uid || null
       })
       toast.success('Entrada criada')
-      resetCreate()
+      setCreateOpen(false)
       await Promise.all([loadEntries(filters), loadReferenceData()])
+      return true
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Erro ao criar entrada')
+      return false
     }
   }
 
-  const handleUpdate = async (id: number) => {
-    if (!isDraftValid(draft)) {
-      toast.error('Preencha origem, destino e os dois idiomas')
-      return
-    }
+  const handleUpdate = async (draft: EntryDraft): Promise<boolean> => {
+    if (!editingEntry) return false
 
     try {
       await window.api.dictionary.update({
-        id,
+        id: editingEntry.id,
         entry: {
           language1: draft.sourceLang,
           language2: draft.targetLang,
@@ -310,10 +253,12 @@ export function DictionaryPage(): React.JSX.Element {
         }
       })
       toast.success('Entrada atualizada')
-      resetEditing()
+      setEditingEntry(null)
       await Promise.all([loadEntries(filters), loadReferenceData()])
+      return true
     } catch (error) {
       toast.error(error instanceof Error ? error.message : 'Erro ao atualizar entrada')
+      return false
     }
   }
 
@@ -321,8 +266,7 @@ export function DictionaryPage(): React.JSX.Element {
     try {
       await window.api.dictionary.delete({ id })
       toast.success('Entrada removida')
-      setPendingDeleteId(null)
-      if (editingId === id) resetEditing()
+      setPendingDeleteEntry(null)
       setSelectedIds((previous) => {
         const next = new Set(previous)
         next.delete(id)
@@ -406,7 +350,7 @@ export function DictionaryPage(): React.JSX.Element {
             type="button"
             onClick={handleExport}
             disabled={loading || displayEntries.length === 0}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
+            className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800 disabled:cursor-not-allowed disabled:opacity-40"
           >
             <Download size={13} />
             Exportar CSV
@@ -414,7 +358,7 @@ export function DictionaryPage(): React.JSX.Element {
           <button
             type="button"
             onClick={() => setImportOpen(true)}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
+            className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
           >
             <Upload size={13} />
             Importar CSV
@@ -433,7 +377,11 @@ export function DictionaryPage(): React.JSX.Element {
             className="min-w-0 flex-1 bg-transparent text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none"
           />
           {text && (
-            <button type="button" onClick={() => setText('')} className="text-neutral-500">
+            <button
+              type="button"
+              onClick={() => setText('')}
+              className="cursor-pointer text-neutral-500"
+            >
               <X size={13} />
             </button>
           )}
@@ -482,7 +430,7 @@ export function DictionaryPage(): React.JSX.Element {
               setSourceLang('')
               setTargetLang('')
             }}
-            className="inline-flex h-8 items-center gap-1 rounded-md border border-dashed border-[#3a404a] px-3 text-xs text-neutral-400 transition-colors hover:bg-[#131518] hover:text-neutral-200"
+            className="inline-flex h-8 cursor-pointer items-center gap-1 rounded-md border border-dashed border-[#3a404a] px-3 text-xs text-neutral-400 transition-colors hover:bg-[#131518] hover:text-neutral-200"
           >
             <FilterX size={12} />
             Limpar
@@ -493,7 +441,7 @@ export function DictionaryPage(): React.JSX.Element {
           <button
             type="button"
             onClick={startCreate}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
+            className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
           >
             <Plus size={13} />
             Nova entrada
@@ -536,127 +484,79 @@ export function DictionaryPage(): React.JSX.Element {
             </tr>
           </thead>
           <tbody>
-            {creating && (
-              <EditableRow
-                draft={newDraft}
-                languages={languages}
-                mods={knownMods}
-                highlight="new"
-                onChange={setNewDraft}
-                onCancel={resetCreate}
-                onSave={handleCreate}
-              />
-            )}
-
-            {displayEntries.map((entry) =>
-              editingId === entry.id ? (
-                <EditableRow
-                  key={entry.id}
-                  id={entry.id}
-                  draft={draft}
-                  languages={languages}
-                  mods={knownMods}
-                  highlight="editing"
-                  onChange={setDraft}
-                  onCancel={resetEditing}
-                  onSave={() => handleUpdate(entry.id)}
-                />
-              ) : (
-                <tr
-                  key={entry.id}
-                  className={cn(
-                    'border-b border-[#1f2329] transition-colors hover:bg-[#131518]',
-                    selectedIds.has(entry.id) && 'bg-[#131518]'
-                  )}
-                >
-                  <td className="px-4 py-3 align-top text-center">
-                    <input
-                      type="checkbox"
-                      checked={selectedIds.has(entry.id)}
-                      onChange={(event) => toggleSelected(entry.id, event.target.checked)}
-                      className="mt-1 h-4 w-4 cursor-pointer accent-amber-500"
-                    />
-                  </td>
-                  <td className="px-4 py-3 align-top">
-                    <span className="font-mono text-[11px] text-neutral-500">
-                      DCT-{String(entry.id).padStart(4, '0')}
+            {displayEntries.map((entry) => (
+              <tr
+                key={entry.id}
+                className={cn(
+                  'border-b border-[#1f2329] transition-colors hover:bg-[#131518]',
+                  selectedIds.has(entry.id) && 'bg-[#131518]'
+                )}
+              >
+                <td className="px-4 py-3 align-top text-center">
+                  <input
+                    type="checkbox"
+                    checked={selectedIds.has(entry.id)}
+                    onChange={(event) => toggleSelected(entry.id, event.target.checked)}
+                    className="mt-1 h-4 w-4 cursor-pointer accent-amber-500"
+                  />
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <span className="font-mono text-[11px] text-neutral-500">
+                    DCT-{String(entry.id).padStart(4, '0')}
+                  </span>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <div className="whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-100">
+                    {entry.sourceText}
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <div className="whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-200">
+                    {entry.targetText}
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <div className="flex flex-col gap-2">
+                    <span className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#252a32] bg-[#0c0d0f] px-2 py-1 text-xs text-neutral-300">
+                      <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
+                      <span className="truncate">{entry.modName || 'Sem mod'}</span>
                     </span>
-                  </td>
-                  <td className="px-4 py-3 align-top">
-                    <div className="font-mono text-sm leading-6 text-neutral-100 whitespace-pre-wrap">
-                      {entry.sourceText}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 align-top">
-                    <div className="font-mono text-sm leading-6 text-neutral-200 whitespace-pre-wrap">
-                      {entry.targetText}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 align-top">
-                    <div className="flex flex-col gap-2">
-                      <span className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#252a32] bg-[#0c0d0f] px-2 py-1 text-xs text-neutral-300">
-                        <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
-                        <span className="truncate">{entry.modName || 'Sem mod'}</span>
+                    {entry.uid && (
+                      <span className="truncate font-mono text-[11px] text-neutral-600">
+                        UID {entry.uid}
                       </span>
-                      {entry.uid && (
-                        <span className="truncate font-mono text-[11px] text-neutral-600">
-                          UID {entry.uid}
-                        </span>
-                      )}
-                    </div>
-                  </td>
-                  <td className="px-4 py-3 align-top">
-                    <span className="inline-flex items-center gap-1 font-mono text-[11px] text-neutral-400">
-                      <span>{entry.sourceLang}</span>
-                      <span className="text-neutral-600">-&gt;</span>
-                      <span className="text-amber-400">{entry.targetLang}</span>
-                    </span>
-                  </td>
-                  <td className="px-4 py-3 align-top">
-                    <div className="flex justify-end gap-1">
-                      {pendingDeleteId === entry.id ? (
-                        <>
-                          <button
-                            type="button"
-                            onClick={() => setPendingDeleteId(null)}
-                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-[#252a32] text-neutral-400 transition-colors hover:bg-[#131518] hover:text-neutral-200"
-                          >
-                            <X size={13} />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => handleDelete(entry.id)}
-                            className="inline-flex h-7 items-center gap-1 rounded-md border border-red-500/40 bg-red-500/10 px-2 text-[11px] font-semibold text-red-300 transition-colors hover:bg-red-500/20"
-                          >
-                            <Trash2 size={12} />
-                            Confirmar
-                          </button>
-                        </>
-                      ) : (
-                        <>
-                          <button
-                            type="button"
-                            onClick={() => startEdit(entry)}
-                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-neutral-400 transition-colors hover:border-[#252a32] hover:bg-[#131518] hover:text-neutral-200"
-                          >
-                            <Pencil size={13} />
-                          </button>
-                          <button
-                            type="button"
-                            onClick={() => setPendingDeleteId(entry.id)}
-                            className="inline-flex h-7 w-7 items-center justify-center rounded-md border border-transparent text-neutral-400 transition-colors hover:border-red-500/30 hover:bg-red-500/10 hover:text-red-300"
-                          >
-                            <Trash2 size={13} />
-                          </button>
-                        </>
-                      )}
-                    </div>
-                  </td>
-                </tr>
-              )
-            )}
+                    )}
+                  </div>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <span className="inline-flex items-center gap-1 font-mono text-[11px] text-neutral-400">
+                    <span>{entry.sourceLang}</span>
+                    <span className="text-neutral-600">-&gt;</span>
+                    <span className="text-amber-400">{entry.targetLang}</span>
+                  </span>
+                </td>
+                <td className="px-4 py-3 align-top">
+                  <div className="flex justify-end gap-1">
+                    <button
+                      type="button"
+                      onClick={() => startEdit(entry)}
+                      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-transparent text-neutral-400 transition-colors hover:border-[#252a32] hover:bg-[#131518] hover:text-neutral-200"
+                    >
+                      <Pencil size={13} />
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => setPendingDeleteEntry(entry)}
+                      className="inline-flex h-7 w-7 cursor-pointer items-center justify-center rounded-md border border-transparent text-neutral-400 transition-colors hover:border-red-500/30 hover:bg-red-500/10 hover:text-red-300"
+                    >
+                      <Trash2 size={13} />
+                    </button>
+                  </div>
+                </td>
+              </tr>
+            ))}
 
-            {!creating && !loading && displayEntries.length === 0 && (
+            {!loading && displayEntries.length === 0 && (
               <tr>
                 <td colSpan={7} className="px-6 py-20">
                   <div className="flex flex-col items-center gap-3 text-center">
@@ -698,7 +598,44 @@ export function DictionaryPage(): React.JSX.Element {
         </span>
       </footer>
 
-      <ImportModal
+      <DictionaryEntryModal
+        open={createOpen}
+        mode="create"
+        initialDraft={createSeed}
+        languages={languages}
+        mods={knownMods}
+        onClose={() => setCreateOpen(false)}
+        onSubmit={handleCreate}
+      />
+
+      <DictionaryEntryModal
+        open={Boolean(editingEntry)}
+        mode="edit"
+        entryId={editingEntry?.id}
+        initialDraft={editingEntry ? toEntryDraft(editingEntry) : EMPTY_ENTRY_DRAFT}
+        languages={languages}
+        mods={knownMods}
+        onClose={() => setEditingEntry(null)}
+        onSubmit={handleUpdate}
+      />
+
+      <ConfirmDialog
+        open={Boolean(pendingDeleteEntry)}
+        title="Excluir entrada?"
+        description={
+          pendingDeleteEntry
+            ? `A entrada #${pendingDeleteEntry.id} sera removida do dicionario.`
+            : ''
+        }
+        confirmLabel="Excluir"
+        destructive
+        onClose={() => setPendingDeleteEntry(null)}
+        onConfirm={() => {
+          if (pendingDeleteEntry) void handleDelete(pendingDeleteEntry.id)
+        }}
+      />
+
+      <DictionaryImportModal
         open={importOpen}
         onClose={() => setImportOpen(false)}
         onImported={async () => {
@@ -735,7 +672,7 @@ function FilterControl({
         type="button"
         onClick={() => onOpenChange(!open)}
         className={cn(
-          'inline-flex h-8 items-center gap-2 rounded-md border px-3 text-xs transition-colors',
+          'inline-flex h-8 cursor-pointer items-center gap-2 rounded-md border px-3 text-xs transition-colors',
           open
             ? 'border-amber-500 bg-[#181b1f] text-neutral-100 shadow-[0_0_0_3px_rgba(245,158,11,0.18)]'
             : 'border-[#1f2329] bg-[#131518] text-neutral-200 hover:border-[#303641]'
@@ -829,7 +766,7 @@ function FilterMenu({
         type="button"
         onClick={() => onSelect('')}
         className={cn(
-          'flex h-8 w-full items-center rounded-md px-2 text-left text-xs transition-colors',
+          'flex h-8 w-full cursor-pointer items-center rounded-md px-2 text-left text-xs transition-colors',
           !value ? 'bg-amber-500/12 text-amber-400' : 'text-neutral-200 hover:bg-[#181b1f]'
         )}
       >
@@ -843,7 +780,7 @@ function FilterMenu({
           type="button"
           onClick={() => onSelect(option.value)}
           className={cn(
-            'flex min-h-8 w-full items-center gap-2 rounded-md px-2 text-left text-xs transition-colors',
+            'flex min-h-8 w-full cursor-pointer items-center gap-2 rounded-md px-2 text-left text-xs transition-colors',
             value === option.value
               ? 'bg-amber-500/12 text-amber-400'
               : 'text-neutral-200 hover:bg-[#181b1f]'
@@ -884,326 +821,6 @@ function StatBlock({
         {detail && <span className="ml-1 text-sm font-normal text-neutral-500">{detail}</span>}
       </div>
     </div>
-  )
-}
-
-function EditableRow({
-  id,
-  draft,
-  languages,
-  mods,
-  highlight,
-  onChange,
-  onCancel,
-  onSave
-}: {
-  id?: number
-  draft: EntryDraft
-  languages: Language[]
-  mods: string[]
-  highlight: 'new' | 'editing'
-  onChange: (draft: EntryDraft) => void
-  onCancel: () => void
-  onSave: () => void
-}) {
-  return (
-    <tr
-      className={cn(
-        'border-b border-[#1f2329]',
-        highlight === 'new'
-          ? 'bg-amber-500/10 shadow-[inset_3px_0_0_#f59e0b]'
-          : 'bg-[#131518] shadow-[inset_3px_0_0_#f59e0b]'
-      )}
-    >
-      <td className="px-4 py-3 align-top text-center">
-        <input
-          type="checkbox"
-          disabled
-          className="mt-1 h-4 w-4 cursor-not-allowed accent-amber-500 opacity-60"
-        />
-      </td>
-      <td className="px-4 py-3 align-top">
-        <span className="font-mono text-[11px] text-neutral-500">
-          {id ? `DCT-${String(id).padStart(4, '0')}` : 'nova'}
-        </span>
-      </td>
-      <td className="px-4 py-3 align-top">
-        <HighlightedTextarea
-          autoFocus
-          value={draft.sourceText}
-          onChange={(event) => onChange({ ...draft, sourceText: event.target.value })}
-          rows={1}
-          containerClassName="rounded-lg border-[#2a2f37] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.22)]"
-          overlayClassName="px-3 py-2 text-[13px] leading-[1.6]"
-          className="field-sizing-content min-h-0 px-3 py-2 text-[13px] leading-[1.6]"
-          placeholder="Texto origem..."
-        />
-      </td>
-      <td className="px-4 py-3 align-top">
-        <HighlightedTextarea
-          value={draft.targetText}
-          onChange={(event) => onChange({ ...draft, targetText: event.target.value })}
-          rows={1}
-          containerClassName="rounded-lg border-[#2a2f37] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.22)]"
-          overlayClassName="px-3 py-2 text-[13px] leading-[1.6]"
-          className="field-sizing-content min-h-0 px-3 py-2 text-[13px] leading-[1.6]"
-          placeholder="Texto destino..."
-        />
-      </td>
-      <td className="px-4 py-3 align-top">
-        <div className="flex flex-col gap-2">
-          <input
-            list="dictionary-mod-options"
-            value={draft.modName}
-            onChange={(event) => onChange({ ...draft, modName: event.target.value })}
-            className={META_INPUT}
-            placeholder="Nome do mod"
-          />
-          <input
-            value={draft.uid}
-            onChange={(event) => onChange({ ...draft, uid: event.target.value })}
-            className={META_INPUT}
-            placeholder="UID opcional"
-          />
-          <datalist id="dictionary-mod-options">
-            {mods.map((modName) => (
-              <option key={modName} value={modName} />
-            ))}
-          </datalist>
-        </div>
-      </td>
-      <td className="px-4 py-3 align-top">
-        <div className="flex items-center gap-2">
-          <select
-            value={draft.sourceLang}
-            onChange={(event) => onChange({ ...draft, sourceLang: event.target.value })}
-            className={cn(FIELD_SELECT, 'h-8 w-24 px-2.5 py-0 text-[12px]')}
-          >
-            <option value="">Origem</option>
-            {languages.map((language) => (
-              <option key={language.code} value={language.code}>
-                {language.code}
-              </option>
-            ))}
-          </select>
-          <span className="font-mono text-neutral-600">-&gt;</span>
-          <select
-            value={draft.targetLang}
-            onChange={(event) => onChange({ ...draft, targetLang: event.target.value })}
-            className={cn(FIELD_SELECT, 'h-8 w-24 px-2.5 py-0 text-[12px]')}
-          >
-            <option value="">Destino</option>
-            {languages.map((language) => (
-              <option key={language.code} value={language.code}>
-                {language.code}
-              </option>
-            ))}
-          </select>
-        </div>
-      </td>
-      <td className="px-4 py-3 align-top">
-        <div className="flex justify-end gap-1">
-          <button
-            type="button"
-            onClick={onCancel}
-            className="inline-flex h-8 w-8 items-center justify-center rounded-md border border-[#252a32] text-neutral-400 transition-colors hover:bg-[#181b1f] hover:text-neutral-200"
-          >
-            <X size={14} />
-          </button>
-          <button
-            type="button"
-            onClick={onSave}
-            className="inline-flex h-8 items-center gap-1 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
-          >
-            <Check size={13} />
-            Salvar
-          </button>
-        </div>
-      </td>
-    </tr>
-  )
-}
-
-function ImportModal({
-  open,
-  onClose,
-  onImported
-}: {
-  open: boolean
-  onClose: () => void
-  onImported: () => Promise<void>
-}) {
-  const [filePath, setFilePath] = useState('')
-  const [preview, setPreview] = useState<DictionaryImportPreview | null>(null)
-  const [loading, setLoading] = useState(false)
-  const [importing, setImporting] = useState(false)
-
-  useEffect(() => {
-    if (!open) {
-      setFilePath('')
-      setPreview(null)
-      setLoading(false)
-      setImporting(false)
-    }
-  }, [open])
-
-  if (!open) return null
-
-  const handleSelectFile = async () => {
-    const paths = await window.api.fs.openDialog({
-      filters: [{ name: 'CSV', extensions: ['csv'] }]
-    })
-    if (!paths[0]) return
-
-    setLoading(true)
-    try {
-      const nextPreview = await window.api.dictionary.previewImport({
-        filePath: paths[0],
-        format: 'csv'
-      })
-      setFilePath(paths[0])
-      setPreview(nextPreview)
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Erro ao ler CSV')
-    } finally {
-      setLoading(false)
-    }
-  }
-
-  const handleImport = async () => {
-    if (!filePath) return
-    setImporting(true)
-    try {
-      const result = await window.api.dictionary.import({ filePath, format: 'csv' })
-      toast.success(`${result.count} entradas importadas`)
-      await onImported()
-      onClose()
-    } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Erro ao importar CSV')
-    } finally {
-      setImporting(false)
-    }
-  }
-
-  return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 px-4 backdrop-blur-sm">
-      <div className="w-full max-w-2xl overflow-hidden rounded-xl border border-[#303641] bg-[#131518] shadow-[0_20px_60px_rgba(0,0,0,0.45)]">
-        <div className="flex items-center gap-3 border-b border-[#1f2329] px-5 py-4">
-          <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-amber-500/12 text-amber-400">
-            <FileSpreadsheet size={16} />
-          </div>
-          <div>
-            <div className="text-sm font-semibold text-neutral-100">Importar dicionario</div>
-            <div className="text-xs text-neutral-500">
-              Compatibilidade com `language1/...` e `src/tgt/src_lang/tgt_lang`
-            </div>
-          </div>
-          <button
-            type="button"
-            onClick={onClose}
-            className="ml-auto inline-flex h-8 w-8 items-center justify-center rounded-md text-neutral-400 transition-colors hover:bg-[#181b1f] hover:text-neutral-200"
-          >
-            <X size={14} />
-          </button>
-        </div>
-
-        <div className="flex flex-col gap-4 px-5 py-5">
-          <button
-            type="button"
-            onClick={handleSelectFile}
-            className="flex min-h-36 flex-col items-center justify-center gap-2 rounded-xl border border-dashed border-[#3a404a] bg-[#0f1114] px-6 py-6 text-center transition-colors hover:border-amber-500 hover:bg-amber-500/6"
-          >
-            <Upload size={18} className="text-neutral-300" />
-            <div className="text-sm font-semibold text-neutral-100">
-              {filePath ? filePath.split(/[\\/]/).pop() : 'Escolher arquivo CSV'}
-            </div>
-            <div className="text-xs text-neutral-500">
-              Abra um CSV para visualizar headers detectados e uma previa antes de importar.
-            </div>
-          </button>
-
-          {loading && <p className="text-sm text-neutral-500">Lendo arquivo...</p>}
-
-          {preview && (
-            <>
-              <div className="rounded-lg border border-[#1f2329] bg-[#0f1114] p-3 text-xs text-neutral-400">
-                <div className="flex flex-wrap items-center gap-3">
-                  <span>{preview.totalRows} linhas detectadas</span>
-                  <span className="font-mono text-neutral-500">
-                    Headers: {preview.headers.join(', ')}
-                  </span>
-                </div>
-              </div>
-
-              <div className="overflow-hidden rounded-lg border border-[#1f2329] bg-[#0f1114]">
-                <div className="flex items-center justify-between border-b border-[#1f2329] px-3 py-2 text-[11px] text-neutral-500">
-                  <span>Previa das primeiras {preview.rows.length} linhas</span>
-                  <span className="font-mono">UTF-8 . CSV</span>
-                </div>
-                <table className="w-full border-collapse text-xs">
-                  <thead>
-                    <tr className="bg-[#131518]">
-                      <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
-                        Origem
-                      </th>
-                      <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
-                        Destino
-                      </th>
-                      <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
-                        Mod
-                      </th>
-                      <th className="px-3 py-2 text-left font-semibold uppercase tracking-[0.06em] text-neutral-500">
-                        Idiomas
-                      </th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {preview.rows.map((row, index) => (
-                      <tr key={`${row.uid ?? 'row'}-${index}`} className="border-t border-[#1f2329]">
-                        <td className="px-3 py-2 font-mono text-neutral-200">{row.sourceText}</td>
-                        <td className="px-3 py-2 font-mono text-neutral-200">{row.targetText}</td>
-                        <td className="px-3 py-2 text-neutral-300">{row.modName || 'Sem mod'}</td>
-                        <td className="px-3 py-2 font-mono text-neutral-400">
-                          {row.sourceLang || '—'} -&gt; {row.targetLang || '—'}
-                        </td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
-              </div>
-            </>
-          )}
-        </div>
-
-        <div className="flex items-center justify-end gap-2 border-t border-[#1f2329] bg-[#0f1114] px-5 py-4">
-          <button
-            type="button"
-            onClick={onClose}
-            className="inline-flex h-8 items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
-          >
-            Cancelar
-          </button>
-          <button
-            type="button"
-            disabled={!preview || importing}
-            onClick={handleImport}
-            className="inline-flex h-8 items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
-          >
-            <Upload size={13} />
-            {importing ? 'Importando...' : `Importar ${preview?.totalRows ?? 0} entradas`}
-          </button>
-        </div>
-      </div>
-    </div>
-  )
-}
-
-function isDraftValid(draft: EntryDraft): boolean {
-  return Boolean(
-    draft.sourceLang.trim() &&
-      draft.targetLang.trim() &&
-      draft.sourceText.trim() &&
-      draft.targetText.trim()
   )
 }
 
@@ -1262,6 +879,17 @@ function toDisplayEntry(entry: DictionaryEntry, filters: DictionaryFilters): Dis
     modName: entry.modName ?? '',
     uid: entry.uid ?? '',
     updatedAt: entry.updatedAt
+  }
+}
+
+function toEntryDraft(entry: DisplayEntry): EntryDraft {
+  return {
+    sourceLang: entry.sourceLang,
+    targetLang: entry.targetLang,
+    sourceText: entry.sourceText,
+    targetText: entry.targetText,
+    modName: entry.modName,
+    uid: entry.uid
   }
 }
 

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -6,6 +6,10 @@ import { DictionaryImportModal } from '@/components/dictionary/DictionaryImportM
 import { DictionaryReplaceModal } from '@/components/dictionary/DictionaryReplaceModal'
 import { applyTextReplace } from '@/components/dictionary/replace'
 import {
+  decodeDictionaryTextForUi,
+  encodeDictionaryTextForPersistence
+} from '@/components/dictionary/text'
+import {
   EMPTY_ENTRY_DRAFT,
   type DisplayEntry,
   type EntryDraft,
@@ -16,6 +20,7 @@ import { ThemedSelect, type ThemedSelectOption } from '@/components/shared/Theme
 import { useDebouncedFilter } from '@/hooks/useDebouncedFilter'
 import { cn } from '@/lib/utils'
 import type { DictionaryEntry, DictionaryFilters, Language } from '@/types'
+import { renderSource } from '@/utils/renderSource'
 import { formatRelativeDate } from '../features/translate/utils/relativeDate'
 
 interface PendingDeleteState {
@@ -209,8 +214,8 @@ export function DictionaryPage(): React.JSX.Element {
       await window.api.dictionary.create({
         language1: draft.sourceLang,
         language2: draft.targetLang,
-        textLanguage1: draft.sourceText,
-        textLanguage2: draft.targetText,
+        textLanguage1: encodeDictionaryTextForPersistence(draft.sourceText),
+        textLanguage2: encodeDictionaryTextForPersistence(draft.targetText),
         modName: draft.modName || null,
         uid: draft.uid || null
       })
@@ -233,8 +238,8 @@ export function DictionaryPage(): React.JSX.Element {
         entry: {
           language1: draft.sourceLang,
           language2: draft.targetLang,
-          textLanguage1: draft.sourceText,
-          textLanguage2: draft.targetText,
+          textLanguage1: encodeDictionaryTextForPersistence(draft.sourceText),
+          textLanguage2: encodeDictionaryTextForPersistence(draft.targetText),
           modName: draft.modName || null,
           uid: draft.uid || null
         }
@@ -287,8 +292,8 @@ export function DictionaryPage(): React.JSX.Element {
           entry: {
             language1: entry.sourceLang,
             language2: entry.targetLang,
-            textLanguage1: nextSource,
-            textLanguage2: nextTarget,
+            textLanguage1: encodeDictionaryTextForPersistence(nextSource),
+            textLanguage2: encodeDictionaryTextForPersistence(nextTarget),
             modName: entry.modName || null,
             uid: entry.uid || null
           }
@@ -554,13 +559,13 @@ export function DictionaryPage(): React.JSX.Element {
                   <span className="font-mono text-[11px] text-neutral-500">{entry.id}</span>
                 </td>
                 <td className="px-4 py-3 align-top">
-                  <div className="whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-100">
-                    {entry.sourceText}
+                  <div className="wrap-break-word whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-100">
+                    {entry.sourceText ? renderSource(entry.sourceText) : null}
                   </div>
                 </td>
                 <td className="px-4 py-3 align-top">
-                  <div className="whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-200">
-                    {entry.targetText}
+                  <div className="wrap-break-word whitespace-pre-wrap font-mono text-sm leading-6 text-neutral-200">
+                    {entry.targetText ? renderSource(entry.targetText) : null}
                   </div>
                 </td>
                 <td className="px-4 py-3 align-top">
@@ -805,8 +810,8 @@ function toDisplayEntry(entry: DictionaryEntry, filters: DictionaryFilters): Dis
     id: entry.id,
     sourceLang: swap ? entry.language2 : entry.language1,
     targetLang: swap ? entry.language1 : entry.language2,
-    sourceText: swap ? entry.textLanguage2 : entry.textLanguage1,
-    targetText: swap ? entry.textLanguage1 : entry.textLanguage2,
+    sourceText: decodeDictionaryTextForUi(swap ? entry.textLanguage2 : entry.textLanguage1),
+    targetText: decodeDictionaryTextForUi(swap ? entry.textLanguage1 : entry.textLanguage2),
     modName: entry.modName ?? '',
     uid: entry.uid ?? '',
     updatedAt: entry.updatedAt


### PR DESCRIPTION
## Summary

This PR refines the UX of the dictionary and translation editor, focusing on visual consistency, batch actions, modal flows, keyboard shortcuts, and correct tag handling.

## What changed

### Layout and navigation
- updates the main layout so the `Sidebar` uses the full vertical height
- moves the `TitleBar` into the content area
- updates the sidebar shortcut badges to `Ctrl 1`, `Ctrl 2`, etc.

### Dictionary
- replaces inline create/edit flows with modals
- adds close-on-overlay-click and `Esc`
- adds discard confirmation when there are unsaved changes
- adds batch actions for selection:
  - delete
  - replace
- adds a replace modal with:
  - find
  - replace with
  - language scope
  - `match case`
  - `match whole word`
- removes inline per-row delete confirmation
- shows the real numeric ID without the `DCT-` prefix
- displays language pairs in uppercase
- renames `Source` and `Target` labels to `Language 1` and `Language 2`
- improves the “showing” summary by highlighting the first number with the primary color
- removes the visual `Ctrl Shortcuts` chip
- aligns filters and selects with the shared select behavior, using internal scroll and avoiding layout shift
- ensures clickable controls use `cursor-pointer`

### Dictionary tags and replace behavior
- decodes XML entities in dictionary previews using the same pattern as the translation page
- renders tags correctly in dictionary rows
- makes the edit UI work with decoded text and only re-encodes on persistence
- fixes replace behavior so it:
  - allows replacing visible text inside tags
  - protects tag attributes and delimiters
  - preserves special tokens such as `{...}`

### Translation editor
- removes the unused `Focus mode` button/state
- adds keyboard shortcuts:
  - `Ctrl+S` to save
  - `Ctrl+T` to switch export format
  - `Ctrl+E` to export
- prevents the browser default behavior for those shortcuts
- adds visible shortcut hints for save, export, and format switching
- refines the export format select so it fits the header layout better

## Validation
- `pnpm typecheck`

## Notes
- no IPC/preload contract changes
- batch delete and batch replace remain renderer-side and use the existing dictionary endpoints
