### PR TITLE
feat(perf): large-data performance — virtualization, pagination, filter-based selection

### DIFF
--- a/drizzle/0005_nostalgic_black_crow.sql
+++ b/drizzle/0005_nostalgic_black_crow.sql
@@ -1,0 +1,3 @@
+CREATE INDEX `dictionary_langs_idx` ON `dictionary` (`language1`,`language2`);--> statement-breakpoint
+CREATE INDEX `dictionary_langs_mod_idx` ON `dictionary` (`language1`,`language2`,`mod_name`);--> statement-breakpoint
+CREATE INDEX `dictionary_mod_idx` ON `dictionary` (`mod_name`);

--- a/drizzle/meta/0004_snapshot.json
+++ b/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,414 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "5e38cc3b-71f7-4e31-82a4-157628bc2c60",
+  "prevId": "bd11751d-8c78-4d4d-9253-416ac9b07336",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dictionary": {
+      "name": "dictionary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "language1": {
+          "name": "language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language2": {
+          "name": "language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1": {
+          "name": "text_language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language2": {
+          "name": "text_language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mod_name": {
+          "name": "mod_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "dictionary_language1_language_code_fk": {
+          "name": "dictionary_language1_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language1"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_language2_language_code_fk": {
+          "name": "dictionary_language2_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language2"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_mod_name_mod_name_fk": {
+          "name": "dictionary_mod_name_mod_name_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language": {
+      "name": "language",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "language_code_unique": {
+          "name": "language_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod": {
+      "name": "mod",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_strings": {
+          "name": "total_strings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_file_path": {
+          "name": "last_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_name_unique": {
+          "name": "mod_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod_meta": {
+      "name": "mod_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta_file_path": {
+          "name": "meta_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_major": {
+          "name": "version_major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_minor": {
+          "name": "version_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_revision": {
+          "name": "version_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_build": {
+          "name": "version_build",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version64": {
+          "name": "version64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_meta_mod_id_unique": {
+          "name": "mod_meta_mod_id_unique",
+          "columns": [
+            "mod_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mod_meta_mod_id_mod_id_fk": {
+          "name": "mod_meta_mod_id_mod_id_fk",
+          "tableFrom": "mod_meta",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/0005_snapshot.json
+++ b/drizzle/meta/0005_snapshot.json
@@ -1,0 +1,439 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "23af3325-94c1-4d46-ac65-2e16348dd6a8",
+  "prevId": "5e38cc3b-71f7-4e31-82a4-157628bc2c60",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dictionary": {
+      "name": "dictionary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "language1": {
+          "name": "language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language2": {
+          "name": "language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1": {
+          "name": "text_language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language2": {
+          "name": "text_language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mod_name": {
+          "name": "mod_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "dictionary_langs_idx": {
+          "name": "dictionary_langs_idx",
+          "columns": [
+            "language1",
+            "language2"
+          ],
+          "isUnique": false
+        },
+        "dictionary_langs_mod_idx": {
+          "name": "dictionary_langs_mod_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_mod_idx": {
+          "name": "dictionary_mod_idx",
+          "columns": [
+            "mod_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "dictionary_language1_language_code_fk": {
+          "name": "dictionary_language1_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language1"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_language2_language_code_fk": {
+          "name": "dictionary_language2_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language2"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_mod_name_mod_name_fk": {
+          "name": "dictionary_mod_name_mod_name_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language": {
+      "name": "language",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "language_code_unique": {
+          "name": "language_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod": {
+      "name": "mod",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_strings": {
+          "name": "total_strings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_file_path": {
+          "name": "last_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_name_unique": {
+          "name": "mod_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod_meta": {
+      "name": "mod_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta_file_path": {
+          "name": "meta_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_major": {
+          "name": "version_major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_minor": {
+          "name": "version_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_revision": {
+          "name": "version_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_build": {
+          "name": "version_build",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version64": {
+          "name": "version64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_meta_mod_id_unique": {
+          "name": "mod_meta_mod_id_unique",
+          "columns": [
+            "mod_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mod_meta_mod_id_mod_id_fk": {
+          "name": "mod_meta_mod_id_mod_id_fk",
+          "tableFrom": "mod_meta",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1778187600000,
       "tag": "0004_drop_dictionary_uid_index",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "6",
+      "when": 1778975652088,
+      "tag": "0005_nostalgic_black_crow",
+      "breakpoints": true
     }
   ]
 }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.1.1
+buildVersion: 1.2.0
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
   "dependencies": {
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
+    "@tanstack/react-virtual": "^3.13.24",
     "adm-zip": "^0.5.17",
     "better-sqlite3": "^12.9.0",
     "clsx": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@electron-toolkit/utils':
         specifier: ^4.0.0
         version: 4.0.0(electron@39.8.9)
+      '@tanstack/react-virtual':
+        specifier: ^3.13.24
+        version: 3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       adm-zip:
         specifier: ^0.5.17
         version: 0.5.17
@@ -1145,6 +1148,15 @@ packages:
     resolution: {integrity: sha512-pCvohwOCspk3ZFn6eJzrrX3g4n2JY73H6MmYC87XfGPyTty4YsCjYTMArRZm/zOI8dIt3+EcrLHAFPe5A4bgtw==}
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
+
+  '@tanstack/react-virtual@3.13.24':
+    resolution: {integrity: sha512-aIJvz5OSkhNIhZIpYivrxrPTKYsjW9Uzy+sP/mx0S3sev2HyvPb7xmjbYvokzEpfgYHy/HjzJ2zFAETuUfgCpg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  '@tanstack/virtual-core@3.14.0':
+    resolution: {integrity: sha512-JLANqGy/D6k4Ujmh8Tr25lGimuOXNiaVyXaCAZS0W+1390sADdGnyUdSWNIfd49gebtIxGMij4IktRVzrdr12Q==}
 
   '@types/adm-zip@0.5.8':
     resolution: {integrity: sha512-RVVH7QvZYbN+ihqZ4kX/dMiowf6o+Jk1fNwiSdx0NahBJLU787zkULhGhJM8mf/obmLGmgdMM0bXsQTmyfbR7Q==}
@@ -3436,6 +3448,14 @@ snapshots:
       '@tailwindcss/oxide': 4.2.4
       tailwindcss: 4.2.4
       vite: 7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0)
+
+  '@tanstack/react-virtual@3.13.24(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@tanstack/virtual-core': 3.14.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+
+  '@tanstack/virtual-core@3.14.0': {}
 
   '@types/adm-zip@0.5.8':
     dependencies:

--- a/src/main/database/repositories/dictionary.repo.ts
+++ b/src/main/database/repositories/dictionary.repo.ts
@@ -296,6 +296,50 @@ export class DictionaryRepository {
     this.db.delete(dictionary).where(eq(dictionary.id, id)).run()
   }
 
+  deleteByFilter(filters: DictionaryFilters): { deleted: number } {
+    const where = this.buildFilterWhere(filters)
+    const result = (
+      where ? this.db.delete(dictionary).where(where) : this.db.delete(dictionary)
+    ).run() as { changes: number }
+    return { deleted: result.changes }
+  }
+
+  updateTextByFilter(
+    filters: DictionaryFilters,
+    patch: { findText: string; replaceText: string; column: 'language1' | 'language2' }
+  ): { updated: number } {
+    const { sourceLang, targetLang } = filters
+    let swapped = false
+    if (sourceLang && targetLang) {
+      ;[, , swapped] = normalizeLangs(sourceLang, targetLang)
+    }
+
+    // user's 'language1' (source) -> textLanguage1 when not swapped, textLanguage2 when swapped
+    const useL1 = (patch.column === 'language1') !== swapped
+    const filterWhere = this.buildFilterWhere(filters)
+    const { findText, replaceText } = patch
+
+    if (useL1) {
+      const likeWhere = sql`${dictionary.textLanguage1} like ${`%${findText}%`}`
+      const finalWhere = filterWhere ? (and(filterWhere, likeWhere) as SQL) : likeWhere
+      const result = this.db
+        .update(dictionary)
+        .set({ textLanguage1: sql`replace(${dictionary.textLanguage1}, ${findText}, ${replaceText})` })
+        .where(finalWhere)
+        .run() as { changes: number }
+      return { updated: result.changes }
+    }
+
+    const likeWhere = sql`${dictionary.textLanguage2} like ${`%${findText}%`}`
+    const finalWhere = filterWhere ? (and(filterWhere, likeWhere) as SQL) : likeWhere
+    const result = this.db
+      .update(dictionary)
+      .set({ textLanguage2: sql`replace(${dictionary.textLanguage2}, ${findText}, ${replaceText})` })
+      .where(finalWhere)
+      .run() as { changes: number }
+    return { updated: result.changes }
+  }
+
   private queryList(filters: DictionaryFilters) {
     const where = this.buildFilterWhere(filters)
     const query = this.db.select().from(dictionary)

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -1,4 +1,4 @@
-import { sqliteTable, text, integer } from 'drizzle-orm/sqlite-core'
+import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
 
 const timestamps = {
@@ -43,20 +43,32 @@ export const modMeta = sqliteTable('mod_meta', {
 
 // Invariant: language1 < language2 (alphabetically sorted) - prevents mirrored duplicates.
 // UID is metadata only. Matching and persistence are based on mod + source text, then source text.
-export const dictionary = sqliteTable('dictionary', {
-  id: integer('id').primaryKey({ autoIncrement: true }),
-  language1: text('language1')
-    .notNull()
-    .references(() => language.code),
-  language2: text('language2')
-    .notNull()
-    .references(() => language.code),
-  textLanguage1: text('text_language1').notNull(),
-  textLanguage2: text('text_language2').notNull(),
-  modName: text('mod_name').references(() => mod.name),
-  uid: text('uid'),
-  ...timestamps
-})
+export const dictionary = sqliteTable(
+  'dictionary',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    language1: text('language1')
+      .notNull()
+      .references(() => language.code),
+    language2: text('language2')
+      .notNull()
+      .references(() => language.code),
+    textLanguage1: text('text_language1').notNull(),
+    textLanguage2: text('text_language2').notNull(),
+    modName: text('mod_name').references(() => mod.name),
+    uid: text('uid'),
+    ...timestamps
+  },
+  (table) => ({
+    dictionary_langs_idx: index('dictionary_langs_idx').on(table.language1, table.language2),
+    dictionary_langs_mod_idx: index('dictionary_langs_mod_idx').on(
+      table.language1,
+      table.language2,
+      table.modName
+    ),
+    dictionary_mod_idx: index('dictionary_mod_idx').on(table.modName)
+  })
+)
 
 export const config = sqliteTable('config', {
   key: text('key').primaryKey(),

--- a/src/main/ipc/dictionary.ipc.ts
+++ b/src/main/ipc/dictionary.ipc.ts
@@ -100,6 +100,24 @@ export function registerDictionaryHandlers(repos: RepositoryRegistry): void {
     return { success: true }
   })
 
+  ipcMain.handle('dictionary:deleteByFilter', (_event, filters: DictionaryFilters) =>
+    repos.dictionary.deleteByFilter(filters)
+  )
+
+  ipcMain.handle(
+    'dictionary:replaceByFilter',
+    (
+      _event,
+      {
+        filters,
+        patch
+      }: {
+        filters: DictionaryFilters
+        patch: { findText: string; replaceText: string; column: 'language1' | 'language2' }
+      }
+    ) => repos.dictionary.updateTextByFilter(filters, patch)
+  )
+
   ipcMain.handle(
     'dictionary:similar',
     (

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -264,6 +264,11 @@ export interface DictionaryApi {
     lang2: string
     limit?: number
   }): Promise<SimilarEntry[]>
+  deleteByFilter(filters: DictionaryFilters): Promise<{ deleted: number }>
+  replaceByFilter(
+    filters: DictionaryFilters,
+    patch: { findText: string; replaceText: string; column: 'language1' | 'language2' }
+  ): Promise<{ updated: number }>
 }
 
 export interface LanguageApi {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -142,7 +142,20 @@ const api: AppApi = {
     }): Promise<{ success: boolean }> => ipcRenderer.invoke('dictionary:export', params),
 
     similar: (params: { text: string; lang1: string; lang2: string; limit?: number }) =>
-      ipcRenderer.invoke('dictionary:similar', params)
+      ipcRenderer.invoke('dictionary:similar', params),
+
+    deleteByFilter: (filters: {
+      text?: string
+      modName?: string
+      sourceLang?: string
+      targetLang?: string
+    }): Promise<{ deleted: number }> => ipcRenderer.invoke('dictionary:deleteByFilter', filters),
+
+    replaceByFilter: (
+      filters: { text?: string; modName?: string; sourceLang?: string; targetLang?: string },
+      patch: { findText: string; replaceText: string; column: 'language1' | 'language2' }
+    ): Promise<{ updated: number }> =>
+      ipcRenderer.invoke('dictionary:replaceByFilter', { filters, patch })
   },
 
   language: {

--- a/src/renderer/src/components/translation/AlreadyTranslatedDialog.tsx
+++ b/src/renderer/src/components/translation/AlreadyTranslatedDialog.tsx
@@ -1,0 +1,62 @@
+import { AlertTriangle } from 'lucide-react'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+
+interface AlreadyTranslatedDialogProps {
+  open: boolean
+  translatedCount: number
+  untranslatedCount: number
+  onProceedAll(): void
+  onSendOnlyUntranslated(): void
+  onClose(): void
+}
+
+export function AlreadyTranslatedDialog({
+  open,
+  translatedCount,
+  untranslatedCount,
+  onProceedAll,
+  onSendOnlyUntranslated,
+  onClose
+}: AlreadyTranslatedDialogProps): React.JSX.Element | null {
+  const { t } = useAppTranslation('translate')
+
+  return (
+    <ModalShell
+      open={open}
+      title={t('alreadyTranslatedDialog.title')}
+      sizeClassName="max-w-md"
+      icon={<AlertTriangle size={16} />}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            {t('alreadyTranslatedDialog.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={onSendOnlyUntranslated}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            {t('alreadyTranslatedDialog.onlyUntranslated', { untranslatedCount })}
+          </button>
+          <button
+            type="button"
+            onClick={onProceedAll}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
+          >
+            {t('alreadyTranslatedDialog.proceedAll')}
+          </button>
+        </>
+      }
+    >
+      <p className="text-sm leading-6 text-neutral-300">
+        {t('alreadyTranslatedDialog.description', { translatedCount })}
+      </p>
+    </ModalShell>
+  )
+}

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -8,6 +8,7 @@ import {
   useState,
   useTransition
 } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import {
   type TranslationSessionEntry,
   useTranslationSession
@@ -82,6 +83,8 @@ export function TranslationGrid({
   const searchInputRef = useRef<HTMLInputElement>(null)
   const textareaRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map())
   const savedByEnterRef = useRef<Set<string>>(new Set())
+  const sideParentRef = useRef<HTMLDivElement>(null)
+  const stackedParentRef = useRef<HTMLDivElement>(null)
 
   const counts = useMemo(() => {
     let translated = 0
@@ -121,6 +124,20 @@ export function TranslationGrid({
 
   const totalPages = Math.max(1, Math.ceil(filteredEntries.length / pageSize))
   const pageEntries = filteredEntries.slice((currentPage - 1) * pageSize, currentPage * pageSize)
+
+  const sideVirtualizer = useVirtualizer({
+    count: pageEntries.length,
+    getScrollElement: () => sideParentRef.current,
+    estimateSize: () => 72,
+    overscan: 10,
+  })
+
+  const stackedVirtualizer = useVirtualizer({
+    count: pageEntries.length,
+    getScrollElement: () => stackedParentRef.current,
+    estimateSize: () => 220,
+    overscan: 10,
+  })
 
   const selectedStats = useMemo(() => {
     let selectedStrings = 0
@@ -418,112 +435,127 @@ export function TranslationGrid({
           </div>
         </div>
 
-        <div className="icosa-scroll min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">
-          {pageEntries.map((entry, index) => {
-            const category = getCategory(entry)
-            const isDone = entry.target.trim() !== ''
-            const isSelected = selectedUids.has(entry.rowId)
-            const isDictionary = category === 'dictionary'
-            const charCount = entry.source.length
-            const globalIndex = (currentPage - 1) * pageSize + index
+        <div
+          ref={sideParentRef}
+          className="icosa-scroll min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]"
+        >
+          <div style={{ height: sideVirtualizer.getTotalSize(), position: 'relative' }}>
+            {sideVirtualizer.getVirtualItems().map((virtualItem) => {
+              const entry = pageEntries[virtualItem.index]
+              const category = getCategory(entry)
+              const isDone = entry.target.trim() !== ''
+              const isSelected = selectedUids.has(entry.rowId)
+              const isDictionary = category === 'dictionary'
+              const charCount = entry.source.length
+              const globalIndex = (currentPage - 1) * pageSize + virtualItem.index
 
-            return (
-              <div
-                key={entry.rowId}
-                className={cn(
-                  'group grid border-b border-[#1f2329] transition-colors hover:bg-[#131518]/60 focus-within:bg-[#131518] focus-within:shadow-[inset_3px_0_0_#f59e0b]',
-                  isSelected && 'bg-blue-950/10'
-                )}
-                style={{ gridTemplateColumns: '80px 1fr 1fr' }}
-              >
+              return (
                 <div
-                  className="flex cursor-pointer flex-col items-center gap-2 border-r border-[#1f2329] bg-[#0f1114] px-3 py-3"
-                  onClick={() => focusEntry(entry.rowId)}
+                  key={entry.rowId}
+                  data-index={virtualItem.index}
+                  ref={sideVirtualizer.measureElement}
+                  className={cn(
+                    'group grid border-b border-[#1f2329] transition-colors hover:bg-[#131518]/60 focus-within:bg-[#131518] focus-within:shadow-[inset_3px_0_0_#f59e0b]',
+                    isSelected && 'bg-blue-950/10'
+                  )}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualItem.start}px)`,
+                    gridTemplateColumns: '80px 1fr 1fr',
+                  }}
                 >
-                  <input
-                    type="checkbox"
-                    checked={isSelected}
-                    onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                  <div
+                    className="flex cursor-pointer flex-col items-center gap-2 border-r border-[#1f2329] bg-[#0f1114] px-3 py-3"
+                    onClick={() => focusEntry(entry.rowId)}
+                  >
+                    <input
+                      type="checkbox"
+                      checked={isSelected}
+                      onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                      onClick={(event) => event.stopPropagation()}
+                      className="cursor-pointer accent-amber-500"
+                    />
+                    <span className="font-mono text-[11px] tabular-nums text-neutral-600">
+                      {String(globalIndex + 1).padStart(3, '0')}
+                    </span>
+                    <span
+                      className={cn(
+                        'mt-auto h-1.5 w-1.5 rounded-full transition-colors',
+                        isDone ? 'bg-amber-500' : 'bg-neutral-700'
+                      )}
+                    />
+                  </div>
+
+                  <div
+                    className="flex min-w-0 cursor-pointer flex-col gap-2 px-4 py-3"
+                    onClick={() => focusEntry(entry.rowId)}
+                  >
+                    <div className="wrap-break-word font-mono text-[13px] leading-[1.6] text-neutral-200 whitespace-pre-wrap">
+                      {entry.source ? (
+                        renderSource(entry.source)
+                      ) : (
+                        <span className="italic text-neutral-600">
+                          {t('grid.emptySource', { ns: 'translate' })}
+                        </span>
+                      )}
+                    </div>
+                    <div className="flex flex-wrap items-center gap-1.5">
+                      {isDictionary && (
+                        <span className="inline-flex items-center gap-1 rounded bg-blue-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-blue-400">
+                          <BookOpen size={10} /> D <span className="text-blue-500/70">1</span>
+                        </span>
+                      )}
+                      <span className="font-mono text-[10px] text-neutral-600">
+                        {t('grid.charCount', { ns: 'translate', count: charCount })}
+                      </span>
+                    </div>
+                  </div>
+
+                  <div
+                    className="flex min-w-0 flex-col gap-2 border-l border-[#1f2329] px-4 py-3"
                     onClick={(event) => event.stopPropagation()}
-                    className="cursor-pointer accent-amber-500"
-                  />
-                  <span className="font-mono text-[11px] tabular-nums text-neutral-600">
-                    {String(globalIndex + 1).padStart(3, '0')}
-                  </span>
-                  <span
-                    className={cn(
-                      'mt-auto h-1.5 w-1.5 rounded-full transition-colors',
-                      isDone ? 'bg-amber-500' : 'bg-neutral-700'
-                    )}
-                  />
-                </div>
-
-                <div
-                  className="flex min-w-0 cursor-pointer flex-col gap-2 px-4 py-3"
-                  onClick={() => focusEntry(entry.rowId)}
-                >
-                  <div className="wrap-break-word font-mono text-[13px] leading-[1.6] text-neutral-200 whitespace-pre-wrap">
-                    {entry.source ? (
-                      renderSource(entry.source)
-                    ) : (
-                      <span className="italic text-neutral-600">
-                        {t('grid.emptySource', { ns: 'translate' })}
+                  >
+                    <HighlightedTextarea
+                      ref={(element) => {
+                        if (element) textareaRefs.current.set(entry.rowId, element)
+                        else textareaRefs.current.delete(entry.rowId)
+                      }}
+                      value={entry.target}
+                      onBlur={(event) => handleEntryBlur(entry, event.target.value)}
+                      onChange={() => {}}
+                      onKeyDown={(event) => handleEnterKey(event, entry)}
+                      rows={1}
+                      placeholder={t('grid.translationPlaceholder', { ns: 'translate' })}
+                      containerClassName="rounded-md"
+                      className="field-sizing-content"
+                    />
+                    <div className="pointer-events-none flex items-center gap-1.5 opacity-0 transition-opacity duration-150 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+                      {/* <button
+                        type="button"
+                        className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
+                      >
+                        <Sparkles size={11} /> Suggest AI
+                      </button> */}
+                      <button
+                        type="button"
+                        className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
+                      >
+                        <BookOpen size={11} /> {t('grid.applyDictionary', { ns: 'translate' })}
+                      </button>
+                      <span className="ml-auto flex items-center gap-1 text-[11px] text-neutral-500">
+                        <KbdHint>Enter</KbdHint> {t('grid.next', { ns: 'translate' })}
+                        <span className="mx-1 text-neutral-700">-</span>
+                        <KbdHint>Shift Enter</KbdHint> {t('grid.newLine', { ns: 'translate' })}
                       </span>
-                    )}
-                  </div>
-                  <div className="flex flex-wrap items-center gap-1.5">
-                    {isDictionary && (
-                      <span className="inline-flex items-center gap-1 rounded bg-blue-500/12 px-1.5 py-0.5 font-mono text-[10px] font-semibold text-blue-400">
-                        <BookOpen size={10} /> D <span className="text-blue-500/70">1</span>
-                      </span>
-                    )}
-                    <span className="font-mono text-[10px] text-neutral-600">
-                      {t('grid.charCount', { ns: 'translate', count: charCount })}
-                    </span>
+                    </div>
                   </div>
                 </div>
-
-                <div
-                  className="flex min-w-0 flex-col gap-2 border-l border-[#1f2329] px-4 py-3"
-                  onClick={(event) => event.stopPropagation()}
-                >
-                  <HighlightedTextarea
-                    ref={(element) => {
-                      if (element) textareaRefs.current.set(entry.rowId, element)
-                      else textareaRefs.current.delete(entry.rowId)
-                    }}
-                    value={entry.target}
-                    onBlur={(event) => handleEntryBlur(entry, event.target.value)}
-                    onChange={() => {}}
-                    onKeyDown={(event) => handleEnterKey(event, entry)}
-                    rows={1}
-                    placeholder={t('grid.translationPlaceholder', { ns: 'translate' })}
-                    containerClassName="rounded-md"
-                    className="field-sizing-content"
-                  />
-                  <div className="pointer-events-none flex items-center gap-1.5 opacity-0 transition-opacity duration-150 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
-                    {/* <button
-                      type="button"
-                      className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
-                    >
-                      <Sparkles size={11} /> Suggest AI
-                    </button> */}
-                    <button
-                      type="button"
-                      className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
-                    >
-                      <BookOpen size={11} /> {t('grid.applyDictionary', { ns: 'translate' })}
-                    </button>
-                    <span className="ml-auto flex items-center gap-1 text-[11px] text-neutral-500">
-                      <KbdHint>Enter</KbdHint> {t('grid.next', { ns: 'translate' })}
-                      <span className="mx-1 text-neutral-700">-</span>
-                      <KbdHint>Shift Enter</KbdHint> {t('grid.newLine', { ns: 'translate' })}
-                    </span>
-                  </div>
-                </div>
-              </div>
-            )
-          })}
+              )
+            })}
+          </div>
         </div>
 
         {PaginationFooter}
@@ -547,172 +579,190 @@ export function TranslationGrid({
         </span>
       </div>
 
-      <div className="icosa-scroll min-h-0 flex-1 overflow-y-auto">
-        <div className="px-7 pb-6 pt-5">
-          <div className="mx-auto flex max-w-275 flex-col gap-3.5">
-            {pageEntries.map((entry, index) => {
-              const category = getCategory(entry)
-              const isDone = entry.target.trim() !== ''
-              const isSelected = selectedUids.has(entry.rowId)
-              const isDictionary = category === 'dictionary'
-              const hasTags = hasXmlTags(entry)
-              const wordCount = entry.source.split(/\s+/).filter(Boolean).length
-              const charCount = entry.source.length
-              const rows = Math.max(2, Math.ceil(charCount / 70))
-              const globalIndex = (currentPage - 1) * pageSize + index
+      <div ref={stackedParentRef} className="icosa-scroll min-h-0 flex-1 overflow-y-auto">
+        {/* 44px = pt-5 (20px) + pb-6 (24px) added to total size so padding is preserved */}
+        <div style={{ height: stackedVirtualizer.getTotalSize() + 44, position: 'relative' }}>
+          {stackedVirtualizer.getVirtualItems().map((virtualItem) => {
+            const entry = pageEntries[virtualItem.index]
+            const category = getCategory(entry)
+            const isDone = entry.target.trim() !== ''
+            const isSelected = selectedUids.has(entry.rowId)
+            const isDictionary = category === 'dictionary'
+            const hasTags = hasXmlTags(entry)
+            const wordCount = entry.source.split(/\s+/).filter(Boolean).length
+            const charCount = entry.source.length
+            const rows = Math.max(2, Math.ceil(charCount / 70))
+            const globalIndex = (currentPage - 1) * pageSize + virtualItem.index
 
-              return (
-                <div
-                  key={entry.rowId}
-                  className={cn(
-                    'group grid cursor-pointer overflow-hidden rounded-xl border transition-all duration-120',
-                    'border-[#1f2329] bg-[#0f1114]',
-                    'hover:-translate-y-px hover:border-[#2a2f37] hover:shadow-[0_4px_16px_rgba(0,0,0,0.18)]',
-                    'focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25),0_8px_24px_rgba(0,0,0,0.24)]',
-                    isSelected && 'border-blue-700/40 bg-blue-950/10'
-                  )}
-                  style={{ gridTemplateColumns: '56px 1fr' }}
-                  onClick={() => focusEntry(entry.rowId)}
-                >
-                  <div className="flex flex-col items-center gap-3 border-r border-[#1f2329] bg-[#0c0d0f] py-4.5">
-                    <input
-                      type="checkbox"
-                      checked={isSelected}
-                      onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
-                      onClick={(event) => event.stopPropagation()}
-                      className="cursor-pointer accent-amber-500"
-                    />
+            return (
+              <div
+                key={entry.rowId}
+                data-index={virtualItem.index}
+                ref={stackedVirtualizer.measureElement}
+                style={{
+                  position: 'absolute',
+                  top: 0,
+                  left: 0,
+                  width: '100%',
+                  // 20px offset = pt-5 top padding
+                  transform: `translateY(${virtualItem.start + 20}px)`,
+                  paddingLeft: '28px',
+                  paddingRight: '28px',
+                  paddingBottom: '14px',
+                }}
+              >
+                <div className="mx-auto max-w-275">
+                  <div
+                    className={cn(
+                      'group grid cursor-pointer overflow-hidden rounded-xl border transition-all duration-120',
+                      'border-[#1f2329] bg-[#0f1114]',
+                      'hover:-translate-y-px hover:border-[#2a2f37] hover:shadow-[0_4px_16px_rgba(0,0,0,0.18)]',
+                      'focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25),0_8px_24px_rgba(0,0,0,0.24)]',
+                      isSelected && 'border-blue-700/40 bg-blue-950/10'
+                    )}
+                    style={{ gridTemplateColumns: '56px 1fr' }}
+                    onClick={() => focusEntry(entry.rowId)}
+                  >
+                    <div className="flex flex-col items-center gap-3 border-r border-[#1f2329] bg-[#0c0d0f] py-4.5">
+                      <input
+                        type="checkbox"
+                        checked={isSelected}
+                        onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                        onClick={(event) => event.stopPropagation()}
+                        className="cursor-pointer accent-amber-500"
+                      />
 
-                    <span
-                      className="mt-auto font-mono text-[11px] tracking-widest text-neutral-600"
-                      style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
-                    >
-                      #{String(globalIndex + 1).padStart(3, '0')}
-                    </span>
+                      <span
+                        className="mt-auto font-mono text-[11px] tracking-widest text-neutral-600"
+                        style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+                      >
+                        #{String(globalIndex + 1).padStart(3, '0')}
+                      </span>
+
+                      <div
+                        className={cn(
+                          'flex h-5.5 w-5.5 items-center justify-center rounded-full border transition-colors',
+                          isDone
+                            ? 'border-amber-500 bg-amber-500 text-white'
+                            : 'border-[#1f2329] bg-[#131518]'
+                        )}
+                      >
+                        {isDone ? (
+                          <Check size={11} strokeWidth={2.5} />
+                        ) : (
+                          <span className="h-1.5 w-1.5 rounded-full bg-neutral-600" />
+                        )}
+                      </div>
+                    </div>
 
                     <div
-                      className={cn(
-                        'flex h-5.5 w-5.5 items-center justify-center rounded-full border transition-colors',
-                        isDone
-                          ? 'border-amber-500 bg-amber-500 text-white'
-                          : 'border-[#1f2329] bg-[#131518]'
-                      )}
+                      className="flex flex-col gap-3 px-5.5 py-4.5"
+                      onClick={(event) => event.stopPropagation()}
                     >
-                      {isDone ? (
-                        <Check size={11} strokeWidth={2.5} />
-                      ) : (
-                        <span className="h-1.5 w-1.5 rounded-full bg-neutral-600" />
-                      )}
-                    </div>
-                  </div>
-
-                  <div
-                    className="flex flex-col gap-3 px-5.5 py-4.5"
-                    onClick={(event) => event.stopPropagation()}
-                  >
-                    <div className="flex items-center gap-2.5">
-                      <LangTag>{sourceLang.toUpperCase()}</LangTag>
-                      <span className="font-mono text-[10px] tracking-[0.02em] text-neutral-600">
-                        {t('grid.wordAndCharCount', {
-                          ns: 'translate',
-                          chars: charCount,
-                          words: wordCount
-                        })}
-                      </span>
-                      <span className="flex-1" />
-                      {isDictionary && (
-                        <span className="inline-flex items-center gap-1 rounded bg-blue-500/12 px-2 py-0.5 text-[11px] font-medium text-blue-400">
-                          <BookOpen size={11} />
-                          {entry.matchType === 'mod-text'
-                            ? t('grid.dictionaryTagMod', { ns: 'translate' })
-                            : t('grid.dictionaryTag', { ns: 'translate' })}
+                      <div className="flex items-center gap-2.5">
+                        <LangTag>{sourceLang.toUpperCase()}</LangTag>
+                        <span className="font-mono text-[10px] tracking-[0.02em] text-neutral-600">
+                          {t('grid.wordAndCharCount', {
+                            ns: 'translate',
+                            chars: charCount,
+                            words: wordCount
+                          })}
                         </span>
-                      )}
-                      {hasTags && (
-                        <span className="inline-flex items-center gap-1 rounded bg-purple-500/14 px-2 py-0.5 text-[11px] font-medium text-purple-300">
-                          <AlertTriangle size={11} /> {t('grid.containsTags', { ns: 'translate' })}
-                        </span>
-                      )}
-                    </div>
-
-                    <div className="wrap-break-word font-mono text-[14px] leading-[1.65] text-neutral-200 whitespace-pre-wrap">
-                      {entry.source ? (
-                        renderSource(entry.source)
-                      ) : (
-                        <span className="italic text-neutral-600">
-                          {t('grid.emptySource', { ns: 'translate' })}
-                        </span>
-                      )}
-                    </div>
-
-                    {isDictionary && (
-                      <div className="hidden flex-wrap items-center gap-2 rounded-lg border border-dashed border-[#2a2f37] bg-[#0c0d0f] px-3 py-2 group-focus-within:flex">
-                        <span className="text-[11px] font-semibold tracking-[0.08em] text-neutral-500 uppercase">
-                          {t('grid.dictionarySuggestion', { ns: 'translate' })}
-                        </span>
-                        <button
-                          type="button"
-                          className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-[#1f2329] bg-[#0f1114] px-2.5 py-0.5 text-[12px] transition-colors hover:border-amber-500 hover:bg-amber-500/10"
-                          onClick={() => {
-                            onEntryChange(entry.rowId, entry.target)
-                          }}
-                        >
-                          <span className="font-mono text-neutral-400">
-                            {entry.source.slice(0, 24)}
-                            {entry.source.length > 24 ? '...' : ''}
-                          </span>
-                          <span className="text-neutral-600">-&gt;</span>
-                          <span className="font-medium text-neutral-200">
-                            {entry.target || '-'}
-                          </span>
-                        </button>
-                      </div>
-                    )}
-
-                    <div className="mt-1 flex items-center gap-2.5 border-t border-dashed border-[#1f2329] pt-1">
-                      <LangTag accent>{targetLang.toUpperCase()}</LangTag>
-                      <div className="pointer-events-none flex flex-1 items-center gap-1.5 opacity-0 transition-opacity duration-150 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
-                        {/* <button
-                          type="button"
-                          className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
-                        >
-                          <Sparkles size={11} /> Suggest AI
-                        </button> */}
-                        <button
-                          type="button"
-                          className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
-                        >
-                          <Check size={11} /> {t('grid.markTranslated', { ns: 'translate' })}
-                        </button>
                         <span className="flex-1" />
-                        <span className="flex items-center gap-1 text-[11px] text-neutral-500">
-                          <KbdHint>Enter</KbdHint> {t('grid.next', { ns: 'translate' })}
-                          <span className="mx-0.5 text-neutral-700">-</span>
-                          <KbdHint>Shift Enter</KbdHint> {t('grid.newLine', { ns: 'translate' })}
-                        </span>
+                        {isDictionary && (
+                          <span className="inline-flex items-center gap-1 rounded bg-blue-500/12 px-2 py-0.5 text-[11px] font-medium text-blue-400">
+                            <BookOpen size={11} />
+                            {entry.matchType === 'mod-text'
+                              ? t('grid.dictionaryTagMod', { ns: 'translate' })
+                              : t('grid.dictionaryTag', { ns: 'translate' })}
+                          </span>
+                        )}
+                        {hasTags && (
+                          <span className="inline-flex items-center gap-1 rounded bg-purple-500/14 px-2 py-0.5 text-[11px] font-medium text-purple-300">
+                            <AlertTriangle size={11} /> {t('grid.containsTags', { ns: 'translate' })}
+                          </span>
+                        )}
                       </div>
-                    </div>
 
-                    <HighlightedTextarea
-                      ref={(element) => {
-                        if (element) textareaRefs.current.set(entry.rowId, element)
-                        else textareaRefs.current.delete(entry.rowId)
-                      }}
-                      value={entry.target}
-                      onBlur={(event) => handleEntryBlur(entry, event.target.value)}
-                      onChange={() => {}}
-                      onKeyDown={(event) => handleEnterKey(event, entry)}
-                      rows={rows}
-                      placeholder={isDone ? '' : t('grid.startTyping', { ns: 'translate' })}
-                      containerClassName="min-h-11 rounded-lg border-[#1f2329] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25)]"
-                      overlayClassName="px-3.5 py-3 text-[13px] leading-[1.6]"
-                      className="min-h-11 px-3.5 py-3 text-[13px] leading-[1.6]"
-                    />
+                      <div className="wrap-break-word font-mono text-[14px] leading-[1.65] text-neutral-200 whitespace-pre-wrap">
+                        {entry.source ? (
+                          renderSource(entry.source)
+                        ) : (
+                          <span className="italic text-neutral-600">
+                            {t('grid.emptySource', { ns: 'translate' })}
+                          </span>
+                        )}
+                      </div>
+
+                      {isDictionary && (
+                        <div className="hidden flex-wrap items-center gap-2 rounded-lg border border-dashed border-[#2a2f37] bg-[#0c0d0f] px-3 py-2 group-focus-within:flex">
+                          <span className="text-[11px] font-semibold tracking-[0.08em] text-neutral-500 uppercase">
+                            {t('grid.dictionarySuggestion', { ns: 'translate' })}
+                          </span>
+                          <button
+                            type="button"
+                            className="inline-flex cursor-pointer items-center gap-1.5 rounded-full border border-[#1f2329] bg-[#0f1114] px-2.5 py-0.5 text-[12px] transition-colors hover:border-amber-500 hover:bg-amber-500/10"
+                            onClick={() => {
+                              onEntryChange(entry.rowId, entry.target)
+                            }}
+                          >
+                            <span className="font-mono text-neutral-400">
+                              {entry.source.slice(0, 24)}
+                              {entry.source.length > 24 ? '...' : ''}
+                            </span>
+                            <span className="text-neutral-600">-&gt;</span>
+                            <span className="font-medium text-neutral-200">
+                              {entry.target || '-'}
+                            </span>
+                          </button>
+                        </div>
+                      )}
+
+                      <div className="mt-1 flex items-center gap-2.5 border-t border-dashed border-[#1f2329] pt-1">
+                        <LangTag accent>{targetLang.toUpperCase()}</LangTag>
+                        <div className="pointer-events-none flex flex-1 items-center gap-1.5 opacity-0 transition-opacity duration-150 group-focus-within:pointer-events-auto group-focus-within:opacity-100">
+                          {/* <button
+                            type="button"
+                            className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
+                          >
+                            <Sparkles size={11} /> Suggest AI
+                          </button> */}
+                          <button
+                            type="button"
+                            className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
+                          >
+                            <Check size={11} /> {t('grid.markTranslated', { ns: 'translate' })}
+                          </button>
+                          <span className="flex-1" />
+                          <span className="flex items-center gap-1 text-[11px] text-neutral-500">
+                            <KbdHint>Enter</KbdHint> {t('grid.next', { ns: 'translate' })}
+                            <span className="mx-0.5 text-neutral-700">-</span>
+                            <KbdHint>Shift Enter</KbdHint> {t('grid.newLine', { ns: 'translate' })}
+                          </span>
+                        </div>
+                      </div>
+
+                      <HighlightedTextarea
+                        ref={(element) => {
+                          if (element) textareaRefs.current.set(entry.rowId, element)
+                          else textareaRefs.current.delete(entry.rowId)
+                        }}
+                        value={entry.target}
+                        onBlur={(event) => handleEntryBlur(entry, event.target.value)}
+                        onChange={() => {}}
+                        onKeyDown={(event) => handleEnterKey(event, entry)}
+                        rows={rows}
+                        placeholder={isDone ? '' : t('grid.startTyping', { ns: 'translate' })}
+                        containerClassName="min-h-11 rounded-lg border-[#1f2329] bg-[#0c0d0f] focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25)]"
+                        overlayClassName="px-3.5 py-3 text-[13px] leading-[1.6]"
+                        className="min-h-11 px-3.5 py-3 text-[13px] leading-[1.6]"
+                      />
+                    </div>
                   </div>
                 </div>
-              )
-            })}
-          </div>
+              </div>
+            )
+          })}
         </div>
       </div>
 

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -77,6 +77,8 @@ export function TranslationGrid({
   const deferredSearch = useDeferredValue(search)
   const deferredFilter = useDeferredValue(filter)
   const [isPending, startFilterTransition] = useTransition()
+  const [pageSize, setPageSize] = useState<100 | 250 | 500 | 1000>(250)
+  const [currentPage, setCurrentPage] = useState(1)
   const searchInputRef = useRef<HTMLInputElement>(null)
   const textareaRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map())
   const savedByEnterRef = useRef<Set<string>>(new Set())
@@ -112,6 +114,13 @@ export function TranslationGrid({
       return true
     })
   }, [deferredFilter, deferredSearch, entries])
+
+  useEffect(() => {
+    setCurrentPage(1)
+  }, [deferredFilter, deferredSearch, entries])
+
+  const totalPages = Math.max(1, Math.ceil(filteredEntries.length / pageSize))
+  const pageEntries = filteredEntries.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
   const selectedStats = useMemo(() => {
     let selectedStrings = 0
@@ -181,8 +190,8 @@ export function TranslationGrid({
 
     if (value.trim()) onEntrySave(entry.rowId, value)
 
-    const nextIndex = filteredEntries.findIndex((item) => item.rowId === entry.rowId) + 1
-    const nextEntry = filteredEntries[nextIndex]
+    const nextIndex = pageEntries.findIndex((item) => item.rowId === entry.rowId) + 1
+    const nextEntry = pageEntries[nextIndex]
     if (!nextEntry) return
 
     const nextTextarea = textareaRefs.current.get(nextEntry.rowId)
@@ -190,6 +199,75 @@ export function TranslationGrid({
     nextTextarea.focus()
     nextTextarea.scrollIntoView({ block: 'nearest', behavior: 'smooth' })
   }
+
+  const btnBase =
+    'inline-flex h-7 cursor-pointer items-center rounded border border-[#1f2329] bg-[#131518] px-2 text-xs font-medium text-neutral-400 transition-colors hover:border-[#2a2f37] hover:text-neutral-200 disabled:cursor-not-allowed disabled:opacity-40'
+
+  const PaginationFooter = (
+    <div className="flex shrink-0 items-center justify-between gap-4 border-t border-[#1f2329] bg-[#0c0d0f] px-5 py-2">
+      <div className="flex items-center gap-2 text-xs text-neutral-500">
+        <span>{t('grid.pagination.pageSizeLabel', { ns: 'translate' })}</span>
+        <select
+          value={pageSize}
+          onChange={(event) => {
+            setPageSize(Number(event.target.value) as typeof pageSize)
+            setCurrentPage(1)
+          }}
+          className="cursor-pointer rounded border border-[#1f2329] bg-[#131518] px-2 py-0.5 text-xs text-neutral-300 focus:outline-none"
+        >
+          {([100, 250, 500, 1000] as const).map((size) => (
+            <option key={size} value={size}>
+              {size}
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-[11px] tabular-nums text-neutral-500">
+          {t('grid.pagination.pageOf', {
+            ns: 'translate',
+            current: currentPage,
+            total: totalPages
+          })}
+        </span>
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            className={btnBase}
+            disabled={currentPage === 1}
+            onClick={() => setCurrentPage(1)}
+          >
+            {t('grid.pagination.first', { ns: 'translate' })}
+          </button>
+          <button
+            type="button"
+            className={btnBase}
+            disabled={currentPage === 1}
+            onClick={() => setCurrentPage((p) => p - 1)}
+          >
+            {t('grid.pagination.prev', { ns: 'translate' })}
+          </button>
+          <button
+            type="button"
+            className={btnBase}
+            disabled={currentPage === totalPages}
+            onClick={() => setCurrentPage((p) => p + 1)}
+          >
+            {t('grid.pagination.next', { ns: 'translate' })}
+          </button>
+          <button
+            type="button"
+            className={btnBase}
+            disabled={currentPage === totalPages}
+            onClick={() => setCurrentPage(totalPages)}
+          >
+            {t('grid.pagination.last', { ns: 'translate' })}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
 
   const filterItems: Array<{
     mode: FilterMode
@@ -341,12 +419,13 @@ export function TranslationGrid({
         </div>
 
         <div className="icosa-scroll min-h-0 flex-1 overflow-y-auto [scrollbar-gutter:stable]">
-          {filteredEntries.map((entry, index) => {
+          {pageEntries.map((entry, index) => {
             const category = getCategory(entry)
             const isDone = entry.target.trim() !== ''
             const isSelected = selectedUids.has(entry.rowId)
             const isDictionary = category === 'dictionary'
             const charCount = entry.source.length
+            const globalIndex = (currentPage - 1) * pageSize + index
 
             return (
               <div
@@ -369,7 +448,7 @@ export function TranslationGrid({
                     className="cursor-pointer accent-amber-500"
                   />
                   <span className="font-mono text-[11px] tabular-nums text-neutral-600">
-                    {String(index + 1).padStart(3, '0')}
+                    {String(globalIndex + 1).padStart(3, '0')}
                   </span>
                   <span
                     className={cn(
@@ -446,6 +525,8 @@ export function TranslationGrid({
             )
           })}
         </div>
+
+        {PaginationFooter}
       </div>
     )
   }
@@ -467,9 +548,9 @@ export function TranslationGrid({
       </div>
 
       <div className="icosa-scroll min-h-0 flex-1 overflow-y-auto">
-        <div className="px-7 pb-20 pt-5">
+        <div className="px-7 pb-6 pt-5">
           <div className="mx-auto flex max-w-275 flex-col gap-3.5">
-            {filteredEntries.map((entry, index) => {
+            {pageEntries.map((entry, index) => {
               const category = getCategory(entry)
               const isDone = entry.target.trim() !== ''
               const isSelected = selectedUids.has(entry.rowId)
@@ -478,6 +559,7 @@ export function TranslationGrid({
               const wordCount = entry.source.split(/\s+/).filter(Boolean).length
               const charCount = entry.source.length
               const rows = Math.max(2, Math.ceil(charCount / 70))
+              const globalIndex = (currentPage - 1) * pageSize + index
 
               return (
                 <div
@@ -505,7 +587,7 @@ export function TranslationGrid({
                       className="mt-auto font-mono text-[11px] tracking-widest text-neutral-600"
                       style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
                     >
-                      #{String(index + 1).padStart(3, '0')}
+                      #{String(globalIndex + 1).padStart(3, '0')}
                     </span>
 
                     <div
@@ -633,6 +715,8 @@ export function TranslationGrid({
           </div>
         </div>
       </div>
+
+      {PaginationFooter}
     </div>
   )
 }

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -10,7 +10,9 @@ import {
 } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import {
+  type FilterSpec,
   type TranslationSessionEntry,
+  materializeSelectedEntries,
   useTranslationSession
 } from '@/context/TranslationSession'
 import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
@@ -71,8 +73,9 @@ export function TranslationGrid({
   viewMode
 }: TranslationGridProps): React.JSX.Element {
   const { t } = useAppTranslation(['translate', 'common'])
-  const { selectedUids, selectEntry, selectEntries, sourceLang, targetLang } =
-    useTranslationSession()
+  const session = useTranslationSession()
+  const { selection, isSelected, selectAllMatching, toggleEntry, clearSelection, sourceLang, targetLang } =
+    session
   const [search, setSearch] = useState('')
   const [filter, setFilter] = useState<FilterMode>('all')
   const deferredSearch = useDeferredValue(search)
@@ -122,6 +125,14 @@ export function TranslationGrid({
     setCurrentPage(1)
   }, [deferredFilter, deferredSearch, entries])
 
+  // clear selection when filter or search changes so count never disagrees with checkbox
+  useEffect(() => {
+    clearSelection()
+  }, [deferredFilter, deferredSearch, clearSelection])
+
+  // single source of truth for which entries "select-all" covers
+  const currentFilter: FilterSpec = { mode: deferredFilter, search: deferredSearch }
+
   const totalPages = Math.max(1, Math.ceil(filteredEntries.length / pageSize))
   const pageEntries = filteredEntries.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
@@ -140,20 +151,18 @@ export function TranslationGrid({
   })
 
   const selectedStats = useMemo(() => {
-    let selectedStrings = 0
-    let selectedCharacters = 0
-
-    for (const entry of entries) {
-      if (!selectedUids.has(entry.rowId)) continue
-      selectedStrings += 1
-      selectedCharacters += entry.source.length
+    const materialized = materializeSelectedEntries(session)
+    return {
+      selectedStrings: materialized.length,
+      selectedCharacters: materialized.reduce((sum, e) => sum + e.source.length, 0)
     }
-
-    return { selectedStrings, selectedCharacters }
-  }, [entries, selectedUids])
+  }, [session.selection, session.entries])
 
   const allFiltered =
-    filteredEntries.length > 0 && filteredEntries.every((entry) => selectedUids.has(entry.rowId))
+    selection.kind === 'all-matching' &&
+    selection.excluded.size === 0 &&
+    selection.filter.mode === deferredFilter &&
+    selection.filter.search === deferredSearch
 
   useEffect(() => {
     const handleFindShortcut = (event: KeyboardEvent) => {
@@ -169,10 +178,11 @@ export function TranslationGrid({
   }, [])
 
   const handleSelectAll = (checked: boolean) => {
-    selectEntries(
-      filteredEntries.map((entry) => entry.rowId),
-      checked
-    )
+    if (checked) {
+      selectAllMatching(currentFilter)
+    } else {
+      clearSelection()
+    }
   }
 
   const focusEntry = (rowId: string) => {
@@ -444,7 +454,7 @@ export function TranslationGrid({
               const entry = pageEntries[virtualItem.index]
               const category = getCategory(entry)
               const isDone = entry.target.trim() !== ''
-              const isSelected = selectedUids.has(entry.rowId)
+              const isRowSelected = isSelected(entry.rowId)
               const isDictionary = category === 'dictionary'
               const charCount = entry.source.length
               const globalIndex = (currentPage - 1) * pageSize + virtualItem.index
@@ -456,7 +466,7 @@ export function TranslationGrid({
                   ref={sideVirtualizer.measureElement}
                   className={cn(
                     'group grid border-b border-[#1f2329] transition-colors hover:bg-[#131518]/60 focus-within:bg-[#131518] focus-within:shadow-[inset_3px_0_0_#f59e0b]',
-                    isSelected && 'bg-blue-950/10'
+                    isRowSelected && 'bg-blue-950/10'
                   )}
                   style={{
                     position: 'absolute',
@@ -473,8 +483,8 @@ export function TranslationGrid({
                   >
                     <input
                       type="checkbox"
-                      checked={isSelected}
-                      onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                      checked={isRowSelected}
+                      onChange={() => toggleEntry(entry.rowId)}
                       onClick={(event) => event.stopPropagation()}
                       className="cursor-pointer accent-amber-500"
                     />
@@ -586,7 +596,7 @@ export function TranslationGrid({
             const entry = pageEntries[virtualItem.index]
             const category = getCategory(entry)
             const isDone = entry.target.trim() !== ''
-            const isSelected = selectedUids.has(entry.rowId)
+            const isRowSelected = isSelected(entry.rowId)
             const isDictionary = category === 'dictionary'
             const hasTags = hasXmlTags(entry)
             const wordCount = entry.source.split(/\s+/).filter(Boolean).length
@@ -618,7 +628,7 @@ export function TranslationGrid({
                       'border-[#1f2329] bg-[#0f1114]',
                       'hover:-translate-y-px hover:border-[#2a2f37] hover:shadow-[0_4px_16px_rgba(0,0,0,0.18)]',
                       'focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25),0_8px_24px_rgba(0,0,0,0.24)]',
-                      isSelected && 'border-blue-700/40 bg-blue-950/10'
+                      isRowSelected && 'border-blue-700/40 bg-blue-950/10'
                     )}
                     style={{ gridTemplateColumns: '56px 1fr' }}
                     onClick={() => focusEntry(entry.rowId)}
@@ -626,8 +636,8 @@ export function TranslationGrid({
                     <div className="flex flex-col items-center gap-3 border-r border-[#1f2329] bg-[#0c0d0f] py-4.5">
                       <input
                         type="checkbox"
-                        checked={isSelected}
-                        onChange={(event) => selectEntry(entry.rowId, event.target.checked)}
+                        checked={isRowSelected}
+                        onChange={() => toggleEntry(entry.rowId)}
                         onClick={(event) => event.stopPropagation()}
                         className="cursor-pointer accent-amber-500"
                       />

--- a/src/renderer/src/context/TranslationSession.tsx
+++ b/src/renderer/src/context/TranslationSession.tsx
@@ -1,4 +1,4 @@
-import { createContext, useCallback, useContext, useEffect, useReducer } from 'react'
+import { createContext, useCallback, useContext, useEffect, useMemo, useReducer } from 'react'
 import { i18n } from '@/i18n'
 import type { XmlEntry } from '@/types'
 
@@ -8,24 +8,73 @@ export interface TranslationSessionEntry extends XmlEntry {
 
 type Phase = 'idle' | 'loading' | 'loaded'
 
-interface State {
+export type FilterMode = 'all' | 'untranslated' | 'translated' | 'dictionary' | 'tags'
+export interface FilterSpec {
+  mode: FilterMode
+  search: string
+}
+export type SelectionState =
+  | { kind: 'explicit'; uids: Set<string> }
+  | { kind: 'all-matching'; filter: FilterSpec; excluded: Set<string> }
+
+// private helpers - mirror predicates from TranslationGrid so entryMatchesFilter stays pure
+function getCategory(entry: TranslationSessionEntry): 'dictionary' | 'tool' | 'manual' | 'none' {
+  if (entry.matchType === 'mod-text' || entry.matchType === 'text') return 'dictionary'
+  if (entry.matchType === 'manual') return 'manual'
+  if (entry.target.trim()) return 'tool'
+  return 'none'
+}
+
+function hasXmlTags(entry: TranslationSessionEntry): boolean {
+  return /(<[^>]+>|\{[^}]+\})/.test(entry.source)
+}
+
+export function entryMatchesFilter(entry: TranslationSessionEntry, filter: FilterSpec): boolean {
+  if (filter.mode === 'untranslated' && entry.target.trim()) return false
+  if (filter.mode === 'translated' && !entry.target.trim()) return false
+  if (filter.mode === 'dictionary' && getCategory(entry) !== 'dictionary') return false
+  if (filter.mode === 'tags' && !hasXmlTags(entry)) return false
+  if (filter.search) {
+    const query = filter.search.toLowerCase()
+    return (
+      entry.source.toLowerCase().includes(query) || entry.target.toLowerCase().includes(query)
+    )
+  }
+  return true
+}
+
+export interface TranslationSessionState {
   phase: Phase
   loadingLabel: string
   entries: TranslationSessionEntry[]
-  selectedUids: Set<string>
+  selection: SelectionState
   modName: string
   sourceLang: string
   targetLang: string
   inputPath: string | null
 }
 
+export function materializeSelectedEntries(
+  state: TranslationSessionState
+): TranslationSessionEntry[] {
+  const { selection, entries } = state
+  if (selection.kind === 'explicit') {
+    return entries.filter((e) => selection.uids.has(e.rowId))
+  }
+  return entries.filter(
+    (e) => entryMatchesFilter(e, selection.filter) && !selection.excluded.has(e.rowId)
+  )
+}
+
+const EMPTY_EXPLICIT: SelectionState = { kind: 'explicit', uids: new Set() }
+
 type Action =
   | { type: 'SET_PHASE'; phase: Phase; loadingLabel?: string }
   | { type: 'SET_ENTRIES'; entries: TranslationSessionEntry[] }
   | { type: 'UPDATE_ENTRY'; rowId: string; target: string }
   | { type: 'MARK_MANUAL'; rowId: string }
-  | { type: 'SELECT_ENTRY'; rowId: string; selected: boolean }
-  | { type: 'SELECT_ENTRIES'; rowIds: string[]; selected: boolean }
+  | { type: 'SELECT_ALL_MATCHING'; filter: FilterSpec }
+  | { type: 'TOGGLE_ENTRY'; rowId: string }
   | { type: 'CLEAR_SELECTION' }
   | { type: 'SET_MOD_NAME'; name: string }
   | { type: 'SET_SOURCE_LANG'; lang: string }
@@ -33,7 +82,7 @@ type Action =
   | { type: 'SET_INPUT_PATH'; path: string }
   | { type: 'RESET' }
 
-function reducer(state: State, action: Action): State {
+function reducer(state: TranslationSessionState, action: Action): TranslationSessionState {
   switch (action.type) {
     case 'SET_PHASE':
       return {
@@ -45,7 +94,7 @@ function reducer(state: State, action: Action): State {
       return {
         ...state,
         entries: action.entries,
-        selectedUids: new Set<string>(),
+        selection: EMPTY_EXPLICIT,
         phase: 'loaded',
         loadingLabel: ''
       }
@@ -63,22 +112,27 @@ function reducer(state: State, action: Action): State {
           e.rowId === action.rowId ? { ...e, matchType: 'manual' } : e
         )
       }
-    case 'SELECT_ENTRY': {
-      const selectedUids = new Set(state.selectedUids)
-      if (action.selected) selectedUids.add(action.rowId)
-      else selectedUids.delete(action.rowId)
-      return { ...state, selectedUids }
-    }
-    case 'SELECT_ENTRIES': {
-      const selectedUids = new Set(state.selectedUids)
-      for (const rowId of action.rowIds) {
-        if (action.selected) selectedUids.add(rowId)
-        else selectedUids.delete(rowId)
+    case 'SELECT_ALL_MATCHING':
+      return {
+        ...state,
+        selection: { kind: 'all-matching', filter: action.filter, excluded: new Set() }
       }
-      return { ...state, selectedUids }
+    case 'TOGGLE_ENTRY': {
+      const { selection } = state
+      if (selection.kind === 'explicit') {
+        const uids = new Set(selection.uids)
+        if (uids.has(action.rowId)) uids.delete(action.rowId)
+        else uids.add(action.rowId)
+        return { ...state, selection: { kind: 'explicit', uids } }
+      }
+      // all-matching: toggle exclusion (excluded = visually unchecked)
+      const excluded = new Set(selection.excluded)
+      if (excluded.has(action.rowId)) excluded.delete(action.rowId)
+      else excluded.add(action.rowId)
+      return { ...state, selection: { ...selection, excluded } }
     }
     case 'CLEAR_SELECTION':
-      return { ...state, selectedUids: new Set<string>() }
+      return { ...state, selection: EMPTY_EXPLICIT }
     case 'SET_MOD_NAME':
       return { ...state, modName: action.name }
     case 'SET_SOURCE_LANG':
@@ -93,7 +147,7 @@ function reducer(state: State, action: Action): State {
         phase: 'idle',
         loadingLabel: '',
         entries: [],
-        selectedUids: new Set<string>(),
+        selection: EMPTY_EXPLICIT,
         inputPath: null
       }
     default:
@@ -101,7 +155,21 @@ function reducer(state: State, action: Action): State {
   }
 }
 
-interface TranslationSessionContext extends State {
+interface TranslationSessionContext extends TranslationSessionState {
+  // new selection API
+  selectAllMatching: (filter: FilterSpec) => void
+  toggleEntry: (rowId: string) => void
+  clearSelection: () => void
+  isSelected: (rowId: string) => boolean
+  selectedCount: number
+  // compat shims - replaced in task 05
+  /** @deprecated use isSelected */
+  selectedUids: Set<string>
+  /** @deprecated use toggleEntry */
+  selectEntry: (rowId: string, selected: boolean) => void
+  /** @deprecated use selectAllMatching */
+  selectEntries: (rowIds: string[], selected: boolean) => void
+  // other
   loadSession: (
     inputPath: string,
     sourceLang: string,
@@ -111,9 +179,6 @@ interface TranslationSessionContext extends State {
   ) => Promise<void>
   updateEntry: (rowId: string, target: string) => void
   markManual: (rowId: string) => void
-  selectEntry: (rowId: string, selected: boolean) => void
-  selectEntries: (rowIds: string[], selected: boolean) => void
-  clearSelection: () => void
   setModName: (name: string) => void
   setSourceLang: (lang: string) => void
   setTargetLang: (lang: string) => void
@@ -134,7 +199,7 @@ export function TranslationSessionProvider({
     phase: 'idle',
     loadingLabel: '',
     entries: [],
-    selectedUids: new Set<string>(),
+    selection: EMPTY_EXPLICIT,
     modName: '',
     sourceLang: DEFAULT_SOURCE,
     targetLang: DEFAULT_TARGET,
@@ -205,17 +270,71 @@ export function TranslationSessionProvider({
     dispatch({ type: 'MARK_MANUAL', rowId })
   }, [])
 
-  const selectEntry = useCallback((rowId: string, selected: boolean) => {
-    dispatch({ type: 'SELECT_ENTRY', rowId, selected })
+  const selectAllMatching = useCallback((filter: FilterSpec) => {
+    dispatch({ type: 'SELECT_ALL_MATCHING', filter })
   }, [])
 
-  const selectEntries = useCallback((rowIds: string[], selected: boolean) => {
-    dispatch({ type: 'SELECT_ENTRIES', rowIds, selected })
+  const toggleEntry = useCallback((rowId: string) => {
+    dispatch({ type: 'TOGGLE_ENTRY', rowId })
   }, [])
 
   const clearSelection = useCallback(() => {
     dispatch({ type: 'CLEAR_SELECTION' })
   }, [])
+
+  const isSelected = useCallback(
+    (rowId: string): boolean => {
+      const { selection, entries } = state
+      if (selection.kind === 'explicit') return selection.uids.has(rowId)
+      const entry = entries.find((e) => e.rowId === rowId)
+      if (!entry) return false
+      return entryMatchesFilter(entry, selection.filter) && !selection.excluded.has(rowId)
+    },
+    [state]
+  )
+
+  const selectedCount = useMemo(() => {
+    const { selection, entries } = state
+    if (selection.kind === 'explicit') return selection.uids.size
+    let count = 0
+    for (const entry of entries) {
+      if (entryMatchesFilter(entry, selection.filter) && !selection.excluded.has(entry.rowId)) {
+        count++
+      }
+    }
+    return count
+  }, [state])
+
+  // compat shim: materializes Set<string> for legacy consumers (task 05 removes)
+  const selectedUids = useMemo(() => {
+    const { selection, entries } = state
+    if (selection.kind === 'explicit') return selection.uids
+    const result = new Set<string>()
+    for (const entry of entries) {
+      if (entryMatchesFilter(entry, selection.filter) && !selection.excluded.has(entry.rowId)) {
+        result.add(entry.rowId)
+      }
+    }
+    return result
+  }, [state])
+
+  // compat shim: maps old per-row select to toggleEntry (task 05 removes)
+  const selectEntry = useCallback(
+    (rowId: string, selected: boolean) => {
+      if (isSelected(rowId) !== selected) dispatch({ type: 'TOGGLE_ENTRY', rowId })
+    },
+    [isSelected]
+  )
+
+  // compat shim: maps old bulk select to individual toggles (task 05 removes)
+  const selectEntries = useCallback(
+    (rowIds: string[], selected: boolean) => {
+      for (const rowId of rowIds) {
+        if (isSelected(rowId) !== selected) dispatch({ type: 'TOGGLE_ENTRY', rowId })
+      }
+    },
+    [isSelected]
+  )
 
   const setModName = useCallback((name: string) => {
     dispatch({ type: 'SET_MOD_NAME', name })
@@ -237,12 +356,17 @@ export function TranslationSessionProvider({
     <Context.Provider
       value={{
         ...state,
+        selectAllMatching,
+        toggleEntry,
+        clearSelection,
+        isSelected,
+        selectedCount,
+        selectedUids,
+        selectEntry,
+        selectEntries,
         loadSession,
         updateEntry,
         markManual,
-        selectEntry,
-        selectEntries,
-        clearSelection,
         setModName,
         setSourceLang,
         setTargetLang,

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -83,7 +83,7 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
       </div>
 
       <BatchActionBar
-        selectedCount={session.selectedUids.size}
+        selectedCount={session.selectedCount}
         batchCompleted={batch.batchCompleted}
         batchTotal={batch.batchTotal}
         onTranslateDeepL={() => batch.batchTranslate('deepl')}

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -8,6 +8,7 @@ import { useDictionarySave } from '../hooks/useDictionarySave'
 import { useLoadedEditorShortcuts } from '../hooks/useLoadedEditorShortcuts'
 import { useTranslationExport } from '../hooks/useTranslationExport'
 import type { TranslationSession } from '../types'
+import { AlreadyTranslatedDialog } from '@/components/translation/AlreadyTranslatedDialog'
 import { EditorHeader } from './EditorHeader'
 import { PackageExportModal } from './PackageExportModal'
 
@@ -91,6 +92,15 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
         onCancelTranslation={batch.cancelBatch}
         onClearSelection={session.clearSelection}
         isTranslating={batch.isBatchTranslating}
+      />
+
+      <AlreadyTranslatedDialog
+        open={batch.pendingDecision}
+        translatedCount={batch.pendingTranslatedCount}
+        untranslatedCount={batch.pendingUntranslatedCount}
+        onProceedAll={batch.confirmProceedAll}
+        onSendOnlyUntranslated={batch.confirmSendOnlyUntranslated}
+        onClose={batch.cancelPending}
       />
 
       {exportFlow.exportMeta && (

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -10,17 +10,25 @@ import type {
 } from '@/types'
 import type { TranslationSession } from '../types'
 
+type BatchEntry = { uid: string; source: string }
+
 export function useBatchTranslation(session: TranslationSession) {
   const { t } = useAppTranslation(['translate', 'toasts', 'common', 'errors'])
   const [isBatchTranslating, setIsBatchTranslating] = useState(false)
   const [activeJobId, setActiveJobId] = useState<string | null>(null)
   const [batchCompleted, setBatchCompleted] = useState(0)
   const [batchTotal, setBatchTotal] = useState(0)
+  const [pendingDecision, setPendingDecision] = useState(false)
+  const [pendingTranslatedCount, setPendingTranslatedCount] = useState(0)
+  const [pendingUntranslatedCount, setPendingUntranslatedCount] = useState(0)
   const batchCleanupRef = useRef<(() => void) | null>(null)
   const activeJobIdRef = useRef<string | null>(null)
   const pendingUidsRef = useRef<Set<string>>(new Set())
   const batchErrorsRef = useRef<Map<string, string>>(new Map())
-  const { entries, sourceLang, targetLang, updateEntry, clearSelection, selectEntries } = session
+  const pendingAllEntriesRef = useRef<BatchEntry[]>([])
+  const pendingUntranslatedEntriesRef = useRef<BatchEntry[]>([])
+  const pendingProviderRef = useRef<'openai' | 'deepl'>('deepl')
+  const { sourceLang, targetLang, updateEntry, clearSelection, selectEntries } = session
 
   const clearListeners = useCallback(() => {
     batchCleanupRef.current?.()
@@ -55,27 +63,15 @@ export function useBatchTranslation(session: TranslationSession) {
     return () => clearListeners()
   }, [clearListeners])
 
-  const batchTranslate = useCallback(
-    async (provider: 'openai' | 'deepl') => {
-      if (isBatchTranslating) return
-
-      const selectedEntries = materializeSelectedEntries(session).map((entry) => ({
-        uid: entry.rowId,
-        source: entry.source
-      }))
-
-      if (selectedEntries.length === 0) {
-        toast.info(t('batchBar.noSelection', { ns: 'translate' }))
-        return
-      }
-
-      pendingUidsRef.current = new Set(selectedEntries.map((entry) => entry.uid))
+  const dispatchBatchEntries = useCallback(
+    async (entriesToSend: BatchEntry[], provider: 'openai' | 'deepl') => {
+      pendingUidsRef.current = new Set(entriesToSend.map((e) => e.uid))
       batchErrorsRef.current = new Map()
       setBatchCompleted(0)
-      setBatchTotal(selectedEntries.length)
+      setBatchTotal(entriesToSend.length)
       setIsBatchTranslating(true)
       clearListeners()
-      const selectedEntriesByUid = new Map(selectedEntries.map((entry) => [entry.uid, entry]))
+      const selectedEntriesByUid = new Map(entriesToSend.map((e) => [e.uid, e]))
 
       const handleBatchProgress = ({
         jobId,
@@ -161,7 +157,7 @@ export function useBatchTranslation(session: TranslationSession) {
         void window.api.log.write({
           scope: 'renderer.batchTranslation',
           message,
-          meta: { provider, sourceLang, targetLang, total: selectedEntries.length }
+          meta: { provider, sourceLang, targetLang, total: entriesToSend.length }
         })
         finishBatchJob(jobId)
       }
@@ -177,7 +173,7 @@ export function useBatchTranslation(session: TranslationSession) {
 
       try {
         const { jobId } = await window.api.translation.batch({
-          entries: selectedEntries,
+          entries: entriesToSend,
           provider,
           sourceLang,
           targetLang
@@ -197,23 +193,84 @@ export function useBatchTranslation(session: TranslationSession) {
           scope: 'renderer.batchTranslation',
           message: err instanceof Error ? err.message : String(err),
           stack: err instanceof Error ? err.stack : undefined,
-          meta: { provider, sourceLang, targetLang, total: selectedEntries.length }
+          meta: { provider, sourceLang, targetLang, total: entriesToSend.length }
         })
       }
     },
     [
       clearListeners,
       clearSelection,
-      entries,
       finishBatchJob,
-      isBatchTranslating,
       restorePendingSelection,
-      session,
       sourceLang,
       targetLang,
       updateEntry
     ]
   )
+
+  const clearPending = useCallback(() => {
+    setPendingDecision(false)
+    setPendingTranslatedCount(0)
+    setPendingUntranslatedCount(0)
+    pendingAllEntriesRef.current = []
+    pendingUntranslatedEntriesRef.current = []
+  }, [])
+
+  const batchTranslate = useCallback(
+    async (provider: 'openai' | 'deepl') => {
+      if (isBatchTranslating) return
+
+      const materialized = materializeSelectedEntries(session)
+      const toEntry = (e: (typeof materialized)[number]): BatchEntry => ({
+        uid: e.rowId,
+        source: e.source
+      })
+
+      if (materialized.length === 0) {
+        toast.info(t('batchBar.noSelection', { ns: 'translate' }))
+        return
+      }
+
+      const translated = materialized.filter((e) => e.target.trim() !== '')
+      const untranslated = materialized.filter((e) => e.target.trim() === '')
+
+      if (translated.length === 0) {
+        await dispatchBatchEntries(materialized.map(toEntry), provider)
+        return
+      }
+
+      // some entries already translated - gate with warning dialog
+      pendingAllEntriesRef.current = materialized.map(toEntry)
+      pendingUntranslatedEntriesRef.current = untranslated.map(toEntry)
+      pendingProviderRef.current = provider
+      setPendingTranslatedCount(translated.length)
+      setPendingUntranslatedCount(untranslated.length)
+      setPendingDecision(true)
+    },
+    [isBatchTranslating, session, dispatchBatchEntries]
+  )
+
+  const confirmProceedAll = useCallback(async () => {
+    const entriesToSend = pendingAllEntriesRef.current
+    const provider = pendingProviderRef.current
+    clearPending()
+    await dispatchBatchEntries(entriesToSend, provider)
+  }, [clearPending, dispatchBatchEntries])
+
+  const confirmSendOnlyUntranslated = useCallback(async () => {
+    const entriesToSend = pendingUntranslatedEntriesRef.current
+    const provider = pendingProviderRef.current
+    clearPending()
+    if (entriesToSend.length === 0) {
+      toast.info(t('batchBar.noSelection', { ns: 'translate' }))
+      return
+    }
+    await dispatchBatchEntries(entriesToSend, provider)
+  }, [clearPending, dispatchBatchEntries])
+
+  const cancelPending = useCallback(() => {
+    clearPending()
+  }, [clearPending])
 
   const cancelBatch = useCallback(async () => {
     if (!activeJobId) return
@@ -226,6 +283,12 @@ export function useBatchTranslation(session: TranslationSession) {
     batchTotal,
     batchTranslate,
     cancelBatch,
-    activeJobId
+    activeJobId,
+    pendingDecision,
+    pendingTranslatedCount,
+    pendingUntranslatedCount,
+    confirmProceedAll,
+    confirmSendOnlyUntranslated,
+    cancelPending
   }
 }

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
+import { materializeSelectedEntries } from '@/context/TranslationSession'
 import { getLocalizedErrorMessage } from '@/i18n/errors'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
 import type {
@@ -19,8 +20,7 @@ export function useBatchTranslation(session: TranslationSession) {
   const activeJobIdRef = useRef<string | null>(null)
   const pendingUidsRef = useRef<Set<string>>(new Set())
   const batchErrorsRef = useRef<Map<string, string>>(new Map())
-  const { entries, selectedUids, sourceLang, targetLang, updateEntry, clearSelection, selectEntries } =
-    session
+  const { entries, sourceLang, targetLang, updateEntry, clearSelection, selectEntries } = session
 
   const clearListeners = useCallback(() => {
     batchCleanupRef.current?.()
@@ -59,9 +59,10 @@ export function useBatchTranslation(session: TranslationSession) {
     async (provider: 'openai' | 'deepl') => {
       if (isBatchTranslating) return
 
-      const selectedEntries = entries
-        .filter((entry) => selectedUids.has(entry.rowId))
-        .map((entry) => ({ uid: entry.rowId, source: entry.source }))
+      const selectedEntries = materializeSelectedEntries(session).map((entry) => ({
+        uid: entry.rowId,
+        source: entry.source
+      }))
 
       if (selectedEntries.length === 0) {
         toast.info(t('batchBar.noSelection', { ns: 'translate' }))
@@ -207,7 +208,7 @@ export function useBatchTranslation(session: TranslationSession) {
       finishBatchJob,
       isBatchTranslating,
       restorePendingSelection,
-      selectedUids,
+      session,
       sourceLang,
       targetLang,
       updateEntry

--- a/src/renderer/src/locales/en/dictionary.json
+++ b/src/renderer/src/locales/en/dictionary.json
@@ -40,7 +40,11 @@
   },
   "selection": {
     "none": "No selection",
-    "count": "{{count}} selected"
+    "count": "{{count}} selected",
+    "pageSelected": "Selected the {{pageSize}} rows on this page.",
+    "selectAllMatching": "Select all {{total}} matching",
+    "allMatchingSelected": "All {{total}} matching rows selected.",
+    "clear": "Clear selection"
   },
   "actions": {
     "exportCsv": "Export CSV",

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -77,7 +77,15 @@
     "containsTags": "contains tags",
     "dictionarySuggestion": "Dictionary suggests:",
     "dictionaryTagMod": "1 term (mod)",
-    "dictionaryTag": "1 term"
+    "dictionaryTag": "1 term",
+    "pagination": {
+      "pageSizeLabel": "Rows per page",
+      "pageOf": "Page {{current}} of {{total}}",
+      "first": "First",
+      "prev": "Previous",
+      "next": "Next",
+      "last": "Last"
+    }
   },
   "batchBar": {
     "selectedCount_one": "{{count}} entry selected",

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -87,6 +87,13 @@
       "last": "Last"
     }
   },
+  "alreadyTranslatedDialog": {
+    "title": "Already-translated entries selected",
+    "description": "{{translatedCount}} of the selected entries already have a translation. How do you want to proceed?",
+    "proceedAll": "Translate everything",
+    "onlyUntranslated": "Send only untranslated ({{untranslatedCount}})",
+    "cancel": "Cancel"
+  },
   "batchBar": {
     "selectedCount_one": "{{count}} entry selected",
     "selectedCount_other": "{{count}} entries selected",

--- a/src/renderer/src/locales/pt-BR/dictionary.json
+++ b/src/renderer/src/locales/pt-BR/dictionary.json
@@ -40,7 +40,11 @@
   },
   "selection": {
     "none": "Nenhuma seleção",
-    "count": "{{count}} selecionadas"
+    "count": "{{count}} selecionadas",
+    "pageSelected": "Selecionadas as {{pageSize}} linhas desta página.",
+    "selectAllMatching": "Selecionar todas as {{total}} correspondentes",
+    "allMatchingSelected": "Todas as {{total}} linhas correspondentes selecionadas.",
+    "clear": "Limpar seleção"
   },
   "actions": {
     "exportCsv": "Exportar CSV",

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -77,7 +77,15 @@
     "containsTags": "contém tags",
     "dictionarySuggestion": "Dicionário sugere:",
     "dictionaryTagMod": "1 termo (mod)",
-    "dictionaryTag": "1 termo"
+    "dictionaryTag": "1 termo",
+    "pagination": {
+      "pageSizeLabel": "Linhas por página",
+      "pageOf": "Página {{current}} de {{total}}",
+      "first": "Primeira",
+      "prev": "Anterior",
+      "next": "Próxima",
+      "last": "Última"
+    }
   },
   "batchBar": {
     "selectedCount_one": "{{count}} entrada selecionada",

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -87,6 +87,13 @@
       "last": "Última"
     }
   },
+  "alreadyTranslatedDialog": {
+    "title": "Entradas já traduzidas selecionadas",
+    "description": "{{translatedCount}} das entradas selecionadas já têm tradução. Como deseja prosseguir?",
+    "proceedAll": "Traduzir tudo",
+    "onlyUntranslated": "Enviar apenas não traduzidas ({{untranslatedCount}})",
+    "cancel": "Cancelar"
+  },
   "batchBar": {
     "selectedCount_one": "{{count}} entrada selecionada",
     "selectedCount_other": "{{count}} entradas selecionadas",

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -43,6 +43,7 @@ interface PendingDeleteState {
   ids: number[]
   title: string
   description: string
+  filterBased?: boolean
 }
 
 interface FilterOption {
@@ -88,6 +89,7 @@ export function DictionaryPage(): React.JSX.Element {
   const [sourceLang, setSourceLang] = useState('')
   const [targetLang, setTargetLang] = useState('')
   const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [selectionScope, setSelectionScope] = useState<'page' | 'all-filtered'>('page')
   const [importOpen, setImportOpen] = useState(false)
   const [createOpen, setCreateOpen] = useState(false)
   const [replaceOpen, setReplaceOpen] = useState(false)
@@ -168,6 +170,7 @@ export function DictionaryPage(): React.JSX.Element {
   useEffect(() => {
     setPage(1)
     setSelectedIds(new Set())
+    setSelectionScope('page')
   }, [filters])
 
   useEffect(() => {
@@ -272,7 +275,7 @@ export function DictionaryPage(): React.JSX.Element {
   const allFilteredSelected =
     displayEntries.length > 0 && displayEntries.every((entry) => selectedIds.has(entry.id))
   const hasFilters = Boolean(text || modName || sourceLang || targetLang)
-  const selectedCount = selectedIds.size
+  const selectedCount = selectionScope === 'all-filtered' ? result.total : selectedIds.size
   const pageStart = result.total === 0 ? 0 : (result.page - 1) * result.pageSize + 1
   const pageEnd = result.total === 0 ? 0 : pageStart + displayEntries.length - 1
 
@@ -356,7 +359,55 @@ export function DictionaryPage(): React.JSX.Element {
     }
   }
 
+  const handleDeleteByFilter = async () => {
+    try {
+      const { deleted } = await window.api.dictionary.deleteByFilter(filters)
+      toast.success(
+        t(deleted === 1 ? 'dictionary.deleted_one' : 'dictionary.deleted_other', {
+          ns: 'toasts',
+          count: deleted
+        })
+      )
+      setPendingDelete(null)
+      setSelectedIds(new Set())
+      setSelectionScope('page')
+      await refreshCurrentPage()
+    } catch (error) {
+      toast.error(getLocalizedErrorMessage(error, t))
+    }
+  }
+
   const handleBatchReplace = async (draft: ReplaceDraft): Promise<boolean> => {
+    if (selectionScope === 'all-filtered') {
+      try {
+        let updated = 0
+        const columns: Array<'language1' | 'language2'> = []
+        if (draft.scope === 'source' || draft.scope === 'both') columns.push('language1')
+        if (draft.scope === 'target' || draft.scope === 'both') columns.push('language2')
+        for (const column of columns) {
+          const res = await window.api.dictionary.replaceByFilter(filters, {
+            findText: draft.find,
+            replaceText: draft.replaceWith,
+            column
+          })
+          updated += res.updated
+        }
+        if (updated === 0) {
+          toast.info(t('dictionary.replaceNone', { ns: 'toasts' }))
+          return false
+        }
+        toast.success(t('dictionary.replaceApplied', { ns: 'toasts', count: updated }))
+        setReplaceOpen(false)
+        setSelectionScope('page')
+        setSelectedIds(new Set())
+        await Promise.all([refreshCurrentPage(), loadReferenceData()])
+        return true
+      } catch (error) {
+        toast.error(getLocalizedErrorMessage(error, t))
+        return false
+      }
+    }
+
     const selectedEntries = displayEntries.filter((entry) => selectedIds.has(entry.id))
     const updates = selectedEntries
       .map((entry) => {
@@ -436,6 +487,7 @@ export function DictionaryPage(): React.JSX.Element {
   }
 
   const toggleSelected = (id: number, checked: boolean) => {
+    if (selectionScope === 'all-filtered') setSelectionScope('page')
     setSelectedIds((previous) => {
       const next = new Set(previous)
       if (checked) next.add(id)
@@ -581,14 +633,26 @@ export function DictionaryPage(): React.JSX.Element {
             type="button"
             disabled={selectedCount === 0}
             onClick={() =>
-              setPendingDelete({
-                ids: Array.from(selectedIds),
-                title: t('dialogs.deleteSelectionTitle', { ns: 'dictionary' }),
-                description: t('dialogs.deleteSelectionDescription', {
-                  ns: 'dictionary',
-                  count: selectedCount
-                })
-              })
+              setPendingDelete(
+                selectionScope === 'all-filtered'
+                  ? {
+                      ids: [],
+                      filterBased: true,
+                      title: t('dialogs.deleteSelectionTitle', { ns: 'dictionary' }),
+                      description: t('dialogs.deleteSelectionDescription', {
+                        ns: 'dictionary',
+                        count: result.total
+                      })
+                    }
+                  : {
+                      ids: Array.from(selectedIds),
+                      title: t('dialogs.deleteSelectionTitle', { ns: 'dictionary' }),
+                      description: t('dialogs.deleteSelectionDescription', {
+                        ns: 'dictionary',
+                        count: selectedCount
+                      })
+                    }
+              )
             }
             className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-red-500/30 bg-red-500/8 px-3 text-xs font-medium text-red-200 transition-colors hover:bg-red-500/14 disabled:cursor-not-allowed disabled:border-[#252a32] disabled:bg-[#131518] disabled:text-neutral-500"
           >
@@ -676,6 +740,51 @@ export function DictionaryPage(): React.JSX.Element {
                 </th>
               </tr>
             </thead>
+            {selectionScope === 'page' &&
+              allFilteredSelected &&
+              result.total > result.pageSize && (
+                <tbody>
+                  <tr>
+                    <td
+                      colSpan={7}
+                      className="border-b border-[#1f2329] bg-amber-500/8 px-4 py-2 text-xs text-amber-300"
+                    >
+                      {t('selection.pageSelected', { ns: 'dictionary', pageSize: displayEntries.length })}
+                      {' '}
+                      <button
+                        type="button"
+                        className="font-semibold underline hover:text-amber-200"
+                        onClick={() => setSelectionScope('all-filtered')}
+                      >
+                        {t('selection.selectAllMatching', { ns: 'dictionary', total: result.total })}
+                      </button>
+                    </td>
+                  </tr>
+                </tbody>
+              )}
+            {selectionScope === 'all-filtered' && (
+              <tbody>
+                <tr>
+                  <td
+                    colSpan={7}
+                    className="border-b border-[#1f2329] bg-blue-500/8 px-4 py-2 text-xs text-blue-300"
+                  >
+                    {t('selection.allMatchingSelected', { ns: 'dictionary', total: result.total })}
+                    {' '}
+                    <button
+                      type="button"
+                      className="font-semibold underline hover:text-blue-200"
+                      onClick={() => {
+                        setSelectionScope('page')
+                        setSelectedIds(new Set())
+                      }}
+                    >
+                      {t('selection.clear', { ns: 'dictionary' })}
+                    </button>
+                  </td>
+                </tr>
+              </tbody>
+            )}
             <tbody>
               {displayEntries.map((entry) => (
                 <tr
@@ -870,7 +979,8 @@ export function DictionaryPage(): React.JSX.Element {
         destructive
         onClose={() => setPendingDelete(null)}
         onConfirm={() => {
-          if (pendingDelete) void handleDeleteMany(pendingDelete.ids)
+          if (pendingDelete?.filterBased) void handleDeleteByFilter()
+          else if (pendingDelete) void handleDeleteMany(pendingDelete.ids)
         }}
       />
 

--- a/src/renderer/src/pages/DictionaryPage.tsx
+++ b/src/renderer/src/pages/DictionaryPage.tsx
@@ -14,6 +14,7 @@ import {
   X
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useVirtualizer } from '@tanstack/react-virtual'
 import { toast } from 'sonner'
 import { DictionaryEntryModal } from '@/components/dictionary/DictionaryEntryModal'
 import { DictionaryImportModal } from '@/components/dictionary/DictionaryImportModal'
@@ -64,6 +65,8 @@ type DictionaryLoadingMode = 'overlay' | 'replace'
 
 const TABLE_HEADER =
   'select-none text-[10px] font-semibold uppercase tracking-[0.08em] text-neutral-500'
+// grid-based virtualization (Option B) - 7 columns matching header and rows
+const GRID_COLS = '48px 112px 1fr 1fr 192px 144px 128px'
 const DEFAULT_PAGE_SIZE = 200
 const MAX_PAGE_SIZE = 1000
 const PAGE_SIZE_OPTIONS = [50, 100, 200, 500, 1000]
@@ -202,6 +205,15 @@ export function DictionaryPage(): React.JSX.Element {
     () => result.items.map((entry) => toDisplayEntry(entry, filters)),
     [filters, result.items]
   )
+
+  const scrollRef = useRef<HTMLDivElement>(null)
+
+  const rowVirtualizer = useVirtualizer({
+    count: displayEntries.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => 44,
+    overscan: 10,
+  })
 
   const modOptions = useMemo(
     () => buildModOptions(displayEntries, knownMods),
@@ -708,114 +720,114 @@ export function DictionaryPage(): React.JSX.Element {
       </div>
 
       <div className="relative min-h-0 flex-1">
-        <div className="icosa-scroll h-full overflow-auto">
-          <table className="w-full border-collapse text-sm">
-            <thead className="sticky top-0 z-10 bg-[#131518]">
-              <tr className="border-b border-[#1f2329]">
-                <th className={cn(TABLE_HEADER, 'w-12 px-4 py-3 text-center')}>
-                  <input
-                    type="checkbox"
-                    checked={allFilteredSelected}
-                    onChange={(event) => toggleSelectAll(event.target.checked)}
-                    className="h-4 w-4 cursor-pointer accent-amber-500"
-                  />
-                </th>
-                <th className={cn(TABLE_HEADER, 'w-28 px-4 py-3 text-left')}>
-                  {t('table.id', { ns: 'dictionary' })}
-                </th>
-                <th className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
-                  {t('table.sourceText', { ns: 'dictionary' })}
-                </th>
-                <th className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
-                  {t('table.targetText', { ns: 'dictionary' })}
-                </th>
-                <th className={cn(TABLE_HEADER, 'w-48 px-4 py-3 text-left')}>
-                  {t('table.mod', { ns: 'dictionary' })}
-                </th>
-                <th className={cn(TABLE_HEADER, 'w-36 px-4 py-3 text-left')}>
-                  {t('table.languages', { ns: 'dictionary' })}
-                </th>
-                <th className={cn(TABLE_HEADER, 'w-32 px-4 py-3 text-right')}>
-                  {t('table.actions', { ns: 'dictionary' })}
-                </th>
-              </tr>
-            </thead>
-            {selectionScope === 'page' &&
-              allFilteredSelected &&
-              result.total > result.pageSize && (
-                <tbody>
-                  <tr>
-                    <td
-                      colSpan={7}
-                      className="border-b border-[#1f2329] bg-amber-500/8 px-4 py-2 text-xs text-amber-300"
-                    >
-                      {t('selection.pageSelected', { ns: 'dictionary', pageSize: displayEntries.length })}
-                      {' '}
-                      <button
-                        type="button"
-                        className="font-semibold underline hover:text-amber-200"
-                        onClick={() => setSelectionScope('all-filtered')}
-                      >
-                        {t('selection.selectAllMatching', { ns: 'dictionary', total: result.total })}
-                      </button>
-                    </td>
-                  </tr>
-                </tbody>
-              )}
-            {selectionScope === 'all-filtered' && (
-              <tbody>
-                <tr>
-                  <td
-                    colSpan={7}
-                    className="border-b border-[#1f2329] bg-blue-500/8 px-4 py-2 text-xs text-blue-300"
-                  >
-                    {t('selection.allMatchingSelected', { ns: 'dictionary', total: result.total })}
-                    {' '}
-                    <button
-                      type="button"
-                      className="font-semibold underline hover:text-blue-200"
-                      onClick={() => {
-                        setSelectionScope('page')
-                        setSelectedIds(new Set())
-                      }}
-                    >
-                      {t('selection.clear', { ns: 'dictionary' })}
-                    </button>
-                  </td>
-                </tr>
-              </tbody>
-            )}
-            <tbody>
-              {displayEntries.map((entry) => (
-                <tr
+        {/* grid-based virtualized layout (Option B) - avoids <table> absolute-positioning quirks */}
+        <div ref={scrollRef} className="icosa-scroll h-full overflow-auto">
+          {/* sticky header row */}
+          <div
+            className="sticky top-0 z-10 grid border-b border-[#1f2329] bg-[#131518] pr-[var(--scrollbar-width,0px)]"
+            style={{ gridTemplateColumns: GRID_COLS }}
+          >
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-center')}>
+              <input
+                type="checkbox"
+                checked={allFilteredSelected}
+                onChange={(event) => toggleSelectAll(event.target.checked)}
+                className="h-4 w-4 cursor-pointer accent-amber-500"
+              />
+            </div>
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
+              {t('table.id', { ns: 'dictionary' })}
+            </div>
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
+              {t('table.sourceText', { ns: 'dictionary' })}
+            </div>
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
+              {t('table.targetText', { ns: 'dictionary' })}
+            </div>
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
+              {t('table.mod', { ns: 'dictionary' })}
+            </div>
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-left')}>
+              {t('table.languages', { ns: 'dictionary' })}
+            </div>
+            <div className={cn(TABLE_HEADER, 'px-4 py-3 text-right')}>
+              {t('table.actions', { ns: 'dictionary' })}
+            </div>
+          </div>
+
+          {/* cross-page selection banners (task 07) */}
+          {selectionScope === 'page' && allFilteredSelected && result.total > result.pageSize && (
+            <div className="border-b border-[#1f2329] bg-amber-500/8 px-4 py-2 text-xs text-amber-300">
+              {t('selection.pageSelected', { ns: 'dictionary', pageSize: displayEntries.length })}{' '}
+              <button
+                type="button"
+                className="font-semibold underline hover:text-amber-200"
+                onClick={() => setSelectionScope('all-filtered')}
+              >
+                {t('selection.selectAllMatching', { ns: 'dictionary', total: result.total })}
+              </button>
+            </div>
+          )}
+          {selectionScope === 'all-filtered' && (
+            <div className="border-b border-[#1f2329] bg-blue-500/8 px-4 py-2 text-xs text-blue-300">
+              {t('selection.allMatchingSelected', { ns: 'dictionary', total: result.total })}{' '}
+              <button
+                type="button"
+                className="font-semibold underline hover:text-blue-200"
+                onClick={() => {
+                  setSelectionScope('page')
+                  setSelectedIds(new Set())
+                }}
+              >
+                {t('selection.clear', { ns: 'dictionary' })}
+              </button>
+            </div>
+          )}
+
+          {/* virtual rows */}
+          <div style={{ height: rowVirtualizer.getTotalSize(), position: 'relative' }}>
+            {rowVirtualizer.getVirtualItems().map((virtualItem) => {
+              const entry = displayEntries[virtualItem.index]
+              return (
+                <div
                   key={entry.id}
+                  data-index={virtualItem.index}
+                  ref={rowVirtualizer.measureElement}
                   className={cn(
-                    'border-b border-[#1f2329] transition-colors hover:bg-[#131518]',
+                    'grid border-b border-[#1f2329] transition-colors hover:bg-[#131518]',
                     selectedIds.has(entry.id) && 'bg-[#131518]'
                   )}
+                  style={{
+                    position: 'absolute',
+                    top: 0,
+                    left: 0,
+                    width: '100%',
+                    transform: `translateY(${virtualItem.start}px)`,
+                    gridTemplateColumns: GRID_COLS,
+                  }}
                 >
-                  <td className="px-4 py-3 align-top text-center">
+                  <div className="px-4 py-3 text-center self-start">
                     <input
                       type="checkbox"
                       checked={selectedIds.has(entry.id)}
                       onChange={(event) => toggleSelected(entry.id, event.target.checked)}
                       className="mt-1 h-4 w-4 cursor-pointer accent-amber-500"
                     />
-                  </td>
-                  <td className="px-4 py-3 align-top">
+                  </div>
+                  <div className="px-4 py-3 self-start">
                     <span className="font-mono text-[11px] text-neutral-500">{entry.id}</span>
-                  </td>
-                  <td className="px-4 py-3 align-top">
+                  </div>
+                  <div className="px-4 py-3 self-start">
                     <div className="wrap-break-word font-mono text-sm leading-6 text-neutral-100 whitespace-pre-wrap">
                       {entry.sourceText ? renderSource(entry.sourceText) : null}
                     </div>
-                  </td>
-                  <td className="px-4 py-3 align-top">
+                  </div>
+                  <div className="px-4 py-3 self-start">
                     <div className="wrap-break-word font-mono text-sm leading-6 text-neutral-200 whitespace-pre-wrap">
                       {entry.targetText ? renderSource(entry.targetText) : null}
                     </div>
-                  </td>
-                  <td className="px-4 py-3 align-top">
+                  </div>
+                  <div className="px-4 py-3 self-start">
                     <div className="flex flex-col gap-2">
                       <span className="inline-flex max-w-full items-center gap-2 rounded-md border border-[#252a32] bg-[#0c0d0f] px-2 py-1 text-xs text-neutral-300">
                         <span className="h-1.5 w-1.5 rounded-full bg-amber-400" />
@@ -829,15 +841,15 @@ export function DictionaryPage(): React.JSX.Element {
                         </span>
                       )}
                     </div>
-                  </td>
-                  <td className="px-4 py-3 align-top">
+                  </div>
+                  <div className="px-4 py-3 self-start">
                     <span className="inline-flex items-center gap-1 font-mono text-[11px] text-neutral-400">
                       <span>{entry.sourceLang.toUpperCase()}</span>
                       <span className="text-neutral-600">-&gt;</span>
                       <span className="text-amber-400">{entry.targetLang.toUpperCase()}</span>
                     </span>
-                  </td>
-                  <td className="px-4 py-3 align-top">
+                  </div>
+                  <div className="px-4 py-3 self-start">
                     <div className="flex justify-end gap-1">
                       <button
                         type="button"
@@ -863,37 +875,33 @@ export function DictionaryPage(): React.JSX.Element {
                         <Trash2 size={13} />
                       </button>
                     </div>
-                  </td>
-                </tr>
-              ))}
+                  </div>
+                </div>
+              )
+            })}
+          </div>
 
-              {!loading && displayEntries.length === 0 && (
-                <tr>
-                  <td colSpan={7} className="px-6 py-20">
-                    <div className="flex flex-col items-center gap-3 text-center">
-                      <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-[#252a32] bg-[#131518] text-neutral-400">
-                        <BookOpen size={20} />
-                      </div>
-                      <div className="text-sm font-semibold text-neutral-200">
-                        {t('table.noEntries', { ns: 'dictionary' })}
-                      </div>
-                      <div className="text-xs text-neutral-500">
-                        {t('table.noEntriesDescription', { ns: 'dictionary' })}
-                      </div>
-                    </div>
-                  </td>
-                </tr>
-              )}
+          {!loading && displayEntries.length === 0 && (
+            <div className="px-6 py-20">
+              <div className="flex flex-col items-center gap-3 text-center">
+                <div className="flex h-12 w-12 items-center justify-center rounded-xl border border-[#252a32] bg-[#131518] text-neutral-400">
+                  <BookOpen size={20} />
+                </div>
+                <div className="text-sm font-semibold text-neutral-200">
+                  {t('table.noEntries', { ns: 'dictionary' })}
+                </div>
+                <div className="text-xs text-neutral-500">
+                  {t('table.noEntriesDescription', { ns: 'dictionary' })}
+                </div>
+              </div>
+            </div>
+          )}
 
-              {bootstrapping && (
-                <tr>
-                  <td colSpan={7} className="px-6 py-16 text-center text-sm text-neutral-500">
-                    {t('table.preparing', { ns: 'dictionary' })}
-                  </td>
-                </tr>
-              )}
-            </tbody>
-          </table>
+          {bootstrapping && (
+            <div className="px-6 py-16 text-center text-sm text-neutral-500">
+              {t('table.preparing', { ns: 'dictionary' })}
+            </div>
+          )}
         </div>
 
         {loading && <DictionaryLoadingOverlay mode={loadingMode} />}


### PR DESCRIPTION
## Summary
- **Translation tab**: replaces flat `selectedUids: Set<string>` with a filter-based `SelectionState` (explicit / all-matching), adds server-side pagination (100–1000 rows/page), virtualizes both side-by-side and stacked views with `@tanstack/react-virtual`, wires select-all to cover every entry matching the current filter (not just the rendered page), and adds a warning dialog before batch-translating already-translated entries.
- **Dictionary tab**: adds cross-page select-all with server-side `deleteByFilter` / `replaceByFilter` IPC calls (single SQL DELETE/UPDATE instead of iterating IDs), virtualizes the table with a CSS-grid-based virtual list, and adds three composite SQLite indexes (`language1+language2`, `language1+language2+mod_name`, `mod_name`) via a Drizzle migration.

## Version
- v1.2.0 (bump reason: multiple new user-visible features)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (pre-existing failures in `.vscode/` and `drizzle/meta/` JSON files are unrelated)
- [x] `pnpm dev`: open `/translate`, load a mod with ≥1000 entries — pagination footer shows "Page 1 of N", only 250 rows rendered by default
- [x] Switch filter to `untranslated`, type a query, click select-all — selected count equals total matching across all pages (not just the current page)
- [x] Uncheck one visible row → select-all checkbox flips to unchecked; count drops by 1
- [x] Click Translate with mixed translated/untranslated selection → warning dialog opens; "Send only untranslated" sends only untranslated entries
- [x] DevTools Elements: scroll the translation grid — DOM row count stays ≤ ~30 regardless of page size
- [x] `pnpm dev`: open `/dictionary`, set page size to 1000 — scrolls smoothly, sticky header stays visible
- [x] Apply a filter so `total > pageSize`, select all on page → banner "Select all N matching" appears; click it → delete all N in one call; verify count drops by N in `pnpm db:studio`
- [x] Batch replace in all-filtered mode applies to every matching row across all pages
- [x] Restart app — migration `0005_nostalgic_black_crow` applies cleanly, no runtime errors