### PR TITLE
fix: dictionary matching

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,5 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
+buildVersion: 1.0.0.1
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/src/main/database/repositories/dictionary.repo.ts
+++ b/src/main/database/repositories/dictionary.repo.ts
@@ -1,7 +1,8 @@
-import { and, desc, eq, or, sql, type SQL } from 'drizzle-orm'
-import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { and, desc, eq, or, type SQL, sql } from 'drizzle-orm'
+import type { drizzle } from 'drizzle-orm/better-sqlite3'
+import { dictionaryTextKey, normalizeDictionaryText } from '../../utils/dictionaryText'
 import { normalizeLangs } from '../../utils/languages'
-import { dictionary, type DictionaryEntry, type NewDictionaryEntry } from '../schema'
+import { type DictionaryEntry, dictionary, type NewDictionaryEntry } from '../schema'
 
 type AppDb = ReturnType<typeof drizzle>
 
@@ -60,15 +61,12 @@ export class DictionaryRepository {
     const safePageSize = Math.max(1, pageSize)
     const where = this.buildFilterWhere(filters)
     const totalRow = where
-      ? (this.db
-          .select({ count: sql<number>`count(*)` })
-          .from(dictionary)
-          .where(where)
-          .get() as { count: number } | undefined)
-      : (this.db
-          .select({ count: sql<number>`count(*)` })
-          .from(dictionary)
-          .get() as { count: number } | undefined)
+      ? (this.db.select({ count: sql<number>`count(*)` }).from(dictionary).where(where).get() as
+          | { count: number }
+          | undefined)
+      : (this.db.select({ count: sql<number>`count(*)` }).from(dictionary).get() as
+          | { count: number }
+          | undefined)
 
     const total = totalRow?.count ?? 0
     const items = this.queryList(filters)
@@ -85,21 +83,16 @@ export class DictionaryRepository {
     sourceText: string
   ): DictionaryEntry | undefined {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
-    const col = swapped ? dictionary.textLanguage2 : dictionary.textLanguage1
-    const normalizedText = sourceText.toLowerCase()
+    const sourceKey = dictionaryTextKey(sourceText)
 
-    return this.db
+    const rows = this.db
       .select()
       .from(dictionary)
-      .where(
-        and(
-          eq(dictionary.language1, l1),
-          eq(dictionary.language2, l2),
-          sql`lower(${col}) = ${normalizedText}`
-        )
-      )
+      .where(and(eq(dictionary.language1, l1), eq(dictionary.language2, l2)))
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .get() as DictionaryEntry | undefined
+      .all() as DictionaryEntry[]
+
+    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
   }
 
   findByModAndText(
@@ -109,11 +102,37 @@ export class DictionaryRepository {
     sourceText: string
   ): DictionaryEntry | undefined {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
-    const col = swapped ? dictionary.textLanguage2 : dictionary.textLanguage1
-    const normalizedText = sourceText.toLowerCase()
+    const sourceKey = dictionaryTextKey(sourceText)
     const normalizedMod = modName.toLowerCase()
 
-    return this.db
+    const rows = this.db
+      .select()
+      .from(dictionary)
+      .where(
+        and(
+          eq(dictionary.language1, l1),
+          eq(dictionary.language2, l2),
+          sql`lower(coalesce(${dictionary.modName}, '')) = ${normalizedMod}`
+        )
+      )
+      .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
+      .all() as DictionaryEntry[]
+
+    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+  }
+
+  findByModUidAndText(
+    modName: string,
+    sourceLang: string,
+    targetLang: string,
+    uid: string,
+    sourceText: string
+  ): DictionaryEntry | undefined {
+    const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
+    const sourceKey = dictionaryTextKey(sourceText)
+    const normalizedMod = modName.toLowerCase()
+
+    const rows = this.db
       .select()
       .from(dictionary)
       .where(
@@ -121,21 +140,36 @@ export class DictionaryRepository {
           eq(dictionary.language1, l1),
           eq(dictionary.language2, l2),
           sql`lower(coalesce(${dictionary.modName}, '')) = ${normalizedMod}`,
-          sql`lower(${col}) = ${normalizedText}`
+          eq(dictionary.uid, uid)
         )
       )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .get() as DictionaryEntry | undefined
+      .all() as DictionaryEntry[]
+
+    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
   }
 
   resolveMatch(params: {
     modName?: string | null
+    uid?: string | null
     sourceLang: string
     targetLang: string
     sourceText: string
   }): { entry: DictionaryEntry; matchType: DictionaryMatchType } | undefined {
     const modName = params.modName?.trim()
+    const uid = params.uid?.trim()
     if (modName) {
+      if (uid) {
+        const byModAndUid = this.findByModUidAndText(
+          modName,
+          params.sourceLang,
+          params.targetLang,
+          uid,
+          params.sourceText
+        )
+        if (byModAndUid) return { entry: byModAndUid, matchType: 'mod-text' }
+      }
+
       const byMod = this.findByModAndText(
         modName,
         params.sourceLang,
@@ -168,8 +202,21 @@ export class DictionaryRepository {
 
   upsert(params: UpsertParams): void {
     const modName = params.modName?.trim()
+    const uid = params.uid?.trim()
 
-    if (modName) {
+    if (modName && uid) {
+      const existing = this.findByModUidAndText(
+        modName,
+        params.sourceLang,
+        params.targetLang,
+        uid,
+        params.sourceText
+      )
+      if (existing) {
+        this.update(existing.id, params)
+        return
+      }
+    } else if (modName) {
       const existing = this.findByModAndText(
         modName,
         params.sourceLang,
@@ -181,11 +228,14 @@ export class DictionaryRepository {
         return
       }
     } else {
-      const existing = this.findUnscopedByText(
-        params.sourceLang,
-        params.targetLang,
-        params.sourceText
-      )
+      const existing = uid
+        ? this.findUnscopedByUidAndText(
+            params.sourceLang,
+            params.targetLang,
+            uid,
+            params.sourceText
+          )
+        : this.findUnscopedByText(params.sourceLang, params.targetLang, params.sourceText)
       if (existing) {
         this.update(existing.id, params)
         return
@@ -213,8 +263,8 @@ export class DictionaryRepository {
       .all() as { t1: string; t2: string }[]
 
     return rows.map((row) => ({
-      source: swapped ? row.t2 : row.t1,
-      target: swapped ? row.t1 : row.t2
+      source: normalizeDictionaryText(swapped ? row.t2 : row.t1),
+      target: normalizeDictionaryText(swapped ? row.t1 : row.t2)
     }))
   }
 
@@ -308,10 +358,34 @@ export class DictionaryRepository {
     sourceText: string
   ): DictionaryEntry | undefined {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
-    const col = swapped ? dictionary.textLanguage2 : dictionary.textLanguage1
-    const normalizedText = sourceText.toLowerCase()
+    const sourceKey = dictionaryTextKey(sourceText)
 
-    return this.db
+    const rows = this.db
+      .select()
+      .from(dictionary)
+      .where(
+        and(
+          eq(dictionary.language1, l1),
+          eq(dictionary.language2, l2),
+          sql`${dictionary.modName} is null`
+        )
+      )
+      .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
+      .all() as DictionaryEntry[]
+
+    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+  }
+
+  private findUnscopedByUidAndText(
+    sourceLang: string,
+    targetLang: string,
+    uid: string,
+    sourceText: string
+  ): DictionaryEntry | undefined {
+    const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
+    const sourceKey = dictionaryTextKey(sourceText)
+
+    const rows = this.db
       .select()
       .from(dictionary)
       .where(
@@ -319,18 +393,20 @@ export class DictionaryRepository {
           eq(dictionary.language1, l1),
           eq(dictionary.language2, l2),
           sql`${dictionary.modName} is null`,
-          sql`lower(${col}) = ${normalizedText}`
+          eq(dictionary.uid, uid)
         )
       )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .get() as DictionaryEntry | undefined
+      .all() as DictionaryEntry[]
+
+    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
   }
 
   private toValues(params: UpsertParams): NewDictionaryEntry {
     const [l1, l2, swapped] = normalizeLangs(params.sourceLang, params.targetLang)
-    const [text1, text2] = swapped
-      ? [params.targetText, params.sourceText]
-      : [params.sourceText, params.targetText]
+    const sourceText = normalizeDictionaryText(params.sourceText)
+    const targetText = normalizeDictionaryText(params.targetText)
+    const [text1, text2] = swapped ? [targetText, sourceText] : [sourceText, targetText]
 
     return {
       language1: l1,
@@ -340,5 +416,9 @@ export class DictionaryRepository {
       modName: params.modName?.trim() || null,
       uid: params.uid?.trim() || null
     }
+  }
+
+  private sourceTextKey(entry: DictionaryEntry, swapped: boolean): string {
+    return dictionaryTextKey(swapped ? entry.textLanguage2 : entry.textLanguage1)
   }
 }

--- a/src/main/ipc/xml.ipc.ts
+++ b/src/main/ipc/xml.ipc.ts
@@ -58,7 +58,8 @@ async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise
       await unpackMod(inputPath, tempDir)
       const sourceFolder = languageFolder(repos, sourceLang)
       const xmlFiles = findLocalizationXmls(tempDir, sourceFolder)
-      if (xmlFiles.length === 0) throw new Error(`No XML found for language "${sourceFolder}" in pak`)
+      if (xmlFiles.length === 0)
+        throw new Error(`No XML found for language "${sourceFolder}" in pak`)
       xmlPath = xmlFiles[0]
     } else if (ext === '.zip') {
       const archiveDir = createTempDir('icosa_zip')
@@ -72,7 +73,8 @@ async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise
       await unpackMod(pakFiles[0], unpackedDir)
       const sourceFolder = languageFolder(repos, sourceLang)
       const xmlFiles = findLocalizationXmls(unpackedDir, sourceFolder)
-      if (xmlFiles.length === 0) throw new Error(`No XML found for language "${sourceFolder}" in pak`)
+      if (xmlFiles.length === 0)
+        throw new Error(`No XML found for language "${sourceFolder}" in pak`)
       xmlPath = xmlFiles[0]
     } else {
       throw new Error(`Unsupported file type: ${ext}. Use .xml, .pak, or .zip`)
@@ -84,6 +86,7 @@ async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise
       const uiEntry = toUiEntry(entry)
       const match = repos.dictionary.resolveMatch({
         modName: modName ?? null,
+        uid: entry.contentuid,
         sourceLang,
         targetLang,
         sourceText: entry.text

--- a/src/main/pipelines/base.pipeline.ts
+++ b/src/main/pipelines/base.pipeline.ts
@@ -1,6 +1,6 @@
-import type { BrowserWindow } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
+import type { BrowserWindow } from 'electron'
 import { getDb } from '../database/connection'
 import type { SimilarityRow } from '../database/repositories/dictionary.repo'
 import {
@@ -119,12 +119,7 @@ export abstract class BasePipeline {
           this.emitProgress(current, total, entry.text, targetText)
         }
 
-        const outXmlPath = path.join(
-          modRoot,
-          'Localization',
-          targetFolder,
-          path.basename(xmlPath)
-        )
+        const outXmlPath = path.join(modRoot, 'Localization', targetFolder, path.basename(xmlPath))
         writeLocalizationXml(translated, outXmlPath)
       }
 
@@ -202,6 +197,7 @@ export abstract class BasePipeline {
 
     const match = this.dictRepo.resolveMatch({
       modName,
+      uid: entry.contentuid || null,
       sourceLang,
       targetLang,
       sourceText: entry.text
@@ -305,4 +301,3 @@ function findMetaLsx(dir: string): string | null {
   }
   return null
 }
-

--- a/src/main/services/merge.service.ts
+++ b/src/main/services/merge.service.ts
@@ -1,6 +1,6 @@
 import type { RepositoryRegistry } from '../database/repositories/registry'
-import { decodeEntities } from './xml-entities.service'
-import { parseLocalizationXml } from './xml-parser.service'
+import { normalizeDictionaryText } from '../utils/dictionaryText'
+import { type LocalizationEntry, parseLocalizationXml } from './xml-parser.service'
 
 export interface MergeXmlsParams {
   sourceXmlPath: string
@@ -20,22 +20,18 @@ export function mergeXmls(repos: RepositoryRegistry, params: MergeXmlsParams): M
   const sourceEntries = parseLocalizationXml(params.sourceXmlPath)
   const targetEntries = parseLocalizationXml(params.targetXmlPath)
 
-  const sourceMap = new Map<string, string>()
-  for (const entry of sourceEntries) sourceMap.set(entry.contentuid, entry.text)
+  const targetBuckets = groupByUid(targetEntries)
 
-  const targetMap = new Map<string, string>()
-  for (const entry of targetEntries) targetMap.set(entry.contentuid, entry.text)
-
-  // Mod must exist before dictionary entries reference it via FK (modName → mod.name).
+  // Mod must exist before dictionary entries reference it via FK (modName -> mod.name).
   repos.mod.upsert(params.modName)
 
   let matched = 0
-  for (const [uid, rawSource] of sourceMap) {
-    const rawTarget = targetMap.get(uid)
-    if (rawTarget === undefined) continue
+  for (const sourceEntry of sourceEntries) {
+    const targetEntry = targetBuckets.get(sourceEntry.contentuid)?.shift()
+    if (!targetEntry) continue
 
-    const sourceText = decodeEntities(rawSource).trim()
-    const targetText = decodeEntities(rawTarget).trim()
+    const sourceText = normalizeDictionaryText(sourceEntry.text)
+    const targetText = normalizeDictionaryText(targetEntry.text)
     if (!sourceText || !targetText) continue
 
     repos.dictionary.upsert({
@@ -44,13 +40,13 @@ export function mergeXmls(repos: RepositoryRegistry, params: MergeXmlsParams): M
       sourceText,
       targetText,
       modName: params.modName,
-      uid
+      uid: sourceEntry.contentuid
     })
     matched++
   }
 
-  const sourceOnly = countMissing(sourceMap, targetMap)
-  const targetOnly = countMissing(targetMap, sourceMap)
+  const sourceOnly = countMissingOccurrences(sourceEntries, targetEntries)
+  const targetOnly = countMissingOccurrences(targetEntries, sourceEntries)
 
   if (matched > 0) {
     repos.mod.upsert(params.modName, { totalStrings: matched })
@@ -59,8 +55,26 @@ export function mergeXmls(repos: RepositoryRegistry, params: MergeXmlsParams): M
   return { matched, sourceOnly, targetOnly }
 }
 
-function countMissing(a: Map<string, string>, b: Map<string, string>): number {
+function groupByUid(entries: LocalizationEntry[]): Map<string, LocalizationEntry[]> {
+  const buckets = new Map<string, LocalizationEntry[]>()
+  for (const entry of entries) {
+    const bucket = buckets.get(entry.contentuid) ?? []
+    bucket.push(entry)
+    buckets.set(entry.contentuid, bucket)
+  }
+  return buckets
+}
+
+function countMissingOccurrences(a: LocalizationEntry[], b: LocalizationEntry[]): number {
+  const aCounts = countUids(a)
+  const bCounts = countUids(b)
   let count = 0
-  for (const key of a.keys()) if (!b.has(key)) count++
+  for (const [uid, total] of aCounts) count += Math.max(0, total - (bCounts.get(uid) ?? 0))
   return count
+}
+
+function countUids(entries: LocalizationEntry[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const entry of entries) counts.set(entry.contentuid, (counts.get(entry.contentuid) ?? 0) + 1)
+  return counts
 }

--- a/src/main/utils/dictionaryText.ts
+++ b/src/main/utils/dictionaryText.ts
@@ -1,0 +1,9 @@
+import { decodeEntities } from '../services/xml-entities.service'
+
+export function normalizeDictionaryText(text: string): string {
+  return decodeEntities(text).trim()
+}
+
+export function dictionaryTextKey(text: string): string {
+  return normalizeDictionaryText(text).toLowerCase()
+}


### PR DESCRIPTION
## Summary

- Fix dictionary matching by normalizing XML entities before comparing and saving entries.
- Preserve duplicate UID rows during dictionary merge by matching UID occurrences instead of overwriting with `Map`.
- Bump build metadata to `1.0.0.1`.

## Validation

- `pnpm typecheck`
- `biome check` on changed files
- Verified `data/english.xml` + `data/ptbr.xml`: merge now creates 685 UID/text identities instead of 665.
- Verified `data/5e`: duplicate UID rows are preserved and normalized dictionary application matches XML entity variants.
