### PR TITLE
feat(merge): add merge translations tool

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -9,6 +9,7 @@ import { registerDictionaryHandlers } from './ipc/dictionary.ipc'
 import { registerFsHandlers } from './ipc/fs.ipc'
 import { registerLanguageHandlers } from './ipc/language.ipc'
 import { registerLogHandlers } from './ipc/log.ipc'
+import { registerMergeHandlers } from './ipc/merge.ipc'
 import { registerModHandlers } from './ipc/mod.ipc'
 import { registerTranslationHandlers } from './ipc/translation.ipc'
 import { registerWindowHandlers, setupWindowEvents } from './ipc/window.ipc'
@@ -72,6 +73,7 @@ app.whenReady().then(() => {
   registerLanguageHandlers(repos)
   registerLogHandlers()
   registerModHandlers(repos)
+  registerMergeHandlers(repos)
   registerConfigHandlers()
   registerFsHandlers()
   registerXmlHandlers(repos)

--- a/src/main/ipc/merge.ipc.ts
+++ b/src/main/ipc/merge.ipc.ts
@@ -1,0 +1,77 @@
+import { ipcMain } from 'electron'
+import type { RepositoryRegistry } from '../database/repositories/registry'
+import { type MergeResult, mergeXmls } from '../services/merge.service'
+import {
+  discardTranslationInput,
+  getStagedCandidate,
+  type PreparedTranslationInput,
+  prepareTranslationInput
+} from '../services/translation-import.service'
+
+interface PrepareInputPayload {
+  inputPath: string
+}
+
+interface DiscardInputPayload {
+  importId: string
+}
+
+interface RunMergePayload {
+  sourceImportId: string
+  sourceCandidateId: string
+  sourceLang: string
+  targetImportId: string
+  targetCandidateId: string
+  targetLang: string
+  modName: string
+}
+
+async function runMerge(repos: RepositoryRegistry, payload: RunMergePayload): Promise<MergeResult> {
+  const sourceCandidate = getStagedCandidate(payload.sourceImportId, payload.sourceCandidateId)
+  const targetCandidate = getStagedCandidate(payload.targetImportId, payload.targetCandidateId)
+
+  if (!sourceCandidate) throw new Error('Source import session expired. Select the file again.')
+  if (!targetCandidate) throw new Error('Target import session expired. Select the file again.')
+  if (!sourceCandidate.valid) throw new Error('Source XML has an invalid format')
+  if (!targetCandidate.valid) throw new Error('Target XML has an invalid format')
+
+  const modName = payload.modName.trim()
+  if (!modName) throw new Error('Mod name is required')
+  if (payload.sourceLang === payload.targetLang) {
+    throw new Error('Source and target languages must differ')
+  }
+
+  try {
+    return mergeXmls(repos, {
+      sourceXmlPath: sourceCandidate.absolutePath,
+      sourceLang: payload.sourceLang,
+      targetXmlPath: targetCandidate.absolutePath,
+      targetLang: payload.targetLang,
+      modName
+    })
+  } finally {
+    discardTranslationInput(payload.sourceImportId)
+    discardTranslationInput(payload.targetImportId)
+  }
+}
+
+export function registerMergeHandlers(repos: RepositoryRegistry): void {
+  ipcMain.handle(
+    'merge:prepareInput',
+    async (_event, payload: PrepareInputPayload): Promise<PreparedTranslationInput> =>
+      prepareTranslationInput(payload.inputPath)
+  )
+
+  ipcMain.handle(
+    'merge:discardInput',
+    async (_event, payload: DiscardInputPayload): Promise<{ success: boolean }> => {
+      discardTranslationInput(payload.importId)
+      return { success: true }
+    }
+  )
+
+  ipcMain.handle(
+    'merge:run',
+    async (_event, payload: RunMergePayload): Promise<MergeResult> => runMerge(repos, payload)
+  )
+}

--- a/src/main/services/merge.service.ts
+++ b/src/main/services/merge.service.ts
@@ -1,0 +1,63 @@
+import type { RepositoryRegistry } from '../database/repositories/registry'
+import { decodeEntities } from './xml-entities.service'
+import { parseLocalizationXml } from './xml-parser.service'
+
+export interface MergeXmlsParams {
+  sourceXmlPath: string
+  sourceLang: string
+  targetXmlPath: string
+  targetLang: string
+  modName: string
+}
+
+export interface MergeResult {
+  matched: number
+  sourceOnly: number
+  targetOnly: number
+}
+
+export function mergeXmls(repos: RepositoryRegistry, params: MergeXmlsParams): MergeResult {
+  const sourceEntries = parseLocalizationXml(params.sourceXmlPath)
+  const targetEntries = parseLocalizationXml(params.targetXmlPath)
+
+  const sourceMap = new Map<string, string>()
+  for (const entry of sourceEntries) sourceMap.set(entry.contentuid, entry.text)
+
+  const targetMap = new Map<string, string>()
+  for (const entry of targetEntries) targetMap.set(entry.contentuid, entry.text)
+
+  let matched = 0
+  for (const [uid, rawSource] of sourceMap) {
+    const rawTarget = targetMap.get(uid)
+    if (rawTarget === undefined) continue
+
+    const sourceText = decodeEntities(rawSource).trim()
+    const targetText = decodeEntities(rawTarget).trim()
+    if (!sourceText || !targetText) continue
+
+    repos.dictionary.upsert({
+      sourceLang: params.sourceLang,
+      targetLang: params.targetLang,
+      sourceText,
+      targetText,
+      modName: params.modName,
+      uid
+    })
+    matched++
+  }
+
+  const sourceOnly = countMissing(sourceMap, targetMap)
+  const targetOnly = countMissing(targetMap, sourceMap)
+
+  if (matched > 0) {
+    repos.mod.upsert(params.modName, { totalStrings: matched })
+  }
+
+  return { matched, sourceOnly, targetOnly }
+}
+
+function countMissing(a: Map<string, string>, b: Map<string, string>): number {
+  let count = 0
+  for (const key of a.keys()) if (!b.has(key)) count++
+  return count
+}

--- a/src/main/services/merge.service.ts
+++ b/src/main/services/merge.service.ts
@@ -26,6 +26,9 @@ export function mergeXmls(repos: RepositoryRegistry, params: MergeXmlsParams): M
   const targetMap = new Map<string, string>()
   for (const entry of targetEntries) targetMap.set(entry.contentuid, entry.text)
 
+  // Mod must exist before dictionary entries reference it via FK (modName → mod.name).
+  repos.mod.upsert(params.modName)
+
   let matched = 0
   for (const [uid, rawSource] of sourceMap) {
     const rawTarget = targetMap.get(uid)

--- a/src/main/services/translation-import.service.ts
+++ b/src/main/services/translation-import.service.ts
@@ -129,6 +129,15 @@ export async function prepareTranslationInput(
   }
 }
 
+export function getStagedCandidate(
+  importId: string,
+  candidateId: string
+): TranslationXmlCandidate | undefined {
+  const staged = stagedImports.get(importId)
+  if (!staged) return undefined
+  return staged.candidates.find((candidate) => candidate.id === candidateId)
+}
+
 export function discardTranslationInput(importId: string): void {
   const staged = stagedImports.get(importId)
   if (!staged) return

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -270,6 +270,26 @@ export interface ModApi {
   }): Promise<{ outputPath: string }>
 }
 
+export interface MergeResult {
+  matched: number
+  sourceOnly: number
+  targetOnly: number
+}
+
+export interface MergeApi {
+  prepareInput(params: { inputPath: string }): Promise<PreparedTranslationInput>
+  discardInput(params: { importId: string }): Promise<{ success: boolean }>
+  run(params: {
+    sourceImportId: string
+    sourceCandidateId: string
+    sourceLang: string
+    targetImportId: string
+    targetCandidateId: string
+    targetLang: string
+    modName: string
+  }): Promise<MergeResult>
+}
+
 export interface XmlApi {
   load(params: {
     inputPath: string
@@ -320,6 +340,7 @@ export interface AppApi {
   fs: FsApi
   log: LogApi
   xml: XmlApi
+  merge: MergeApi
   window: WindowApi
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -257,6 +257,24 @@ const api: AppApi = {
     }): Promise<void> => ipcRenderer.invoke('xml:export', params)
   },
 
+  merge: {
+    prepareInput: (params: { inputPath: string }) =>
+      ipcRenderer.invoke('merge:prepareInput', params),
+
+    discardInput: (params: { importId: string }): Promise<{ success: boolean }> =>
+      ipcRenderer.invoke('merge:discardInput', params),
+
+    run: (params: {
+      sourceImportId: string
+      sourceCandidateId: string
+      sourceLang: string
+      targetImportId: string
+      targetCandidateId: string
+      targetLang: string
+      modName: string
+    }) => ipcRenderer.invoke('merge:run', params)
+  },
+
   config: {
     get: (params: { key: string }): Promise<{ value: string | null }> =>
       ipcRenderer.invoke('config:get', params),

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { TranslationSessionProvider } from './context/TranslationSession'
 import { DictionaryPage } from './pages/DictionaryPage'
 import { EntryEditPage } from './pages/EntryEditPage'
 import { ExtractPage } from './pages/ExtractPage'
+import { MergeToolPage } from './pages/MergeToolPage'
 import { PackagePage } from './pages/PackagePage'
 import { SettingsPage } from './pages/SettingsPage'
 import { TranslatePage } from './pages/TranslatePage'
@@ -29,6 +30,7 @@ function App(): React.JSX.Element {
           <Route path="/dictionary" element={<DictionaryPage />} />
           <Route path="/extract" element={<ExtractPage />} />
           <Route path="/package" element={<PackagePage />} />
+          <Route path="/merge" element={<MergeToolPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>
       </Routes>

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -1,15 +1,16 @@
-import { BookOpen, Languages, Package, PackageOpen, Settings } from 'lucide-react'
+import { BookOpen, Languages, Merge, Package, PackageOpen, Settings } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 import { cn } from '@/lib/utils'
 
 const NAV_ITEMS = [
   { to: '/translate', icon: Languages, label: 'Translate', kbd: 'Ctrl 1' },
   { to: '/dictionary', icon: BookOpen, label: 'Dictionary', kbd: 'Ctrl 2' },
-  { to: '/extract', icon: PackageOpen, label: 'Extract Mod', kbd: 'Ctrl 3' },
-  { to: '/package', icon: Package, label: 'Create Package', kbd: 'Ctrl 4' }
+  { to: '/merge', icon: Merge, label: 'Merge Translations', kbd: 'Ctrl 3' },
+  { to: '/extract', icon: PackageOpen, label: 'Extract Mod', kbd: 'Ctrl 4' },
+  { to: '/package', icon: Package, label: 'Create Package', kbd: 'Ctrl 5' }
 ] as const
 
-const FOOTER_ITEMS = [{ to: '/settings', icon: Settings, label: 'Settings', kbd: 'Ctrl 5' }] as const
+const FOOTER_ITEMS = [{ to: '/settings', icon: Settings, label: 'Settings', kbd: 'Ctrl 6' }] as const
 
 function NavItem({
   to,
@@ -58,7 +59,7 @@ export function Sidebar(): React.JSX.Element {
   return (
     <aside
       style={{ transition: 'width 180ms cubic-bezier(0.2, 0.8, 0.2, 1)' }}
-      className="group/sidebar fixed top-0 left-0 z-40 flex h-screen w-14 flex-col overflow-hidden border-r border-[#1f2329] bg-[#0f1114] hover:w-55"
+      className="group/sidebar fixed top-0 left-0 z-40 flex h-screen w-14 flex-col overflow-hidden border-r border-[#1f2329] bg-[#0f1114] hover:w-62"
     >
       <nav className="flex flex-1 flex-col gap-0.5 px-2 py-3">
         {NAV_ITEMS.map((item) => (

--- a/src/renderer/src/features/merge/components/MergeBottomBar.tsx
+++ b/src/renderer/src/features/merge/components/MergeBottomBar.tsx
@@ -1,0 +1,41 @@
+import { Loader2, Merge } from 'lucide-react'
+import { btnBase, btnPrimary } from '@/features/translate/components/styles'
+import { cn } from '@/lib/utils'
+
+interface MergeBottomBarProps {
+  ready: boolean
+  isRunning: boolean
+  onCancel: () => void
+  onRun: () => void
+}
+
+export function MergeBottomBar({
+  ready,
+  isRunning,
+  onCancel,
+  onRun
+}: MergeBottomBarProps): React.JSX.Element {
+  return (
+    <div className="shrink-0 px-6 py-3 border-t border-[#1f2329]">
+      <div className="max-w-220 mx-auto flex items-center gap-2.5 px-4 py-3 bg-[#131518] border border-neutral-700 rounded-xl shadow-xl">
+        <div className="flex-1 text-xs text-neutral-400">
+          {ready
+            ? 'Pronto para fundir as entradas casadas no dicionario'
+            : 'Complete os 3 passos para iniciar a fusao'}
+        </div>
+        <button type="button" className={btnBase} onClick={onCancel} disabled={isRunning}>
+          Cancelar
+        </button>
+        <button
+          type="button"
+          className={cn(btnPrimary, (!ready || isRunning) && 'opacity-40 cursor-not-allowed')}
+          disabled={!ready || isRunning}
+          onClick={onRun}
+        >
+          {isRunning ? <Loader2 size={13} className="animate-spin" /> : <Merge size={13} />}
+          Fundir e salvar
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/features/merge/components/MergeFileStep.tsx
+++ b/src/renderer/src/features/merge/components/MergeFileStep.tsx
@@ -1,0 +1,93 @@
+import { ArrowRight } from 'lucide-react'
+import { FileInputCard } from '@/features/translate/components/FileInputCard'
+import { LanguagePicker } from '@/features/translate/components/LanguagePicker'
+import { SetupStepCard } from '@/features/translate/components/SetupStepCard'
+import type { Language } from '@/types'
+import type { MergeFileSlot, SlotKey } from '../types'
+
+interface MergeFileStepProps {
+  step: string
+  title: string
+  description: string
+  slot: MergeFileSlot
+  slotKey: SlotKey
+  languages: Language[]
+  accent?: boolean
+  onLangChange: (code: string) => void
+  onBrowse: (slot: SlotKey) => Promise<void>
+  onDrop: (slot: SlotKey, event: React.DragEvent) => Promise<void>
+  onDragChange: (slot: SlotKey, dragging: boolean) => void
+  onClear: (slot: SlotKey) => Promise<void>
+}
+
+export function MergeFileStep({
+  step,
+  title,
+  description,
+  slot,
+  slotKey,
+  languages,
+  accent,
+  onLangChange,
+  onBrowse,
+  onDrop,
+  onDragChange,
+  onClear
+}: MergeFileStepProps): React.JSX.Element {
+  return (
+    <SetupStepCard step={step}>
+      <div>
+        <h3 className="text-[15px] font-semibold text-neutral-200 tracking-tight m-0">{title}</h3>
+        <p className="text-xs text-neutral-500 mt-1 m-0">{description}</p>
+      </div>
+
+      <div className="grid grid-cols-[1fr_auto] gap-3.5 items-end">
+        <div>
+          <span className="block text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500 mb-1.5">
+            Idioma
+          </span>
+          <LanguagePicker
+            value={slot.lang}
+            onChange={onLangChange}
+            languages={languages}
+            accent={accent}
+          />
+        </div>
+        <div className="pb-2 text-neutral-600">
+          <ArrowRight size={16} />
+        </div>
+      </div>
+
+      <FileInputCard
+        fileName={slot.fileName}
+        isDragging={slot.isDragging}
+        onBrowse={() => onBrowse(slotKey)}
+        onDragOver={(event) => {
+          event.preventDefault()
+          onDragChange(slotKey, true)
+        }}
+        onDragLeave={() => onDragChange(slotKey, false)}
+        onDrop={(event) => {
+          void onDrop(slotKey, event)
+        }}
+        onClear={() => {
+          void onClear(slotKey)
+        }}
+      />
+
+      {slot.prepared && slot.candidateId && <CandidateSummary slot={slot} />}
+    </SetupStepCard>
+  )
+}
+
+function CandidateSummary({ slot }: { slot: MergeFileSlot }): React.JSX.Element | null {
+  const candidate = slot.prepared?.candidates.find((item) => item.id === slot.candidateId)
+  if (!candidate) return null
+  return (
+    <div className="flex items-center gap-2 text-[11px] text-neutral-500 font-mono px-2">
+      <span className="text-amber-400">XML</span>
+      <span className="truncate flex-1">{candidate.relativePath}</span>
+      <span>{candidate.stringCount} entradas</span>
+    </div>
+  )
+}

--- a/src/renderer/src/features/merge/components/MergeNameStep.tsx
+++ b/src/renderer/src/features/merge/components/MergeNameStep.tsx
@@ -1,0 +1,34 @@
+import { SetupStepCard } from '@/features/translate/components/SetupStepCard'
+
+interface MergeNameStepProps {
+  value: string
+  onChange: (value: string) => void
+}
+
+export function MergeNameStep({ value, onChange }: MergeNameStepProps): React.JSX.Element {
+  return (
+    <SetupStepCard step="03">
+      <div>
+        <h3 className="text-[15px] font-semibold text-neutral-200 tracking-tight m-0">
+          Detalhes do merge
+        </h3>
+        <p className="text-xs text-neutral-500 mt-1 m-0">
+          O nome do mod e usado para escopar as entradas no dicionario.
+        </p>
+      </div>
+
+      <label className="flex flex-col gap-1.5">
+        <span className="text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500">
+          Nome do mod
+        </span>
+        <input
+          type="text"
+          placeholder="ex: Order of the Dracolich"
+          className="w-full bg-[#0f1114] border border-[#1f2329] rounded-lg px-3.5 py-2.5 text-sm text-neutral-200 outline-none focus:border-amber-500/60 focus:ring-1 focus:ring-amber-500/40 transition-colors placeholder:text-neutral-700"
+          value={value}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      </label>
+    </SetupStepCard>
+  )
+}

--- a/src/renderer/src/features/merge/components/MergeToolScreen.tsx
+++ b/src/renderer/src/features/merge/components/MergeToolScreen.tsx
@@ -1,0 +1,124 @@
+import { Merge } from 'lucide-react'
+import { XmlSelectionModal } from '@/features/translate/components/XmlSelectionModal'
+import type { PreparedTranslationInput } from '@/types'
+import { useMergeSetup } from '../hooks/useMergeSetup'
+import type { SlotKey } from '../types'
+import { MergeBottomBar } from './MergeBottomBar'
+import { MergeFileStep } from './MergeFileStep'
+import { MergeNameStep } from './MergeNameStep'
+
+export function MergeToolScreen(): React.JSX.Element {
+  const setup = useMergeSetup()
+  const pendingSlot =
+    setup.pendingSelection === 'source'
+      ? setup.source
+      : setup.pendingSelection === 'target'
+        ? setup.target
+        : null
+
+  return (
+    <>
+      <div className="flex flex-col h-full min-h-0">
+        <div className="flex items-center gap-3 px-5 h-10 border-b border-[#1f2329] bg-[#131518] shrink-0">
+          <span className="flex items-center gap-1.5 font-mono text-[12px] text-neutral-200">
+            <Merge size={12} />
+            Nova ferramenta de merge
+          </span>
+          <span className="flex-1" />
+          <span className="flex items-center gap-2 font-mono text-[11px]">
+            <span className={setup.step1Done ? 'text-amber-400' : 'text-neutral-600'}>
+              1 Origem
+            </span>
+            <span className="text-neutral-700">-</span>
+            <span className={setup.step2Done ? 'text-amber-400' : 'text-neutral-600'}>
+              2 Traduzido
+            </span>
+            <span className="text-neutral-700">-</span>
+            <span className={setup.step3Done ? 'text-amber-400' : 'text-neutral-600'}>
+              3 Mod
+            </span>
+          </span>
+        </div>
+
+        <div className="flex-1 overflow-y-auto icosa-scroll [scrollbar-gutter:stable] px-6 pt-7 pb-6 min-h-0">
+          <div className="max-w-220 mx-auto flex flex-col gap-3.5">
+            <MergeFileStep
+              step="01"
+              title="Arquivo de origem"
+              description="Forneca o arquivo com os textos originais que servirao de base."
+              slot={setup.source}
+              slotKey="source"
+              languages={setup.languages}
+              onLangChange={setup.setSourceLang}
+              onBrowse={setup.browseFile}
+              onDrop={setup.dropFile}
+              onDragChange={setup.setDragging}
+              onClear={setup.clearFile}
+            />
+
+            <MergeFileStep
+              step="02"
+              title="Arquivo traduzido"
+              description="Forneca o arquivo ja traduzido para a fusao."
+              slot={setup.target}
+              slotKey="target"
+              languages={setup.languages}
+              accent
+              onLangChange={setup.setTargetLang}
+              onBrowse={setup.browseFile}
+              onDrop={setup.dropFile}
+              onDragChange={setup.setDragging}
+              onClear={setup.clearFile}
+            />
+
+            <MergeNameStep value={setup.modName} onChange={setup.setModName} />
+          </div>
+        </div>
+
+        <MergeBottomBar
+          ready={setup.ready}
+          isRunning={setup.isRunning}
+          onCancel={() => {
+            void setup.reset()
+          }}
+          onRun={() => {
+            void setup.runMerge()
+          }}
+        />
+      </div>
+
+      {pendingSlot?.prepared && setup.pendingSelection && (
+        <PendingSelectionModal
+          prepared={pendingSlot.prepared}
+          slotKey={setup.pendingSelection}
+          onCancel={setup.closeSelection}
+          onSelect={setup.selectCandidate}
+        />
+      )}
+    </>
+  )
+}
+
+interface PendingSelectionModalProps {
+  prepared: PreparedTranslationInput
+  slotKey: SlotKey
+  onCancel: () => Promise<void>
+  onSelect: (slotKey: SlotKey, candidateId: string) => void
+}
+
+function PendingSelectionModal({
+  prepared,
+  slotKey,
+  onCancel,
+  onSelect
+}: PendingSelectionModalProps): React.JSX.Element {
+  return (
+    <XmlSelectionModal
+      prepared={prepared}
+      onCancel={onCancel}
+      onSelect={async (candidateId) => {
+        onSelect(slotKey, candidateId)
+      }}
+    />
+  )
+}

--- a/src/renderer/src/features/merge/hooks/useMergeSetup.ts
+++ b/src/renderer/src/features/merge/hooks/useMergeSetup.ts
@@ -1,0 +1,277 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import type { Language, MergeResult, PreparedTranslationInput } from '@/types'
+import type { MergeFileSlot, SlotKey } from '../types'
+
+const ACCEPTED_EXT = ['xml', 'pak', 'zip']
+const FILE_FILTERS = [{ name: 'Mod Files', extensions: ACCEPTED_EXT }]
+
+function emptySlot(lang: string): MergeFileSlot {
+  return {
+    filePath: null,
+    fileName: null,
+    lang,
+    importId: null,
+    candidateId: null,
+    prepared: null,
+    isDragging: false,
+    isPreparing: false
+  }
+}
+
+function fileNameFromPath(filePath: string): string {
+  return filePath.split(/[\\/]/).pop() ?? filePath
+}
+
+function hasAcceptedExt(name: string): boolean {
+  const ext = name.split('.').pop()?.toLowerCase() ?? ''
+  return ACCEPTED_EXT.includes(ext)
+}
+
+interface UseMergeSetupResult {
+  source: MergeFileSlot
+  target: MergeFileSlot
+  modName: string
+  languages: Language[]
+  ready: boolean
+  isRunning: boolean
+  pendingSelection: SlotKey | null
+  step1Done: boolean
+  step2Done: boolean
+  step3Done: boolean
+  setSourceLang: (code: string) => void
+  setTargetLang: (code: string) => void
+  setModName: (value: string) => void
+  setDragging: (slot: SlotKey, dragging: boolean) => void
+  browseFile: (slot: SlotKey) => Promise<void>
+  dropFile: (slot: SlotKey, event: React.DragEvent) => Promise<void>
+  clearFile: (slot: SlotKey) => Promise<void>
+  selectCandidate: (slot: SlotKey, candidateId: string) => void
+  closeSelection: () => Promise<void>
+  runMerge: () => Promise<void>
+  reset: () => Promise<void>
+}
+
+export function useMergeSetup(): UseMergeSetupResult {
+  const [source, setSource] = useState<MergeFileSlot>(() => emptySlot(''))
+  const [target, setTarget] = useState<MergeFileSlot>(() => emptySlot(''))
+  const [modName, setModName] = useState('')
+  const [languages, setLanguages] = useState<Language[]>([])
+  const [isRunning, setIsRunning] = useState(false)
+  const [pendingSelection, setPendingSelection] = useState<SlotKey | null>(null)
+
+  useEffect(() => {
+    window.api.language.getAll().then((items) => {
+      setLanguages(items)
+      setSource((prev) => (prev.lang ? prev : { ...prev, lang: items[0]?.code ?? '' }))
+      setTarget((prev) => (prev.lang ? prev : { ...prev, lang: items[1]?.code ?? items[0]?.code ?? '' }))
+    })
+  }, [])
+
+  const updateSlot = useCallback(
+    (key: SlotKey, updater: (prev: MergeFileSlot) => MergeFileSlot) => {
+      if (key === 'source') setSource(updater)
+      else setTarget(updater)
+    },
+    []
+  )
+
+  const getSlot = useCallback(
+    (key: SlotKey): MergeFileSlot => (key === 'source' ? source : target),
+    [source, target]
+  )
+
+  const prepare = useCallback(
+    async (key: SlotKey, filePath: string, fileName: string) => {
+      const previous = getSlot(key)
+      if (previous.importId) {
+        await window.api.merge.discardInput({ importId: previous.importId }).catch(() => undefined)
+      }
+
+      updateSlot(key, (prev) => ({
+        ...prev,
+        filePath,
+        fileName,
+        importId: null,
+        candidateId: null,
+        prepared: null,
+        isPreparing: true
+      }))
+
+      let prepared: PreparedTranslationInput
+      try {
+        prepared = await window.api.merge.prepareInput({ inputPath: filePath })
+      } catch (error) {
+        updateSlot(key, () => emptySlot(previous.lang))
+        toast.error(error instanceof Error ? error.message : 'Falha ao preparar arquivo')
+        return
+      }
+
+      const validCandidates = prepared.candidates.filter((candidate) => candidate.valid)
+      const autoCandidate = !prepared.requiresSelection
+        ? prepared.candidates[0]
+        : validCandidates.length === 1
+          ? validCandidates[0]
+          : null
+
+      updateSlot(key, (prev) => ({
+        ...prev,
+        prepared,
+        importId: prepared.importId,
+        candidateId: autoCandidate?.id ?? null,
+        isPreparing: false
+      }))
+
+      if (!autoCandidate) setPendingSelection(key)
+    },
+    [getSlot, updateSlot]
+  )
+
+  const browseFile = useCallback(
+    async (key: SlotKey) => {
+      const paths = await window.api.fs.openDialog({ filters: FILE_FILTERS })
+      if (paths.length === 0) return
+      await prepare(key, paths[0], fileNameFromPath(paths[0]))
+    },
+    [prepare]
+  )
+
+  const dropFile = useCallback(
+    async (key: SlotKey, event: React.DragEvent) => {
+      event.preventDefault()
+      updateSlot(key, (prev) => ({ ...prev, isDragging: false }))
+      const file = event.dataTransfer.files[0]
+      if (!file) return
+      if (!hasAcceptedExt(file.name)) {
+        toast.error('Formato invalido. Use .xml, .pak ou .zip')
+        return
+      }
+      const filePath = window.api.fs.getPathForFile(file)
+      await prepare(key, filePath, file.name)
+    },
+    [prepare, updateSlot]
+  )
+
+  const clearFile = useCallback(
+    async (key: SlotKey) => {
+      const slot = getSlot(key)
+      if (slot.importId) {
+        await window.api.merge.discardInput({ importId: slot.importId }).catch(() => undefined)
+      }
+      updateSlot(key, () => emptySlot(slot.lang))
+      if (pendingSelection === key) setPendingSelection(null)
+    },
+    [getSlot, pendingSelection, updateSlot]
+  )
+
+  const selectCandidate = useCallback(
+    (key: SlotKey, candidateId: string) => {
+      updateSlot(key, (prev) => ({ ...prev, candidateId }))
+      setPendingSelection(null)
+    },
+    [updateSlot]
+  )
+
+  const closeSelection = useCallback(async () => {
+    if (!pendingSelection) return
+    await clearFile(pendingSelection)
+  }, [clearFile, pendingSelection])
+
+  const setDragging = useCallback(
+    (key: SlotKey, dragging: boolean) => {
+      updateSlot(key, (prev) => ({ ...prev, isDragging: dragging }))
+    },
+    [updateSlot]
+  )
+
+  const setSourceLang = useCallback(
+    (code: string) => setSource((prev) => ({ ...prev, lang: code })),
+    []
+  )
+
+  const setTargetLang = useCallback(
+    (code: string) => setTarget((prev) => ({ ...prev, lang: code })),
+    []
+  )
+
+  const reset = useCallback(async () => {
+    if (source.importId) {
+      await window.api.merge.discardInput({ importId: source.importId }).catch(() => undefined)
+    }
+    if (target.importId) {
+      await window.api.merge.discardInput({ importId: target.importId }).catch(() => undefined)
+    }
+    setSource((prev) => emptySlot(prev.lang))
+    setTarget((prev) => emptySlot(prev.lang))
+    setModName('')
+    setPendingSelection(null)
+  }, [source.importId, target.importId])
+
+  const step1Done = !!source.lang && !!source.importId && !!source.candidateId
+  const step2Done = !!target.lang && !!target.importId && !!target.candidateId
+  const step3Done = modName.trim().length > 0
+
+  const ready =
+    step1Done &&
+    step2Done &&
+    step3Done &&
+    source.lang !== target.lang &&
+    !isRunning
+
+  const runMerge = useCallback(async () => {
+    if (!ready) return
+    if (!source.importId || !source.candidateId || !target.importId || !target.candidateId) return
+    setIsRunning(true)
+    try {
+      const result: MergeResult = await window.api.merge.run({
+        sourceImportId: source.importId,
+        sourceCandidateId: source.candidateId,
+        sourceLang: source.lang,
+        targetImportId: target.importId,
+        targetCandidateId: target.candidateId,
+        targetLang: target.lang,
+        modName: modName.trim()
+      })
+
+      const ignored = result.sourceOnly + result.targetOnly
+      toast.success(
+        ignored > 0
+          ? `${result.matched} entradas mescladas (${ignored} ignoradas)`
+          : `${result.matched} entradas mescladas`
+      )
+
+      // ImportIds are discarded on the main side after run; clear local state.
+      setSource((prev) => emptySlot(prev.lang))
+      setTarget((prev) => emptySlot(prev.lang))
+      setModName('')
+    } catch (error) {
+      toast.error(error instanceof Error ? error.message : 'Falha ao mesclar arquivos')
+    } finally {
+      setIsRunning(false)
+    }
+  }, [modName, ready, source, target])
+
+  return {
+    source,
+    target,
+    modName,
+    languages,
+    ready,
+    isRunning,
+    pendingSelection,
+    step1Done,
+    step2Done,
+    step3Done,
+    setSourceLang,
+    setTargetLang,
+    setModName,
+    setDragging,
+    browseFile,
+    dropFile,
+    clearFile,
+    selectCandidate,
+    closeSelection,
+    runMerge,
+    reset
+  }
+}

--- a/src/renderer/src/features/merge/types.ts
+++ b/src/renderer/src/features/merge/types.ts
@@ -1,0 +1,14 @@
+import type { PreparedTranslationInput } from '@/types'
+
+export type SlotKey = 'source' | 'target'
+
+export interface MergeFileSlot {
+  filePath: string | null
+  fileName: string | null
+  lang: string
+  importId: string | null
+  candidateId: string | null
+  prepared: PreparedTranslationInput | null
+  isDragging: boolean
+  isPreparing: boolean
+}

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -4,9 +4,10 @@ import { useNavigate } from 'react-router-dom'
 const SHORTCUTS: Record<string, string> = {
   '1': '/translate',
   '2': '/dictionary',
-  '3': '/extract',
-  '4': '/package',
-  '5': '/settings'
+  '3': '/merge',
+  '4': '/extract',
+  '5': '/package',
+  '6': '/settings'
 }
 
 export function useKeyboardShortcuts(): void {

--- a/src/renderer/src/pages/MergeToolPage.tsx
+++ b/src/renderer/src/pages/MergeToolPage.tsx
@@ -1,0 +1,5 @@
+import { MergeToolScreen } from '@/features/merge/components/MergeToolScreen'
+
+export function MergeToolPage(): React.JSX.Element {
+  return <MergeToolScreen />
+}


### PR DESCRIPTION
## Summary

- Adds a new **Merge Translations** tool (`/merge`) that recovers lost translations by cross-referencing UIDs between an original mod file and a previously translated file, then bulk-inserts matched pairs into the dictionary
- Supports `.xml`, `.pak`, and `.zip` inputs for both slots — same extraction pipeline as the translate page
- Shows an XML selection modal when a pak/zip contains multiple localization files
- Saves matched entries to the dictionary via `repos.dictionary.upsert`, respecting the `language1 < language2` alphabetical invariant and the `modName → mod.name` FK

## What changed

**Backend**
- `src/main/services/merge.service.ts` — new `mergeXmls()`: parses both XMLs, intersects UIDs, decodes entities, upserts to dictionary. Upserts the mod record **before** the dictionary loop to satisfy the FK constraint (`dictionary.modName → mod.name`)
- `src/main/ipc/merge.ipc.ts` — three IPC handlers: `merge:prepareInput`, `merge:discardInput`, `merge:run`. Reuses `prepareTranslationInput`/`discardTranslationInput` from the existing translation-import service
- `src/main/services/translation-import.service.ts` — exports `getStagedCandidate` so merge IPC can resolve candidates without duplicating the staged-imports map
- `src/main/index.ts` — registers `registerMergeHandlers`

**Preload**
- `src/preload/api-types.ts` — adds `MergeApi` and `MergeResult` types
- `src/preload/index.ts` — exposes `window.api.merge` namespace

**Renderer**
- `src/renderer/src/features/merge/` — new feature folder: `useMergeSetup` hook (two file slots with lang, staged import tracking, drag/drop, XML candidate selection, run) + `MergeFileStep`, `MergeNameStep`, `MergeBottomBar`, `MergeToolScreen` components. Reuses `FileInputCard`, `LanguagePicker`, `SetupStepCard`, `XmlSelectionModal` from the translate feature
- `src/renderer/src/pages/MergeToolPage.tsx` — thin page wrapper
- `src/renderer/src/App.tsx` — adds `/merge` route
- `src/renderer/src/components/layout/Sidebar.tsx` — Merge Translations as the 3rd nav item (Ctrl+3); sidebar hover width increased to `w-62` to fit the longer label
- `src/renderer/src/hooks/useKeyboardShortcuts.ts` — shortcut map updated (Ctrl+3 → merge, Ctrl+4 → extract, Ctrl+5 → package, Ctrl+6 → settings)

## Reviewer notes

- No schema changes — uses existing `dictionary` and `mod` tables
- Language codes are loaded from `language.getAll()` on mount, never hardcoded, to match exact case in the DB (`pt-BR`, `zh-CN`, etc.)
- Temp directories from `prepareTranslationInput` are always cleaned up in `merge:run`'s `finally` block
- `pnpm typecheck` and `pnpm build` pass cleanly

## Test plan

- [ ] Navigate to `/merge` via sidebar or Ctrl+3
- [ ] Drop a `.zip` (EN) into slot 1 — verify XML selection modal appears when multiple candidates exist, auto-selects when only one valid candidate
- [ ] Drop a `.zip` (PT-BR) into slot 2
- [ ] Fill mod name, click "Fundir e salvar" — toast shows matched/ignored count
- [ ] Open `/dictionary`, filter by mod name — confirm EN↔PT-BR entries with `uid` populated
- [ ] Repeat merge with same files — `upsert` updates without duplicating
- [ ] `pnpm db:studio` — confirm `language1 < language2` in all new rows