### PR TITLE
feat(perf): non-blocking merge and xml:load with real-time progress (v1.3.0)

### DIFF
--- a/drizzle/0006_fair_captain_universe.sql
+++ b/drizzle/0006_fair_captain_universe.sql
@@ -1,0 +1,7 @@
+ALTER TABLE `dictionary` ADD `text_language1_key` text DEFAULT '' NOT NULL;--> statement-breakpoint
+ALTER TABLE `dictionary` ADD `text_language2_key` text DEFAULT '' NOT NULL;--> statement-breakpoint
+CREATE INDEX `dictionary_match_idx` ON `dictionary` (`language1`,`language2`,`mod_name`,`text_language1_key`);--> statement-breakpoint
+CREATE INDEX `dictionary_match_uid_idx` ON `dictionary` (`language1`,`language2`,`mod_name`,`uid`,`text_language1_key`);--> statement-breakpoint
+UPDATE `dictionary` SET
+  `text_language1_key` = lower(trim(`text_language1`)),
+  `text_language2_key` = lower(trim(`text_language2`));

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,476 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "71b63901-7547-43ca-8a68-0a33def80716",
+  "prevId": "23af3325-94c1-4d46-ac65-2e16348dd6a8",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dictionary": {
+      "name": "dictionary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "language1": {
+          "name": "language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language2": {
+          "name": "language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1": {
+          "name": "text_language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language2": {
+          "name": "text_language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1_key": {
+          "name": "text_language1_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "text_language2_key": {
+          "name": "text_language2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mod_name": {
+          "name": "mod_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "dictionary_langs_idx": {
+          "name": "dictionary_langs_idx",
+          "columns": [
+            "language1",
+            "language2"
+          ],
+          "isUnique": false
+        },
+        "dictionary_langs_mod_idx": {
+          "name": "dictionary_langs_mod_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_mod_idx": {
+          "name": "dictionary_mod_idx",
+          "columns": [
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_match_idx": {
+          "name": "dictionary_match_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name",
+            "text_language1_key"
+          ],
+          "isUnique": false
+        },
+        "dictionary_match_uid_idx": {
+          "name": "dictionary_match_uid_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name",
+            "uid",
+            "text_language1_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "dictionary_language1_language_code_fk": {
+          "name": "dictionary_language1_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language1"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_language2_language_code_fk": {
+          "name": "dictionary_language2_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language2"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_mod_name_mod_name_fk": {
+          "name": "dictionary_mod_name_mod_name_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language": {
+      "name": "language",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "language_code_unique": {
+          "name": "language_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod": {
+      "name": "mod",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_strings": {
+          "name": "total_strings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_file_path": {
+          "name": "last_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_name_unique": {
+          "name": "mod_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod_meta": {
+      "name": "mod_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta_file_path": {
+          "name": "meta_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_major": {
+          "name": "version_major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_minor": {
+          "name": "version_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_revision": {
+          "name": "version_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_build": {
+          "name": "version_build",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version64": {
+          "name": "version64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_meta_mod_id_unique": {
+          "name": "mod_meta_mod_id_unique",
+          "columns": [
+            "mod_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mod_meta_mod_id_mod_id_fk": {
+          "name": "mod_meta_mod_id_mod_id_fk",
+          "tableFrom": "mod_meta",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1778975652088,
       "tag": "0005_nostalgic_black_crow",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "6",
+      "when": 1778982960726,
+      "tag": "0006_fair_captain_universe",
+      "breakpoints": true
     }
   ]
 }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.2.0
+buildVersion: 1.3.0
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -1,10 +1,19 @@
-import { resolve } from 'path'
-import { defineConfig } from 'electron-vite'
-import react from '@vitejs/plugin-react'
+import { resolve } from 'node:path'
 import tailwindcss from '@tailwindcss/vite'
+import react from '@vitejs/plugin-react'
+import { defineConfig } from 'electron-vite'
 
 export default defineConfig({
-  main: {},
+  main: {
+    build: {
+      rollupOptions: {
+        input: {
+          index: resolve('src/main/index.ts'),
+          'merge.worker': resolve('src/main/workers/merge.worker.ts')
+        }
+      }
+    }
+  },
   preload: {},
   renderer: {
     resolve: {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/src/main/database/connection.ts
+++ b/src/main/database/connection.ts
@@ -1,13 +1,20 @@
+import path from 'node:path'
+import { is } from '@electron-toolkit/utils'
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
 import { migrate } from 'drizzle-orm/better-sqlite3/migrator'
 import { app } from 'electron'
-import { is } from '@electron-toolkit/utils'
-import path from 'path'
+import { dictionaryTextKey } from '../utils/dictionaryText'
 import * as schema from './schema'
 import { seedLanguages } from './seeds/languages.seed'
 
 type AppDb = ReturnType<typeof drizzle<typeof schema>>
+
+interface DictionaryTextRow {
+  id: number
+  text_language1: string
+  text_language2: string
+}
 
 let _db: AppDb | null = null
 let _sqlite: Database.Database | null = null
@@ -20,6 +27,7 @@ export function getDb(): AppDb {
     _sqlite.pragma('foreign_keys = ON')
     _db = drizzle(_sqlite, { schema })
     migrate(_db, { migrationsFolder: getMigrationsFolder() })
+    backfillDictionaryTextKeys(_sqlite)
     seedLanguages(_db)
   }
   return _db
@@ -29,6 +37,33 @@ export function closeDb(): void {
   _sqlite?.close()
   _sqlite = null
   _db = null
+}
+
+// Backfill text_language1_key / text_language2_key for rows whose text contains XML
+// entities (e.g. &apos;, &amp;). The SQL migration uses lower(trim(...)) which cannot
+// decode entities, so this pass corrects any affected rows after the migrator runs.
+function backfillDictionaryTextKeys(sqlite: Database.Database): void {
+  const rows = sqlite
+    .prepare(
+      "SELECT id, text_language1, text_language2 FROM dictionary WHERE text_language1 LIKE '%&%' OR text_language2 LIKE '%&%'"
+    )
+    .all() as DictionaryTextRow[]
+
+  if (rows.length === 0) return
+
+  const update = sqlite.prepare(
+    'UPDATE dictionary SET text_language1_key = ?, text_language2_key = ? WHERE id = ?'
+  )
+
+  sqlite.transaction(() => {
+    for (const row of rows) {
+      update.run(
+        dictionaryTextKey(row.text_language1),
+        dictionaryTextKey(row.text_language2),
+        row.id
+      )
+    }
+  })()
 }
 
 function getMigrationsFolder(): string {

--- a/src/main/database/repositories/dictionary.repo.ts
+++ b/src/main/database/repositories/dictionary.repo.ts
@@ -84,15 +84,16 @@ export class DictionaryRepository {
   ): DictionaryEntry | undefined {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
     const sourceKey = dictionaryTextKey(sourceText)
+    const keyColumn = swapped ? dictionary.textLanguage2Key : dictionary.textLanguage1Key
 
-    const rows = this.db
+    return this.db
       .select()
       .from(dictionary)
-      .where(and(eq(dictionary.language1, l1), eq(dictionary.language2, l2)))
+      .where(
+        and(eq(dictionary.language1, l1), eq(dictionary.language2, l2), eq(keyColumn, sourceKey))
+      )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .all() as DictionaryEntry[]
-
-    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+      .get() as DictionaryEntry | undefined
   }
 
   findByModAndText(
@@ -104,21 +105,21 @@ export class DictionaryRepository {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
     const sourceKey = dictionaryTextKey(sourceText)
     const normalizedMod = modName.toLowerCase()
+    const keyColumn = swapped ? dictionary.textLanguage2Key : dictionary.textLanguage1Key
 
-    const rows = this.db
+    return this.db
       .select()
       .from(dictionary)
       .where(
         and(
           eq(dictionary.language1, l1),
           eq(dictionary.language2, l2),
-          sql`lower(coalesce(${dictionary.modName}, '')) = ${normalizedMod}`
+          sql`lower(coalesce(${dictionary.modName}, '')) = ${normalizedMod}`,
+          eq(keyColumn, sourceKey)
         )
       )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .all() as DictionaryEntry[]
-
-    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+      .get() as DictionaryEntry | undefined
   }
 
   findByModUidAndText(
@@ -131,8 +132,9 @@ export class DictionaryRepository {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
     const sourceKey = dictionaryTextKey(sourceText)
     const normalizedMod = modName.toLowerCase()
+    const keyColumn = swapped ? dictionary.textLanguage2Key : dictionary.textLanguage1Key
 
-    const rows = this.db
+    return this.db
       .select()
       .from(dictionary)
       .where(
@@ -140,13 +142,12 @@ export class DictionaryRepository {
           eq(dictionary.language1, l1),
           eq(dictionary.language2, l2),
           sql`lower(coalesce(${dictionary.modName}, '')) = ${normalizedMod}`,
-          eq(dictionary.uid, uid)
+          eq(dictionary.uid, uid),
+          eq(keyColumn, sourceKey)
         )
       )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .all() as DictionaryEntry[]
-
-    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+      .get() as DictionaryEntry | undefined
   }
 
   resolveMatch(params: {
@@ -245,6 +246,80 @@ export class DictionaryRepository {
     this.create(params)
   }
 
+  loadKeyMap(
+    sourceLang: string,
+    targetLang: string,
+    modName: string
+  ): Map<string, { id: number; targetKey: string; uid: string | null }> {
+    const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
+    const normalizedMod = modName.toLowerCase()
+
+    const rows = this.db
+      .select({
+        id: dictionary.id,
+        uid: dictionary.uid,
+        key1: dictionary.textLanguage1Key,
+        key2: dictionary.textLanguage2Key
+      })
+      .from(dictionary)
+      .where(
+        and(
+          eq(dictionary.language1, l1),
+          eq(dictionary.language2, l2),
+          sql`lower(coalesce(${dictionary.modName}, '')) = ${normalizedMod}`
+        )
+      )
+      .all() as { id: number; uid: string | null; key1: string; key2: string }[]
+
+    const map = new Map<string, { id: number; targetKey: string; uid: string | null }>()
+    for (const row of rows) {
+      const sourceKey = swapped ? row.key2 : row.key1
+      const targetKey = swapped ? row.key1 : row.key2
+      map.set(sourceKey, { id: row.id, targetKey, uid: row.uid })
+    }
+    return map
+  }
+
+  // Multi-row VALUES INSERT in a single transaction. Chunks internally so the bound
+  // parameter count stays under SQLite's 999-param cap (8 cols * 100 rows = 800).
+  bulkInsert(rows: NewDictionaryEntry[]): void {
+    if (rows.length === 0) return
+    const CHUNK_SIZE = 100
+
+    this.db.transaction((tx) => {
+      for (let i = 0; i < rows.length; i += CHUNK_SIZE) {
+        const chunk = rows.slice(i, i + CHUNK_SIZE)
+        tx.insert(dictionary).values(chunk).run()
+      }
+    })
+  }
+
+  // Per-row UPDATE in a single transaction. uid is COALESCEd so null leaves it untouched.
+  bulkUpdate(
+    updates: { id: number; targetText: string; targetTextKey: string; uid: string | null }[],
+    column: 'language1' | 'language2' = 'language2'
+  ): void {
+    if (updates.length === 0) return
+
+    this.db.transaction((tx) => {
+      for (const u of updates) {
+        const setPayload =
+          column === 'language1'
+            ? { textLanguage1: u.targetText, textLanguage1Key: u.targetTextKey }
+            : { textLanguage2: u.targetText, textLanguage2Key: u.targetTextKey }
+
+        tx.update(dictionary)
+          .set({
+            ...setPayload,
+            uid: sql`COALESCE(${u.uid}, ${dictionary.uid})`,
+            updatedAt: sql`(datetime('now'))`
+          })
+          .where(eq(dictionary.id, u.id))
+          .run()
+      }
+    })
+  }
+
   getAll(lang1: string, lang2: string): DictionaryEntry[] {
     const [l1, l2] = normalizeLangs(lang1, lang2)
     return this.db
@@ -324,7 +399,9 @@ export class DictionaryRepository {
       const finalWhere = filterWhere ? (and(filterWhere, likeWhere) as SQL) : likeWhere
       const result = this.db
         .update(dictionary)
-        .set({ textLanguage1: sql`replace(${dictionary.textLanguage1}, ${findText}, ${replaceText})` })
+        .set({
+          textLanguage1: sql`replace(${dictionary.textLanguage1}, ${findText}, ${replaceText})`
+        })
         .where(finalWhere)
         .run() as { changes: number }
       return { updated: result.changes }
@@ -334,7 +411,9 @@ export class DictionaryRepository {
     const finalWhere = filterWhere ? (and(filterWhere, likeWhere) as SQL) : likeWhere
     const result = this.db
       .update(dictionary)
-      .set({ textLanguage2: sql`replace(${dictionary.textLanguage2}, ${findText}, ${replaceText})` })
+      .set({
+        textLanguage2: sql`replace(${dictionary.textLanguage2}, ${findText}, ${replaceText})`
+      })
       .where(finalWhere)
       .run() as { changes: number }
     return { updated: result.changes }
@@ -403,21 +482,21 @@ export class DictionaryRepository {
   ): DictionaryEntry | undefined {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
     const sourceKey = dictionaryTextKey(sourceText)
+    const keyColumn = swapped ? dictionary.textLanguage2Key : dictionary.textLanguage1Key
 
-    const rows = this.db
+    return this.db
       .select()
       .from(dictionary)
       .where(
         and(
           eq(dictionary.language1, l1),
           eq(dictionary.language2, l2),
-          sql`${dictionary.modName} is null`
+          sql`${dictionary.modName} is null`,
+          eq(keyColumn, sourceKey)
         )
       )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .all() as DictionaryEntry[]
-
-    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+      .get() as DictionaryEntry | undefined
   }
 
   private findUnscopedByUidAndText(
@@ -428,8 +507,9 @@ export class DictionaryRepository {
   ): DictionaryEntry | undefined {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
     const sourceKey = dictionaryTextKey(sourceText)
+    const keyColumn = swapped ? dictionary.textLanguage2Key : dictionary.textLanguage1Key
 
-    const rows = this.db
+    return this.db
       .select()
       .from(dictionary)
       .where(
@@ -437,13 +517,12 @@ export class DictionaryRepository {
           eq(dictionary.language1, l1),
           eq(dictionary.language2, l2),
           sql`${dictionary.modName} is null`,
-          eq(dictionary.uid, uid)
+          eq(dictionary.uid, uid),
+          eq(keyColumn, sourceKey)
         )
       )
       .orderBy(desc(dictionary.updatedAt), desc(dictionary.id))
-      .all() as DictionaryEntry[]
-
-    return rows.find((entry) => this.sourceTextKey(entry, swapped) === sourceKey)
+      .get() as DictionaryEntry | undefined
   }
 
   private toValues(params: UpsertParams): NewDictionaryEntry {
@@ -457,12 +536,10 @@ export class DictionaryRepository {
       language2: l2,
       textLanguage1: text1,
       textLanguage2: text2,
+      textLanguage1Key: dictionaryTextKey(text1),
+      textLanguage2Key: dictionaryTextKey(text2),
       modName: params.modName?.trim() || null,
       uid: params.uid?.trim() || null
     }
-  }
-
-  private sourceTextKey(entry: DictionaryEntry, swapped: boolean): string {
-    return dictionaryTextKey(swapped ? entry.textLanguage2 : entry.textLanguage1)
   }
 }

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -1,5 +1,5 @@
-import { sqliteTable, text, integer, index } from 'drizzle-orm/sqlite-core'
 import { sql } from 'drizzle-orm'
+import { index, integer, sqliteTable, text } from 'drizzle-orm/sqlite-core'
 
 const timestamps = {
   createdAt: text('created_at').default(sql`(datetime('now'))`),
@@ -55,6 +55,8 @@ export const dictionary = sqliteTable(
       .references(() => language.code),
     textLanguage1: text('text_language1').notNull(),
     textLanguage2: text('text_language2').notNull(),
+    textLanguage1Key: text('text_language1_key').notNull().default(''),
+    textLanguage2Key: text('text_language2_key').notNull().default(''),
     modName: text('mod_name').references(() => mod.name),
     uid: text('uid'),
     ...timestamps
@@ -66,7 +68,20 @@ export const dictionary = sqliteTable(
       table.language2,
       table.modName
     ),
-    dictionary_mod_idx: index('dictionary_mod_idx').on(table.modName)
+    dictionary_mod_idx: index('dictionary_mod_idx').on(table.modName),
+    dictionary_match_idx: index('dictionary_match_idx').on(
+      table.language1,
+      table.language2,
+      table.modName,
+      table.textLanguage1Key
+    ),
+    dictionary_match_uid_idx: index('dictionary_match_uid_idx').on(
+      table.language1,
+      table.language2,
+      table.modName,
+      table.uid,
+      table.textLanguage1Key
+    )
   })
 )
 

--- a/src/main/ipc/merge.ipc.ts
+++ b/src/main/ipc/merge.ipc.ts
@@ -1,4 +1,4 @@
-import { ipcMain } from 'electron'
+import { ipcMain, type WebContents } from 'electron'
 import type { RepositoryRegistry } from '../database/repositories/registry'
 import { type MergeResult, mergeXmls } from '../services/merge.service'
 import {
@@ -26,7 +26,11 @@ interface RunMergePayload {
   modName: string
 }
 
-async function runMerge(repos: RepositoryRegistry, payload: RunMergePayload): Promise<MergeResult> {
+async function runMerge(
+  repos: RepositoryRegistry,
+  sender: WebContents,
+  payload: RunMergePayload
+): Promise<MergeResult> {
   const sourceCandidate = getStagedCandidate(payload.sourceImportId, payload.sourceCandidateId)
   const targetCandidate = getStagedCandidate(payload.targetImportId, payload.targetCandidateId)
 
@@ -47,7 +51,8 @@ async function runMerge(repos: RepositoryRegistry, payload: RunMergePayload): Pr
       sourceLang: payload.sourceLang,
       targetXmlPath: targetCandidate.absolutePath,
       targetLang: payload.targetLang,
-      modName
+      modName,
+      onProgress: (p) => sender.send('merge:progress', p)
     })
   } finally {
     discardTranslationInput(payload.sourceImportId)
@@ -72,6 +77,7 @@ export function registerMergeHandlers(repos: RepositoryRegistry): void {
 
   ipcMain.handle(
     'merge:run',
-    async (_event, payload: RunMergePayload): Promise<MergeResult> => runMerge(repos, payload)
+    async (event, payload: RunMergePayload): Promise<MergeResult> =>
+      runMerge(repos, event.sender, payload)
   )
 }

--- a/src/main/ipc/xml.ipc.ts
+++ b/src/main/ipc/xml.ipc.ts
@@ -1,5 +1,5 @@
 import path from 'node:path'
-import { ipcMain } from 'electron'
+import { ipcMain, type WebContents } from 'electron'
 import { getDictionaryTargetText } from '../database/repositories/dictionary.repo'
 import type { RepositoryRegistry } from '../database/repositories/registry'
 import { unpackMod } from '../services/lslib.service'
@@ -34,6 +34,11 @@ interface ExportPayload {
   entries: XmlEntry[]
 }
 
+type XmlLoadProgress =
+  | { phase: 'unpacking' }
+  | { phase: 'parsing' }
+  | { phase: 'matching'; processed: number; total: number }
+
 function toUiEntry(entry: LocalizationEntry): Pick<XmlEntry, 'uid' | 'version' | 'source'> {
   return {
     uid: entry.contentuid,
@@ -42,7 +47,13 @@ function toUiEntry(entry: LocalizationEntry): Pick<XmlEntry, 'uid' | 'version' |
   }
 }
 
-async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise<XmlEntry[]> {
+const MATCH_CHUNK = 500
+
+async function loadXml(
+  sender: WebContents,
+  repos: RepositoryRegistry,
+  payload: LoadPayload
+): Promise<XmlEntry[]> {
   const { inputPath, sourceLang, targetLang, modName } = payload
   const ext = path.extname(inputPath).toLowerCase()
 
@@ -53,6 +64,7 @@ async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise
     if (ext === '.xml') {
       xmlPath = inputPath
     } else if (ext === '.pak') {
+      sender.send('xml:load:progress', { phase: 'unpacking' } satisfies XmlLoadProgress)
       const tempDir = createTempDir('icosa_xml')
       tempDirs.push(tempDir)
       await unpackMod(inputPath, tempDir)
@@ -62,6 +74,7 @@ async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise
         throw new Error(`No XML found for language "${sourceFolder}" in pak`)
       xmlPath = xmlFiles[0]
     } else if (ext === '.zip') {
+      sender.send('xml:load:progress', { phase: 'unpacking' } satisfies XmlLoadProgress)
       const archiveDir = createTempDir('icosa_zip')
       tempDirs.push(archiveDir)
       extract(inputPath, archiveDir)
@@ -80,32 +93,40 @@ async function loadXml(repos: RepositoryRegistry, payload: LoadPayload): Promise
       throw new Error(`Unsupported file type: ${ext}. Use .xml, .pak, or .zip`)
     }
 
+    sender.send('xml:load:progress', { phase: 'parsing' } satisfies XmlLoadProgress)
     const localizationEntries = parseLocalizationXml(xmlPath)
+    const total = localizationEntries.length
+    const result: XmlEntry[] = new Array(total)
 
-    return localizationEntries.map((entry) => {
-      const uiEntry = toUiEntry(entry)
-      const match = repos.dictionary.resolveMatch({
-        modName: modName ?? null,
-        uid: entry.contentuid,
-        sourceLang,
-        targetLang,
-        sourceText: entry.text
-      })
-
-      if (match) {
-        return {
-          ...uiEntry,
-          target: decodeEntities(getDictionaryTargetText(match.entry, sourceLang, targetLang)),
-          matchType: match.matchType
-        }
+    for (let i = 0; i < total; i += MATCH_CHUNK) {
+      const end = Math.min(i + MATCH_CHUNK, total)
+      for (let j = i; j < end; j++) {
+        const entry = localizationEntries[j]
+        const uiEntry = toUiEntry(entry)
+        const match = repos.dictionary.resolveMatch({
+          modName: modName ?? null,
+          uid: entry.contentuid,
+          sourceLang,
+          targetLang,
+          sourceText: entry.text
+        })
+        result[j] = match
+          ? {
+              ...uiEntry,
+              target: decodeEntities(getDictionaryTargetText(match.entry, sourceLang, targetLang)),
+              matchType: match.matchType
+            }
+          : { ...uiEntry, target: '', matchType: 'none' }
       }
+      sender.send('xml:load:progress', {
+        phase: 'matching',
+        processed: end,
+        total
+      } satisfies XmlLoadProgress)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
 
-      return {
-        ...uiEntry,
-        target: '',
-        matchType: 'none'
-      }
-    })
+    return result
   } finally {
     for (const tempDir of tempDirs) cleanupTempDir(tempDir)
   }
@@ -127,6 +148,8 @@ function languageFolder(repos: RepositoryRegistry, languageCode: string): string
 }
 
 export function registerXmlHandlers(repos: RepositoryRegistry): void {
-  ipcMain.handle('xml:load', async (_event, payload: LoadPayload) => loadXml(repos, payload))
+  ipcMain.handle('xml:load', async (event, payload: LoadPayload) =>
+    loadXml(event.sender, repos, payload)
+  )
   ipcMain.handle('xml:export', (_event, payload: ExportPayload) => exportXml(payload))
 }

--- a/src/main/services/merge.service.ts
+++ b/src/main/services/merge.service.ts
@@ -1,6 +1,12 @@
+import path from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { app } from 'electron'
 import type { RepositoryRegistry } from '../database/repositories/registry'
-import { normalizeDictionaryText } from '../utils/dictionaryText'
-import { type LocalizationEntry, parseLocalizationXml } from './xml-parser.service'
+import type { MergeProgress, MergeResult, MergeWorkerInput } from '../workers/merge.worker.runtime'
+
+export type { MergeResult }
+
+export type MergeProgressUpdate = Exclude<MergeProgress, { phase: 'done' } | { phase: 'error' }>
 
 export interface MergeXmlsParams {
   sourceXmlPath: string
@@ -8,73 +14,40 @@ export interface MergeXmlsParams {
   targetXmlPath: string
   targetLang: string
   modName: string
+  onProgress?: (p: MergeProgressUpdate) => void
 }
 
-export interface MergeResult {
-  matched: number
-  sourceOnly: number
-  targetOnly: number
-}
+// repos is kept on the signature so the current IPC handler keeps compiling -
+// task 04 drops it when it rewires merge.ipc.ts for the progress channel.
+export function mergeXmls(
+  _repos: RepositoryRegistry,
+  params: MergeXmlsParams
+): Promise<MergeResult> {
+  const { onProgress, ...rest } = params
+  const input: MergeWorkerInput = { ...rest, dbPath: getDbPath() }
 
-export function mergeXmls(repos: RepositoryRegistry, params: MergeXmlsParams): MergeResult {
-  const sourceEntries = parseLocalizationXml(params.sourceXmlPath)
-  const targetEntries = parseLocalizationXml(params.targetXmlPath)
+  return new Promise<MergeResult>((resolve, reject) => {
+    const worker = new Worker(path.join(__dirname, 'merge.worker.js'), { workerData: input })
 
-  const targetBuckets = groupByUid(targetEntries)
-
-  // Mod must exist before dictionary entries reference it via FK (modName -> mod.name).
-  repos.mod.upsert(params.modName)
-
-  let matched = 0
-  for (const sourceEntry of sourceEntries) {
-    const targetEntry = targetBuckets.get(sourceEntry.contentuid)?.shift()
-    if (!targetEntry) continue
-
-    const sourceText = normalizeDictionaryText(sourceEntry.text)
-    const targetText = normalizeDictionaryText(targetEntry.text)
-    if (!sourceText || !targetText) continue
-
-    repos.dictionary.upsert({
-      sourceLang: params.sourceLang,
-      targetLang: params.targetLang,
-      sourceText,
-      targetText,
-      modName: params.modName,
-      uid: sourceEntry.contentuid
+    worker.on('message', (msg: MergeProgress) => {
+      if (msg.phase === 'done') {
+        resolve(msg.result)
+        return
+      }
+      if (msg.phase === 'error') {
+        reject(new Error(msg.message))
+        return
+      }
+      onProgress?.(msg)
     })
-    matched++
-  }
 
-  const sourceOnly = countMissingOccurrences(sourceEntries, targetEntries)
-  const targetOnly = countMissingOccurrences(targetEntries, sourceEntries)
-
-  if (matched > 0) {
-    repos.mod.upsert(params.modName, { totalStrings: matched })
-  }
-
-  return { matched, sourceOnly, targetOnly }
+    worker.on('error', reject)
+    worker.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`merge worker exited with code ${code}`))
+    })
+  })
 }
 
-function groupByUid(entries: LocalizationEntry[]): Map<string, LocalizationEntry[]> {
-  const buckets = new Map<string, LocalizationEntry[]>()
-  for (const entry of entries) {
-    const bucket = buckets.get(entry.contentuid) ?? []
-    bucket.push(entry)
-    buckets.set(entry.contentuid, bucket)
-  }
-  return buckets
-}
-
-function countMissingOccurrences(a: LocalizationEntry[], b: LocalizationEntry[]): number {
-  const aCounts = countUids(a)
-  const bCounts = countUids(b)
-  let count = 0
-  for (const [uid, total] of aCounts) count += Math.max(0, total - (bCounts.get(uid) ?? 0))
-  return count
-}
-
-function countUids(entries: LocalizationEntry[]): Map<string, number> {
-  const counts = new Map<string, number>()
-  for (const entry of entries) counts.set(entry.contentuid, (counts.get(entry.contentuid) ?? 0) + 1)
-  return counts
+function getDbPath(): string {
+  return path.join(app.getPath('userData'), 'icosa.db')
 }

--- a/src/main/workers/merge.worker.runtime.ts
+++ b/src/main/workers/merge.worker.runtime.ts
@@ -1,3 +1,12 @@
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { DictionaryRepository } from '../database/repositories/dictionary.repo'
+import type { NewDictionaryEntry } from '../database/schema'
+import * as schema from '../database/schema'
+import { type LocalizationEntry, parseLocalizationXml } from '../services/xml-parser.service'
+import { dictionaryTextKey, normalizeDictionaryText } from '../utils/dictionaryText'
+import { normalizeLangs } from '../utils/languages'
+
 export interface MergeWorkerInput {
   sourceXmlPath: string
   sourceLang: string
@@ -21,10 +30,143 @@ export type MergeProgress =
   | { phase: 'done'; result: MergeResult }
   | { phase: 'error'; message: string }
 
-// Task 03 replaces this stub with the real merge pipeline.
+interface PendingUpdate {
+  id: number
+  targetText: string
+  targetTextKey: string
+  uid: string | null
+}
+
+const WRITE_CHUNK = 500
+
 export async function runMergeWorker(
-  _input: MergeWorkerInput,
+  input: MergeWorkerInput,
   post: (msg: MergeProgress) => void
 ): Promise<void> {
-  post({ phase: 'done', result: { matched: 0, sourceOnly: 0, targetOnly: 0 } })
+  const sqlite = new Database(input.dbPath)
+  sqlite.pragma('journal_mode = WAL')
+  sqlite.pragma('foreign_keys = ON')
+  sqlite.pragma('synchronous = NORMAL')
+  sqlite.pragma('cache_size = -64000')
+  sqlite.pragma('temp_store = MEMORY')
+  sqlite.pragma('mmap_size = 268435456')
+
+  try {
+    const db = drizzle(sqlite, { schema })
+    const repo = new DictionaryRepository(db)
+
+    post({ phase: 'parsing' })
+    const sourceEntries = parseLocalizationXml(input.sourceXmlPath)
+    const targetEntries = parseLocalizationXml(input.targetXmlPath)
+    const targetBuckets = groupByUid(targetEntries)
+
+    post({ phase: 'loading-map' })
+    const keyMap = repo.loadKeyMap(input.sourceLang, input.targetLang, input.modName)
+
+    // mod FK row - INSERT OR IGNORE so dictionary writes never violate the FK.
+    sqlite
+      .prepare('INSERT INTO mod (name) VALUES (?) ON CONFLICT(name) DO NOTHING')
+      .run(input.modName)
+
+    post({ phase: 'classifying' })
+    const [l1, l2, swapped] = normalizeLangs(input.sourceLang, input.targetLang)
+    const updateColumn: 'language1' | 'language2' = swapped ? 'language1' : 'language2'
+
+    const inserts: NewDictionaryEntry[] = []
+    const updates: PendingUpdate[] = []
+    let matched = 0
+
+    for (const sourceEntry of sourceEntries) {
+      const targetEntry = targetBuckets.get(sourceEntry.contentuid)?.shift()
+      if (!targetEntry) continue
+
+      const sourceText = normalizeDictionaryText(sourceEntry.text)
+      const targetText = normalizeDictionaryText(targetEntry.text)
+      if (!sourceText || !targetText) continue
+
+      matched++
+
+      const sourceKey = dictionaryTextKey(sourceText)
+      const targetKey = dictionaryTextKey(targetText)
+      const existing = keyMap.get(sourceKey)
+
+      if (existing) {
+        // skip-if-equal: nothing changed for this row.
+        if (existing.targetKey === targetKey) continue
+        updates.push({
+          id: existing.id,
+          targetText,
+          targetTextKey: targetKey,
+          uid: sourceEntry.contentuid
+        })
+      } else {
+        const [text1, text2] = swapped ? [targetText, sourceText] : [sourceText, targetText]
+        inserts.push({
+          language1: l1,
+          language2: l2,
+          textLanguage1: text1,
+          textLanguage2: text2,
+          textLanguage1Key: dictionaryTextKey(text1),
+          textLanguage2Key: dictionaryTextKey(text2),
+          modName: input.modName,
+          uid: sourceEntry.contentuid
+        })
+      }
+    }
+
+    const total = inserts.length + updates.length
+    let processed = 0
+    post({ phase: 'writing', processed, total })
+
+    for (let i = 0; i < inserts.length; i += WRITE_CHUNK) {
+      const chunk = inserts.slice(i, i + WRITE_CHUNK)
+      repo.bulkInsert(chunk)
+      processed += chunk.length
+      post({ phase: 'writing', processed, total })
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+
+    for (let i = 0; i < updates.length; i += WRITE_CHUNK) {
+      const chunk = updates.slice(i, i + WRITE_CHUNK)
+      repo.bulkUpdate(chunk, updateColumn)
+      processed += chunk.length
+      post({ phase: 'writing', processed, total })
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+
+    if (matched > 0) {
+      sqlite.prepare('UPDATE mod SET total_strings = ? WHERE name = ?').run(matched, input.modName)
+    }
+
+    const sourceOnly = countMissingOccurrences(sourceEntries, targetEntries)
+    const targetOnly = countMissingOccurrences(targetEntries, sourceEntries)
+
+    post({ phase: 'done', result: { matched, sourceOnly, targetOnly } })
+  } finally {
+    sqlite.close()
+  }
+}
+
+function groupByUid(entries: LocalizationEntry[]): Map<string, LocalizationEntry[]> {
+  const buckets = new Map<string, LocalizationEntry[]>()
+  for (const entry of entries) {
+    const bucket = buckets.get(entry.contentuid) ?? []
+    bucket.push(entry)
+    buckets.set(entry.contentuid, bucket)
+  }
+  return buckets
+}
+
+function countMissingOccurrences(a: LocalizationEntry[], b: LocalizationEntry[]): number {
+  const aCounts = countUids(a)
+  const bCounts = countUids(b)
+  let count = 0
+  for (const [uid, total] of aCounts) count += Math.max(0, total - (bCounts.get(uid) ?? 0))
+  return count
+}
+
+function countUids(entries: LocalizationEntry[]): Map<string, number> {
+  const counts = new Map<string, number>()
+  for (const entry of entries) counts.set(entry.contentuid, (counts.get(entry.contentuid) ?? 0) + 1)
+  return counts
 }

--- a/src/main/workers/merge.worker.runtime.ts
+++ b/src/main/workers/merge.worker.runtime.ts
@@ -1,11 +1,14 @@
 import Database from 'better-sqlite3'
 import { drizzle } from 'drizzle-orm/better-sqlite3'
+import type { MergeProgress, MergeResult } from '../../preload/api-types'
 import { DictionaryRepository } from '../database/repositories/dictionary.repo'
 import type { NewDictionaryEntry } from '../database/schema'
 import * as schema from '../database/schema'
 import { type LocalizationEntry, parseLocalizationXml } from '../services/xml-parser.service'
 import { dictionaryTextKey, normalizeDictionaryText } from '../utils/dictionaryText'
 import { normalizeLangs } from '../utils/languages'
+
+export type { MergeProgress, MergeResult }
 
 export interface MergeWorkerInput {
   sourceXmlPath: string
@@ -15,20 +18,6 @@ export interface MergeWorkerInput {
   modName: string
   dbPath: string
 }
-
-export interface MergeResult {
-  matched: number
-  sourceOnly: number
-  targetOnly: number
-}
-
-export type MergeProgress =
-  | { phase: 'parsing' }
-  | { phase: 'loading-map' }
-  | { phase: 'classifying' }
-  | { phase: 'writing'; processed: number; total: number }
-  | { phase: 'done'; result: MergeResult }
-  | { phase: 'error'; message: string }
 
 interface PendingUpdate {
   id: number

--- a/src/main/workers/merge.worker.runtime.ts
+++ b/src/main/workers/merge.worker.runtime.ts
@@ -1,0 +1,30 @@
+export interface MergeWorkerInput {
+  sourceXmlPath: string
+  sourceLang: string
+  targetXmlPath: string
+  targetLang: string
+  modName: string
+  dbPath: string
+}
+
+export interface MergeResult {
+  matched: number
+  sourceOnly: number
+  targetOnly: number
+}
+
+export type MergeProgress =
+  | { phase: 'parsing' }
+  | { phase: 'loading-map' }
+  | { phase: 'classifying' }
+  | { phase: 'writing'; processed: number; total: number }
+  | { phase: 'done'; result: MergeResult }
+  | { phase: 'error'; message: string }
+
+// Task 03 replaces this stub with the real merge pipeline.
+export async function runMergeWorker(
+  _input: MergeWorkerInput,
+  post: (msg: MergeProgress) => void
+): Promise<void> {
+  post({ phase: 'done', result: { matched: 0, sourceOnly: 0, targetOnly: 0 } })
+}

--- a/src/main/workers/merge.worker.ts
+++ b/src/main/workers/merge.worker.ts
@@ -1,0 +1,19 @@
+import { parentPort, workerData } from 'node:worker_threads'
+import { type MergeWorkerInput, runMergeWorker } from './merge.worker.runtime'
+
+if (parentPort === null) {
+  throw new Error('merge.worker must be spawned via worker_threads')
+}
+
+const port = parentPort
+
+;(async () => {
+  try {
+    await runMergeWorker(workerData as MergeWorkerInput, (msg) => port.postMessage(msg))
+    process.exit(0)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    port.postMessage({ phase: 'error', message })
+    process.exit(1)
+  }
+})()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -341,6 +341,11 @@ export interface MergeApi {
   onProgress(cb: (data: MergeProgress) => void): UnsubscribeFn
 }
 
+export type XmlLoadProgress =
+  | { phase: 'unpacking' }
+  | { phase: 'parsing' }
+  | { phase: 'matching'; processed: number; total: number }
+
 export interface XmlApi {
   load(params: {
     inputPath: string
@@ -349,6 +354,7 @@ export interface XmlApi {
     modName?: string
   }): Promise<XmlEntry[]>
   export(params: { outputPath: string; entries: XmlEntry[] }): Promise<void>
+  onLoadProgress(cb: (data: XmlLoadProgress) => void): UnsubscribeFn
 }
 
 export interface ConfigApi {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -318,6 +318,14 @@ export interface MergeResult {
   targetOnly: number
 }
 
+export type MergeProgress =
+  | { phase: 'parsing' }
+  | { phase: 'loading-map' }
+  | { phase: 'classifying' }
+  | { phase: 'writing'; processed: number; total: number }
+  | { phase: 'done'; result: MergeResult }
+  | { phase: 'error'; message: string }
+
 export interface MergeApi {
   prepareInput(params: { inputPath: string }): Promise<PreparedTranslationInput>
   discardInput(params: { importId: string }): Promise<{ success: boolean }>
@@ -330,6 +338,7 @@ export interface MergeApi {
     targetLang: string
     modName: string
   }): Promise<MergeResult>
+  onProgress(cb: (data: MergeProgress) => void): UnsubscribeFn
 }
 
 export interface XmlApi {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -267,7 +267,10 @@ const api: AppApi = {
     export: (params: {
       outputPath: string
       entries: { uid: string; version: string; source: string; target: string; matchType: string }[]
-    }): Promise<void> => ipcRenderer.invoke('xml:export', params)
+    }): Promise<void> => ipcRenderer.invoke('xml:export', params),
+
+    onLoadProgress: (cb: (data: import('./api-types').XmlLoadProgress) => void): UnsubscribeFn =>
+      on('xml:load:progress', cb)
   },
 
   merge: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -57,12 +57,10 @@ const api: AppApi = {
       provider: 'openai' | 'deepl'
       sourceLang: string
       targetLang: string
-    }): Promise<{ jobId: string }> =>
-      ipcRenderer.invoke('translation:batch', payload),
+    }): Promise<{ jobId: string }> => ipcRenderer.invoke('translation:batch', payload),
 
-    onBatchProgress: (
-      cb: (data: TranslationBatchProgressEvent) => void
-    ): UnsubscribeFn => on('translation:batchProgress', cb),
+    onBatchProgress: (cb: (data: TranslationBatchProgressEvent) => void): UnsubscribeFn =>
+      on('translation:batchProgress', cb),
 
     onBatchDone: (cb: (data: TranslationBatchDoneEvent) => void): UnsubscribeFn =>
       on('translation:batchDone', cb),
@@ -122,10 +120,8 @@ const api: AppApi = {
     delete: (params: { id: number }): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('dictionary:delete', params),
 
-    previewImport: (params: {
-      filePath: string
-      format: 'csv' | 'xlsx'
-    }) => ipcRenderer.invoke('dictionary:previewImport', params),
+    previewImport: (params: { filePath: string; format: 'csv' | 'xlsx' }) =>
+      ipcRenderer.invoke('dictionary:previewImport', params),
 
     import: (params: { filePath: string; format: 'csv' | 'xlsx' }): Promise<{ count: number }> =>
       ipcRenderer.invoke('dictionary:import', params),
@@ -289,7 +285,10 @@ const api: AppApi = {
       targetCandidateId: string
       targetLang: string
       modName: string
-    }) => ipcRenderer.invoke('merge:run', params)
+    }) => ipcRenderer.invoke('merge:run', params),
+
+    onProgress: (cb: (data: import('./api-types').MergeProgress) => void): UnsubscribeFn =>
+      on('merge:progress', cb)
   },
 
   config: {

--- a/src/renderer/src/context/TranslationSession.tsx
+++ b/src/renderer/src/context/TranslationSession.tsx
@@ -1,6 +1,6 @@
 import { createContext, useCallback, useContext, useEffect, useMemo, useReducer } from 'react'
 import { i18n } from '@/i18n'
-import type { XmlEntry } from '@/types'
+import type { XmlEntry, XmlLoadProgress } from '@/types'
 
 export interface TranslationSessionEntry extends XmlEntry {
   rowId: string
@@ -36,9 +36,7 @@ export function entryMatchesFilter(entry: TranslationSessionEntry, filter: Filte
   if (filter.mode === 'tags' && !hasXmlTags(entry)) return false
   if (filter.search) {
     const query = filter.search.toLowerCase()
-    return (
-      entry.source.toLowerCase().includes(query) || entry.target.toLowerCase().includes(query)
-    )
+    return entry.source.toLowerCase().includes(query) || entry.target.toLowerCase().includes(query)
   }
   return true
 }
@@ -46,6 +44,7 @@ export function entryMatchesFilter(entry: TranslationSessionEntry, filter: Filte
 export interface TranslationSessionState {
   phase: Phase
   loadingLabel: string
+  loadingProgress: XmlLoadProgress | null
   entries: TranslationSessionEntry[]
   selection: SelectionState
   modName: string
@@ -70,6 +69,7 @@ const EMPTY_EXPLICIT: SelectionState = { kind: 'explicit', uids: new Set() }
 
 type Action =
   | { type: 'SET_PHASE'; phase: Phase; loadingLabel?: string }
+  | { type: 'SET_LOADING_PROGRESS'; progress: XmlLoadProgress | null }
   | { type: 'SET_ENTRIES'; entries: TranslationSessionEntry[] }
   | { type: 'UPDATE_ENTRY'; rowId: string; target: string }
   | { type: 'MARK_MANUAL'; rowId: string }
@@ -90,13 +90,16 @@ function reducer(state: TranslationSessionState, action: Action): TranslationSes
         phase: action.phase,
         loadingLabel: action.phase === 'loading' ? (action.loadingLabel ?? state.loadingLabel) : ''
       }
+    case 'SET_LOADING_PROGRESS':
+      return { ...state, loadingProgress: action.progress }
     case 'SET_ENTRIES':
       return {
         ...state,
         entries: action.entries,
         selection: EMPTY_EXPLICIT,
         phase: 'loaded',
-        loadingLabel: ''
+        loadingLabel: '',
+        loadingProgress: null
       }
     case 'UPDATE_ENTRY':
       return {
@@ -146,6 +149,7 @@ function reducer(state: TranslationSessionState, action: Action): TranslationSes
         ...state,
         phase: 'idle',
         loadingLabel: '',
+        loadingProgress: null,
         entries: [],
         selection: EMPTY_EXPLICIT,
         inputPath: null
@@ -198,6 +202,7 @@ export function TranslationSessionProvider({
   const [state, dispatch] = useReducer(reducer, {
     phase: 'idle',
     loadingLabel: '',
+    loadingProgress: null,
     entries: [],
     selection: EMPTY_EXPLICIT,
     modName: '',
@@ -236,12 +241,20 @@ export function TranslationSessionProvider({
         phase: 'loading',
         loadingLabel: i18n.t('setup.loadingEntries', { ns: 'translate' })
       })
-      const entries = await window.api.xml.load({
-        inputPath: storedPath,
-        sourceLang,
-        targetLang,
-        modName
+      const unsub = window.api.xml.onLoadProgress((p) => {
+        dispatch({ type: 'SET_LOADING_PROGRESS', progress: p })
       })
+      let entries: Awaited<ReturnType<typeof window.api.xml.load>>
+      try {
+        entries = await window.api.xml.load({
+          inputPath: storedPath,
+          sourceLang,
+          targetLang,
+          modName
+        })
+      } finally {
+        unsub()
+      }
       if (modName) {
         dispatch({
           type: 'SET_PHASE',

--- a/src/renderer/src/features/merge/components/MergeBottomBar.tsx
+++ b/src/renderer/src/features/merge/components/MergeBottomBar.tsx
@@ -1,11 +1,13 @@
 import { Loader2, Merge } from 'lucide-react'
-import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { btnBase, btnPrimary } from '@/features/translate/components/styles'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { cn } from '@/lib/utils'
+import type { MergeProgress } from '@/types'
 
 interface MergeBottomBarProps {
   ready: boolean
   isRunning: boolean
+  progress: MergeProgress | null
   onCancel: () => void
   onRun: () => void
 }
@@ -13,29 +15,79 @@ interface MergeBottomBarProps {
 export function MergeBottomBar({
   ready,
   isRunning,
+  progress,
   onCancel,
   onRun
 }: MergeBottomBarProps): React.JSX.Element {
   const { t } = useAppTranslation(['merge', 'common'])
 
+  const showProgress =
+    isRunning &&
+    progress !== null &&
+    progress !== undefined &&
+    progress.phase !== 'done' &&
+    progress.phase !== 'error'
+
+  const progressLabel = (): string => {
+    if (!progress) return t('bottomBar.running', { ns: 'merge' })
+    if (progress.phase === 'parsing') return t('bottomBar.progressParsing', { ns: 'merge' })
+    if (progress.phase === 'loading-map') return t('bottomBar.progressLoadingMap', { ns: 'merge' })
+    if (progress.phase === 'classifying') return t('bottomBar.progressClassifying', { ns: 'merge' })
+    if (progress.phase === 'writing')
+      return t('bottomBar.progressWriting', {
+        ns: 'merge',
+        processed: progress.processed.toLocaleString(),
+        total: progress.total.toLocaleString()
+      })
+    return t('bottomBar.running', { ns: 'merge' })
+  }
+
+  const progressPct =
+    progress?.phase === 'writing' && progress.total > 0
+      ? (progress.processed / progress.total) * 100
+      : undefined
+
   return (
     <div className="shrink-0 border-t border-[#1f2329] px-6 py-3">
-      <div className="mx-auto flex max-w-220 items-center gap-2.5 rounded-xl border border-neutral-700 bg-[#131518] px-4 py-3 shadow-xl">
-        <div className="flex-1 text-xs text-neutral-400">
-          {ready ? t('bottomBar.ready', { ns: 'merge' }) : t('bottomBar.idle', { ns: 'merge' })}
+      <div className="mx-auto flex max-w-220 flex-col gap-2 rounded-xl border border-neutral-700 bg-[#131518] px-4 py-3 shadow-xl">
+        {showProgress && (
+          <div className="space-y-1.5">
+            <div className="h-2 rounded-full bg-[#1d2127]">
+              {progressPct !== undefined ? (
+                <div
+                  className="h-full rounded-full bg-amber-400/80 transition-[width] duration-200"
+                  style={{ width: `${progressPct}%` }}
+                />
+              ) : (
+                <div className="h-full w-2/3 animate-pulse rounded-full bg-amber-400/80" />
+              )}
+            </div>
+            <p className="text-xs text-neutral-400">{progressLabel()}</p>
+          </div>
+        )}
+        <div className="flex items-center gap-2.5">
+          <div className="flex-1 text-xs text-neutral-400">
+            {isRunning && !showProgress
+              ? t('bottomBar.running', { ns: 'merge' })
+              : ready
+                ? t('bottomBar.ready', { ns: 'merge' })
+                : t('bottomBar.idle', { ns: 'merge' })}
+          </div>
+          <button type="button" className={btnBase} onClick={onCancel} disabled={isRunning}>
+            {t('actions.cancel', { ns: 'common' })}
+          </button>
+          <button
+            type="button"
+            className={cn(btnPrimary, (!ready || isRunning) && 'cursor-not-allowed opacity-40')}
+            disabled={!ready || isRunning}
+            onClick={onRun}
+          >
+            {isRunning ? <Loader2 size={13} className="animate-spin" /> : <Merge size={13} />}
+            {isRunning
+              ? t('bottomBar.running', { ns: 'merge' })
+              : t('actions.run', { ns: 'common' })}
+          </button>
         </div>
-        <button type="button" className={btnBase} onClick={onCancel} disabled={isRunning}>
-          {t('actions.cancel', { ns: 'common' })}
-        </button>
-        <button
-          type="button"
-          className={cn(btnPrimary, (!ready || isRunning) && 'cursor-not-allowed opacity-40')}
-          disabled={!ready || isRunning}
-          onClick={onRun}
-        >
-          {isRunning ? <Loader2 size={13} className="animate-spin" /> : <Merge size={13} />}
-          {isRunning ? t('bottomBar.running', { ns: 'merge' }) : t('actions.run', { ns: 'common' })}
-        </button>
       </div>
     </div>
   )

--- a/src/renderer/src/features/merge/components/MergeToolScreen.tsx
+++ b/src/renderer/src/features/merge/components/MergeToolScreen.tsx
@@ -1,6 +1,6 @@
 import { Merge } from 'lucide-react'
-import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { XmlSelectionModal } from '@/features/translate/components/XmlSelectionModal'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
 import type { PreparedTranslationInput } from '@/types'
 import { useMergeSetup } from '../hooks/useMergeSetup'
 import type { SlotKey } from '../types'
@@ -80,6 +80,7 @@ export function MergeToolScreen(): React.JSX.Element {
         <MergeBottomBar
           ready={setup.ready}
           isRunning={setup.isRunning}
+          progress={setup.progress}
           onCancel={() => {
             void setup.reset()
           }}

--- a/src/renderer/src/features/merge/hooks/useMergeSetup.ts
+++ b/src/renderer/src/features/merge/hooks/useMergeSetup.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useState } from 'react'
 import { toast } from 'sonner'
 import { getLocalizedErrorMessage } from '@/i18n/errors'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
-import type { Language, MergeResult, PreparedTranslationInput } from '@/types'
+import type { Language, MergeProgress, MergeResult, PreparedTranslationInput } from '@/types'
 import type { MergeFileSlot, SlotKey } from '../types'
 
 const ACCEPTED_EXT = ['xml', 'pak', 'zip']
@@ -37,6 +37,7 @@ interface UseMergeSetupResult {
   languages: Language[]
   ready: boolean
   isRunning: boolean
+  progress: MergeProgress | null
   pendingSelection: SlotKey | null
   step1Done: boolean
   step2Done: boolean
@@ -61,7 +62,13 @@ export function useMergeSetup(): UseMergeSetupResult {
   const [modName, setModName] = useState('')
   const [languages, setLanguages] = useState<Language[]>([])
   const [isRunning, setIsRunning] = useState(false)
+  const [progress, setProgress] = useState<MergeProgress | null>(null)
   const [pendingSelection, setPendingSelection] = useState<SlotKey | null>(null)
+
+  useEffect(() => {
+    const unsub = window.api.merge.onProgress(setProgress)
+    return unsub
+  }, [])
 
   useEffect(() => {
     window.api.language.getAll().then((items) => {
@@ -218,17 +225,13 @@ export function useMergeSetup(): UseMergeSetupResult {
   const step2Done = !!target.lang && !!target.importId && !!target.candidateId
   const step3Done = modName.trim().length > 0
 
-  const ready =
-    step1Done &&
-    step2Done &&
-    step3Done &&
-    source.lang !== target.lang &&
-    !isRunning
+  const ready = step1Done && step2Done && step3Done && source.lang !== target.lang && !isRunning
 
   const runMerge = useCallback(async () => {
     if (!ready) return
     if (!source.importId || !source.candidateId || !target.importId || !target.candidateId) return
     setIsRunning(true)
+    setProgress(null)
     try {
       const result: MergeResult = await window.api.merge.run({
         sourceImportId: source.importId,
@@ -242,14 +245,11 @@ export function useMergeSetup(): UseMergeSetupResult {
 
       const ignored = result.sourceOnly + result.targetOnly
       toast.success(
-        t(
-          ignored > 0 ? 'merge.mergedWithIgnored' : 'merge.merged',
-          {
-            ns: 'toasts',
-            matched: result.matched,
-            ignored
-          }
-        )
+        t(ignored > 0 ? 'merge.mergedWithIgnored' : 'merge.merged', {
+          ns: 'toasts',
+          matched: result.matched,
+          ignored
+        })
       )
 
       setSource((prev) => emptySlot(prev.lang))
@@ -259,6 +259,7 @@ export function useMergeSetup(): UseMergeSetupResult {
       toast.error(getLocalizedErrorMessage(error, t))
     } finally {
       setIsRunning(false)
+      setProgress(null)
     }
   }, [modName, ready, source, t, target])
 
@@ -269,6 +270,7 @@ export function useMergeSetup(): UseMergeSetupResult {
     languages,
     ready,
     isRunning,
+    progress,
     pendingSelection,
     step1Done,
     step2Done,

--- a/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
@@ -25,10 +25,24 @@ export function TranslateIdleScreen({ session }: TranslateIdleScreenProps): Reac
     modName: setup.modName
   })
   const isLoading = session.phase === 'loading' || importFlow.isPreparing
-  const loadingLabel =
+  const baseLabel =
     importFlow.isPreparing && session.phase !== 'loading'
       ? t('setup.loadingPreparingFile', { ns: 'translate' })
       : session.loadingLabel || t('setup.loadingEditor', { ns: 'translate' })
+  const loadingProgress = session.loadingProgress
+  const loadingLabel = (() => {
+    if (!loadingProgress || importFlow.isPreparing) return baseLabel
+    if (loadingProgress.phase === 'unpacking')
+      return t('setup.loadingUnpacking', { ns: 'translate' })
+    if (loadingProgress.phase === 'parsing') return t('setup.loadingParsing', { ns: 'translate' })
+    if (loadingProgress.phase === 'matching')
+      return t('setup.loadingMatching', {
+        ns: 'translate',
+        processed: loadingProgress.processed.toLocaleString(),
+        total: loadingProgress.total.toLocaleString()
+      })
+    return baseLabel
+  })()
 
   return (
     <>
@@ -173,7 +187,16 @@ export function TranslateIdleScreen({ session }: TranslateIdleScreenProps): Reac
               </div>
               <div className="space-y-2">
                 <div className="h-2 rounded-full bg-[#1d2127]">
-                  <div className="h-full w-2/3 animate-pulse rounded-full bg-amber-400/80" />
+                  {loadingProgress?.phase === 'matching' && loadingProgress.total > 0 ? (
+                    <div
+                      className="h-full rounded-full bg-amber-400/80 transition-[width] duration-200"
+                      style={{
+                        width: `${(loadingProgress.processed / loadingProgress.total) * 100}%`
+                      }}
+                    />
+                  ) : (
+                    <div className="h-full w-2/3 animate-pulse rounded-full bg-amber-400/80" />
+                  )}
                 </div>
                 <div className="grid gap-2">
                   <div className="h-8 animate-pulse rounded-lg bg-[#1a1d22]" />

--- a/src/renderer/src/locales/en/merge.json
+++ b/src/renderer/src/locales/en/merge.json
@@ -27,6 +27,10 @@
   "bottomBar": {
     "ready": "Ready to merge files",
     "idle": "Complete the three steps to run merge",
-    "running": "Merging..."
+    "running": "Merging...",
+    "progressParsing": "Parsing XMLs…",
+    "progressLoadingMap": "Loading existing entries…",
+    "progressClassifying": "Classifying entries…",
+    "progressWriting": "Writing {{processed}} / {{total}}"
   }
 }

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -49,7 +49,10 @@
     "loadingEntries": "Loading XML entries...",
     "loadingModData": "Updating mod data...",
     "loadingPreparingFile": "Preparing file to open the editor...",
-    "loadingEditor": "Loading translation editor..."
+    "loadingEditor": "Loading translation editor...",
+    "loadingUnpacking": "Unpacking mod files…",
+    "loadingParsing": "Parsing localization XML…",
+    "loadingMatching": "Matching dictionary {{processed}} / {{total}}"
   },
   "routeSkeleton": {
     "header": "Loading translation workspace"

--- a/src/renderer/src/locales/pt-BR/merge.json
+++ b/src/renderer/src/locales/pt-BR/merge.json
@@ -27,6 +27,10 @@
   "bottomBar": {
     "ready": "Pronto para mesclar os arquivos",
     "idle": "Complete os três passos para iniciar a fusão",
-    "running": "Mesclando..."
+    "running": "Mesclando...",
+    "progressParsing": "Lendo XMLs…",
+    "progressLoadingMap": "Carregando entradas existentes…",
+    "progressClassifying": "Classificando entradas…",
+    "progressWriting": "Gravando {{processed}} / {{total}}"
   }
 }

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -49,7 +49,10 @@
     "loadingEntries": "Carregando entradas do XML...",
     "loadingModData": "Atualizando dados do mod...",
     "loadingPreparingFile": "Preparando arquivo para abrir o editor...",
-    "loadingEditor": "Carregando editor de tradução..."
+    "loadingEditor": "Carregando editor de tradução...",
+    "loadingUnpacking": "Descompactando arquivos do mod…",
+    "loadingParsing": "Lendo XML de localização…",
+    "loadingMatching": "Comparando dicionário {{processed}} / {{total}}"
   },
   "routeSkeleton": {
     "header": "Carregando área de tradução"


### PR DESCRIPTION
## Summary
- Moves dictionary merge (`merge:run`) into a Node `worker_threads` worker with an in-memory key map, multi-row bulk INSERT/UPDATE in transactions, and skip-if-equal logic — eliminating the ~3-4 min main-thread block that caused \"Not Responding\" on Windows with 220k-entry XMLs.
- Adds chunked `setImmediate` yielding to `xml:load` so the renderer stays responsive while matching dictionary entries during mod import.
- Adds composite indexes and normalized text-key columns to `dictionary` so all `findBy*` lookups go from O(n) JS `.find()` to O(log n) indexed SQL.
- Streams real-time progress events (`xml:load:progress`, `merge:progress`) from main → renderer; both the translate loading modal and the merge bottom bar now show deterministic progress bars and phase labels instead of a hardcoded `w-2/3 animate-pulse`.

## Version
- v1.3.0 (bump reason: feat — multiple user-visible performance and UX improvements)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` produces `out/main/merge.worker.js` alongside `out/main/index.js`
- [x] Open `/translate`, import a mod with ≥10k entries: window stays responsive, loading modal shows "Matching dictionary N / TOTAL" with a growing bar (no "Not Responding")
- [x] Open merge tool, select `data/english.xml` (en) + `data/ptbr.xml` (pt-BR), run merge: completes without freezing, progress bar fills smoothly, result toast shows correct `matched` count
- [x] Run the same merge a second time: finishes faster (skip-if-equal path)
- [ ] `pnpm db:studio` after merge: `language1 < language2` invariant holds, no duplicate `(language1, language2, mod_name, text_language1_key)` tuples
- [x] Switch app language to pt-BR and repeat: all loading/merge labels render in Portuguese with thousand separators