### PR TITLE
feat: translate multi xml import

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ PLANNING.md
 .env
 *.md
 data/
+*.txt
+*.xml

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.0.0.1
+buildVersion: 1.1.1
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.0.1",
+  "version": "1.1.1",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/src/main/ipc/mod.ipc.ts
+++ b/src/main/ipc/mod.ipc.ts
@@ -89,7 +89,7 @@ export function registerModHandlers(repos: RepositoryRegistry): void {
     'mod:completeTranslationImport',
     (
       _event,
-      params: { importId: string; candidateId: string; modName: string; targetLang: string }
+      params: { importId: string; candidateIds: string[]; modName: string; targetLang: string }
     ) => {
       return completeImport(repos, params)
     }

--- a/src/main/services/translation-import.service.ts
+++ b/src/main/services/translation-import.service.ts
@@ -149,7 +149,7 @@ export function completeTranslationImport(
   repos: RepositoryRegistry,
   params: {
     importId: string
-    candidateId: string
+    candidateIds: string[]
     modName: string
     targetLang: string
   }
@@ -157,20 +157,24 @@ export function completeTranslationImport(
   const staged = stagedImports.get(params.importId)
   if (!staged) throw new Error('Import session expired. Select the file again.')
 
-  const candidate = staged.candidates.find((item) => item.id === params.candidateId)
-  if (!candidate) throw new Error('Selected XML was not found')
-  if (!candidate.valid) throw new Error('Selected XML has an invalid format')
+  const requestedIds = new Set(params.candidateIds)
+  if (requestedIds.size === 0) throw new Error('No valid XML found')
+
+  const candidates = staged.candidates.filter((candidate) => requestedIds.has(candidate.id))
+  if (candidates.length !== requestedIds.size) throw new Error('Selected XML was not found')
+  if (candidates.some((candidate) => !candidate.valid)) {
+    throw new Error('Selected XML has an invalid format')
+  }
 
   const modDir = getStoredModDir(params.modName)
   fs.mkdirSync(modDir, { recursive: true })
 
-  const xmlPath = path.join(modDir, path.basename(candidate.absolutePath))
-  if (path.resolve(candidate.absolutePath) !== path.resolve(xmlPath)) {
-    fs.copyFileSync(candidate.absolutePath, xmlPath)
-  }
+  const mergedEntries = candidates.flatMap((candidate) => parseLocalizationXml(candidate.absolutePath))
+  const xmlPath = path.join(modDir, 'translation_merged.xml')
+  writeLocalizationXml(mergedEntries, xmlPath)
 
   repos.mod.upsert(params.modName, {
-    totalStrings: candidate.stringCount,
+    totalStrings: mergedEntries.length,
     lastFilePath: xmlPath
   })
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -291,7 +291,7 @@ export interface ModApi {
   discardTranslationInput(params: { importId: string }): Promise<{ success: boolean }>
   completeTranslationImport(params: {
     importId: string
-    candidateId: string
+    candidateIds: string[]
     modName: string
     targetLang: string
   }): Promise<CompleteTranslationImportResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -192,7 +192,7 @@ const api: AppApi = {
 
     completeTranslationImport: (params: {
       importId: string
-      candidateId: string
+      candidateIds: string[]
       modName: string
       targetLang: string
     }) => ipcRenderer.invoke('mod:completeTranslationImport', params),

--- a/src/renderer/src/features/merge/components/MergeToolScreen.tsx
+++ b/src/renderer/src/features/merge/components/MergeToolScreen.tsx
@@ -118,7 +118,8 @@ function PendingSelectionModal({
     <XmlSelectionModal
       prepared={prepared}
       onCancel={onCancel}
-      onSelect={async (candidateId) => {
+      onSelect={async ([candidateId]) => {
+        if (!candidateId) return
         onSelect(slotKey, candidateId)
       }}
     />

--- a/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
@@ -189,10 +189,11 @@ export function TranslateIdleScreen({ session }: TranslateIdleScreenProps): Reac
       {importFlow.preparedImport && (
         <XmlSelectionModal
           prepared={importFlow.preparedImport}
+          selectionMode="multi"
           onCancel={importFlow.closeImportModal}
-          onSelect={(candidateId) =>
+          onSelect={(candidateIds) =>
             importFlow.preparedImport
-              ? importFlow.completeImport(importFlow.preparedImport.importId, candidateId)
+              ? importFlow.completeImport(importFlow.preparedImport.importId, candidateIds)
               : Promise.resolve()
           }
         />

--- a/src/renderer/src/features/translate/components/XmlCandidateCard.tsx
+++ b/src/renderer/src/features/translate/components/XmlCandidateCard.tsx
@@ -5,6 +5,7 @@ import type { TranslationXmlCandidate } from '@/types'
 interface XmlCandidateCardProps {
   candidate: TranslationXmlCandidate
   index: number
+  selectionMode?: 'single' | 'multi'
   selected: boolean
   onSelect: () => void
 }
@@ -12,6 +13,7 @@ interface XmlCandidateCardProps {
 export function XmlCandidateCard({
   candidate,
   index,
+  selectionMode = 'single',
   selected,
   onSelect
 }: XmlCandidateCardProps): React.JSX.Element {
@@ -52,11 +54,19 @@ export function XmlCandidateCard({
         </div>
         <div
           className={cn(
-            'w-4.5 h-4.5 rounded-full border flex items-center justify-center shrink-0',
+            'w-4.5 h-4.5 border flex items-center justify-center shrink-0',
+            selectionMode === 'multi' ? 'rounded-[4px]' : 'rounded-full',
             selected ? 'border-amber-400' : 'border-neutral-600'
           )}
         >
-          {selected && <div className="w-2 h-2 rounded-full bg-amber-400" />}
+          {selected && (
+            <div
+              className={cn(
+                'bg-amber-400',
+                selectionMode === 'multi' ? 'h-2.5 w-2.5 rounded-[2px]' : 'h-2 w-2 rounded-full'
+              )}
+            />
+          )}
         </div>
       </div>
     </button>

--- a/src/renderer/src/features/translate/components/XmlSelectionModal.tsx
+++ b/src/renderer/src/features/translate/components/XmlSelectionModal.tsx
@@ -10,27 +10,53 @@ import { XmlCandidateCard } from './XmlCandidateCard'
 
 interface XmlSelectionModalProps {
   prepared: PreparedTranslationInput
+  selectionMode?: 'single' | 'multi'
   onCancel: () => Promise<void>
-  onSelect: (candidateId: string) => Promise<void>
+  onSelect: (candidateIds: string[]) => Promise<void>
 }
 
 export function XmlSelectionModal({
   prepared,
+  selectionMode = 'single',
   onCancel,
   onSelect
 }: XmlSelectionModalProps): React.JSX.Element {
   const { t } = useAppTranslation(['translate', 'common'])
-  const [selectedId, setSelectedId] = useState(
-    prepared.candidates.find((candidate) => candidate.valid)?.id ?? ''
+  const firstValidId = prepared.candidates.find((candidate) => candidate.valid)?.id ?? ''
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(
+    () => new Set(firstValidId ? [firstValidId] : [])
   )
   const [loading, setLoading] = useState(false)
-  const selected = prepared.candidates.find((candidate) => candidate.id === selectedId)
+  const validCandidateIds = prepared.candidates
+    .filter((candidate) => candidate.valid)
+    .map((candidate) => candidate.id)
+  const selectedValidIds = validCandidateIds.filter((id) => selectedIds.has(id))
+  const allValidSelected =
+    validCandidateIds.length > 0 && validCandidateIds.every((id) => selectedIds.has(id))
+
+  const selectCandidate = (candidateId: string) => {
+    if (selectionMode === 'single') {
+      setSelectedIds(new Set([candidateId]))
+      return
+    }
+
+    setSelectedIds((prev) => {
+      const next = new Set(prev)
+      if (next.has(candidateId)) next.delete(candidateId)
+      else next.add(candidateId)
+      return next
+    })
+  }
+
+  const selectAllValid = () => {
+    setSelectedIds(new Set(validCandidateIds))
+  }
 
   const handleSelect = async () => {
-    if (!selected?.valid) return
+    if (selectedValidIds.length === 0) return
     setLoading(true)
     try {
-      await onSelect(selected.id)
+      await onSelect(selectedValidIds)
     } catch (err) {
       toast.error(getLocalizedErrorMessage(err, t))
     } finally {
@@ -57,14 +83,37 @@ export function XmlSelectionModal({
         </div>
 
         <div className="flex-1 overflow-y-auto icosa-scroll p-5">
+          {selectionMode === 'multi' && (
+            <div className="mb-3 flex items-center justify-between gap-3">
+              <span className="font-mono text-[11px] text-neutral-500">
+                {t('xmlSelection.selectedCount', {
+                  ns: 'translate',
+                  count: selectedValidIds.length
+                })}
+              </span>
+              <button
+                type="button"
+                className={cn(
+                  btnBase,
+                  (allValidSelected || loading || validCandidateIds.length === 0) &&
+                    'opacity-40 cursor-not-allowed'
+                )}
+                disabled={allValidSelected || loading || validCandidateIds.length === 0}
+                onClick={selectAllValid}
+              >
+                {t('xmlSelection.selectAll', { ns: 'translate' })}
+              </button>
+            </div>
+          )}
           <div className="flex flex-col gap-2.5">
             {prepared.candidates.map((candidate, index) => (
               <XmlCandidateCard
                 key={candidate.id}
                 candidate={candidate}
                 index={index}
-                selected={candidate.id === selectedId}
-                onSelect={() => setSelectedId(candidate.id)}
+                selectionMode={selectionMode}
+                selected={selectedIds.has(candidate.id)}
+                onSelect={() => selectCandidate(candidate.id)}
               />
             ))}
           </div>
@@ -78,9 +127,9 @@ export function XmlSelectionModal({
             type="button"
             className={cn(
               btnPrimary,
-              (!selected?.valid || loading) && 'opacity-40 cursor-not-allowed'
+              (selectedValidIds.length === 0 || loading) && 'opacity-40 cursor-not-allowed'
             )}
-            disabled={!selected?.valid || loading}
+            disabled={selectedValidIds.length === 0 || loading}
             onClick={handleSelect}
           >
             {loading ? <Loader2 size={13} className="animate-spin" /> : <Check size={13} />}

--- a/src/renderer/src/features/translate/hooks/useTranslationImport.ts
+++ b/src/renderer/src/features/translate/hooks/useTranslationImport.ts
@@ -22,10 +22,10 @@ export function useTranslationImport({
   const [isPreparing, setIsPreparing] = useState(false)
   const [preparedImport, setPreparedImport] = useState<PreparedTranslationInput | null>(null)
 
-  const completeImport = async (importId: string, candidateId: string) => {
+  const completeImport = async (importId: string, candidateIds: string[]) => {
     const result = await window.api.mod.completeTranslationImport({
       importId,
-      candidateId,
+      candidateIds,
       modName,
       targetLang
     })
@@ -57,7 +57,7 @@ export function useTranslationImport({
         return
       }
 
-      await completeImport(prepared.importId, candidate.id)
+      await completeImport(prepared.importId, [candidate.id])
     } catch (err) {
       toast.error(getLocalizedErrorMessage(err, t))
     } finally {

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -102,7 +102,10 @@
   "xmlSelection": {
     "title": "Select XML",
     "description": "Files without content tags appear as Invalid format.",
+    "selectAll": "Select all XMLs",
     "useXml": "Use XML",
+    "selectedCount_one": "{{count}} XML selected",
+    "selectedCount_other": "{{count}} XMLs selected",
     "strings": "{{count}} strings"
   },
   "loaded": {

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -102,7 +102,10 @@
   "xmlSelection": {
     "title": "Selecionar XML",
     "description": "Arquivos sem tags de conteúdo aparecem como Formato inválido.",
+    "selectAll": "Selecionar todos os XMLs",
     "useXml": "Usar XML",
+    "selectedCount_one": "{{count}} XML selecionado",
+    "selectedCount_other": "{{count}} XMLs selecionados",
     "strings": "{{count}} strings"
   },
   "loaded": {


### PR DESCRIPTION
This pull request introduces multi-file selection and merging for XML translation imports, allowing users to select and merge multiple valid XML files during the import process. The changes update the backend, API, and UI to support this workflow, including new selection modes, improved user feedback, and localization updates.

**Multi-file XML import and merging:**

* Updated the backend (`completeTranslationImport` in `translation-import.service.ts`) to accept multiple XML candidate IDs, merge their contents, and save the merged result, with error handling for invalid or missing files.
* Changed the IPC handler, preload API (`api-types.ts`, `index.ts`), and hook (`useTranslationImport.ts`) to support arrays of candidate IDs instead of a single ID, ensuring end-to-end multi-file support. [[1]](diffhunk://#diff-e5972fd6b9af68a7b8feeb1742270dbb594d785e121b6a726b972915089e1590L92-R92) [[2]](diffhunk://#diff-be9ee57be5e5a9247097ac3056f6dad4cd8e936620df0747a866d19b2feeb7d6L294-R294) [[3]](diffhunk://#diff-ab22c748afd4538220cdeba0013847231dc39f27e2b94e71fb21002712d375c0L195-R195) [[4]](diffhunk://#diff-549f480618f356ccf57512425be49fd34b1964a29bed139adec9ce6476fb07deL25-R28) [[5]](diffhunk://#diff-549f480618f356ccf57512425be49fd34b1964a29bed139adec9ce6476fb07deL60-R60)

**User interface enhancements:**

* Refactored `XmlSelectionModal` and `XmlCandidateCard` components to support both single and multi-selection modes, including a "Select all" button, selection count display, and visual distinction between single and multi-select. [[1]](diffhunk://#diff-629d9e81b6e0ad68811af1a5ef54805ea0a259921e6e9249c3506f0276cd41b5R13-R59) [[2]](diffhunk://#diff-629d9e81b6e0ad68811af1a5ef54805ea0a259921e6e9249c3506f0276cd41b5R86-R116) [[3]](diffhunk://#diff-629d9e81b6e0ad68811af1a5ef54805ea0a259921e6e9249c3506f0276cd41b5L81-R132) [[4]](diffhunk://#diff-3bdc03c42e0245506ecf5abc1a7173e0981dcf661cd9c9e599d193a335c73e7aR8-R16) [[5]](diffhunk://#diff-3bdc03c42e0245506ecf5abc1a7173e0981dcf661cd9c9e599d193a335c73e7aL55-R69)
* Updated modal usage in translation and merge screens to pass and handle arrays of candidate IDs, and enable multi-selection where appropriate. [[1]](diffhunk://#diff-ef39061dede56b79538e4d310e26b7f53837ff1c5813d5c4d17d1a8c09c6f176L121-R122) [[2]](diffhunk://#diff-38455d9753967532b94d0779dd094e3e4bcf943ff3cefcba9e4ee042306169c3R192-R196)

**Localization updates:**

* Added and updated strings for multi-selection UI in English and Portuguese translation files, including "Select all" and selection count messages. [[1]](diffhunk://#diff-dba25cfda796a7e1734cc363d4b3f390c7144bf1d7746b3aa351c65291ee595eR105-R108) [[2]](diffhunk://#diff-c5a8f0f2ba3d18db2dc8c741d4f4634d4a7557df754db068270fbf32d4c41381R105-R108)

**Versioning:**

* Bumped the application version to 1.1.1 in both `package.json` and `electron-builder.yml` to reflect the new feature. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-abfd13c4441842dc2fc303311c40908ecd004ecec4c4bb5827c366b454a1f721L3-R3)