### PR TITLE
feat(perf): move xml:load and translation pipeline to worker threads

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.3.0
+buildVersion: 1.4.0
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -9,7 +9,9 @@ export default defineConfig({
       rollupOptions: {
         input: {
           index: resolve('src/main/index.ts'),
-          'merge.worker': resolve('src/main/workers/merge.worker.ts')
+          'merge.worker': resolve('src/main/workers/merge.worker.ts'),
+          'translate.worker': resolve('src/main/workers/translate.worker.ts'),
+          'xml-load.worker': resolve('src/main/workers/xml-load.worker.ts')
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/src/main/database/repositories/dictionary.repo.ts
+++ b/src/main/database/repositories/dictionary.repo.ts
@@ -34,6 +34,17 @@ export interface UpsertParams {
 
 export type DictionaryMatchType = 'mod-text' | 'text'
 
+export interface DictionaryMatchIndex {
+  readonly byModUidKey: Map<string, DictionaryEntry>
+  readonly byModKey: Map<string, DictionaryEntry>
+  readonly byKey: Map<string, DictionaryEntry>
+  resolve(params: {
+    modName: string | null
+    uid: string | null
+    sourceText: string
+  }): { entry: DictionaryEntry; matchType: DictionaryMatchType } | undefined
+}
+
 export function getDictionaryTargetText(
   entry: { language1: string; textLanguage1: string; textLanguage2: string },
   sourceLang: string,
@@ -278,6 +289,79 @@ export class DictionaryRepository {
       map.set(sourceKey, { id: row.id, targetKey, uid: row.uid })
     }
     return map
+  }
+
+  // - modName param is reserved for future scoping; the index always covers the full language pair
+  loadMatchIndex(
+    sourceLang: string,
+    targetLang: string,
+    _modName?: string | null
+  ): DictionaryMatchIndex {
+    const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
+
+    const rows = this.db
+      .select()
+      .from(dictionary)
+      .where(and(eq(dictionary.language1, l1), eq(dictionary.language2, l2)))
+      .all() as DictionaryEntry[]
+
+    const byModUidKey = new Map<string, DictionaryEntry>()
+    const byModKey = new Map<string, DictionaryEntry>()
+    const byKey = new Map<string, DictionaryEntry>()
+
+    function newerWins(existing: DictionaryEntry, incoming: DictionaryEntry): boolean {
+      const a = existing.updatedAt ?? ''
+      const b = incoming.updatedAt ?? ''
+      if (b > a) return true
+      if (b < a) return false
+      return incoming.id > existing.id
+    }
+
+    for (const row of rows) {
+      const sourceKey = swapped ? row.textLanguage2Key : row.textLanguage1Key
+      if (!sourceKey) continue
+
+      const prev = byKey.get(sourceKey)
+      if (!prev || newerWins(prev, row)) byKey.set(sourceKey, row)
+
+      if (row.modName) {
+        const normalizedMod = row.modName.toLowerCase()
+        const modKey = `${normalizedMod}|${sourceKey}`
+        const prevMod = byModKey.get(modKey)
+        if (!prevMod || newerWins(prevMod, row)) byModKey.set(modKey, row)
+
+        if (row.uid) {
+          const modUidKey = `${normalizedMod}|${row.uid}|${sourceKey}`
+          const prevModUid = byModUidKey.get(modUidKey)
+          if (!prevModUid || newerWins(prevModUid, row)) byModUidKey.set(modUidKey, row)
+        }
+      }
+    }
+
+    return {
+      byModUidKey,
+      byModKey,
+      byKey,
+      resolve(params) {
+        const normalizedMod = params.modName?.trim().toLowerCase() || null
+        const sourceKey = dictionaryTextKey(params.sourceText)
+
+        if (normalizedMod) {
+          const uid = params.uid?.trim()
+          if (uid) {
+            const entry = byModUidKey.get(`${normalizedMod}|${uid}|${sourceKey}`)
+            if (entry) return { entry, matchType: 'mod-text' }
+          }
+          const entry = byModKey.get(`${normalizedMod}|${sourceKey}`)
+          if (entry) return { entry, matchType: 'mod-text' }
+        }
+
+        const entry = byKey.get(sourceKey)
+        if (entry) return { entry, matchType: 'text' }
+
+        return undefined
+      }
+    }
   }
 
   // Multi-row VALUES INSERT in a single transaction. Chunks internally so the bound

--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -3,16 +3,14 @@ import { eq } from 'drizzle-orm'
 import { type BrowserWindow, ipcMain } from 'electron'
 import { getDb } from '../database/connection'
 import { config } from '../database/schema'
-import type { BasePipeline, PipelineOptions } from '../pipelines/base.pipeline'
-import { DeepLPipeline } from '../pipelines/deepl.pipeline'
-import { ManualPipeline } from '../pipelines/manual.pipeline'
-import { OpenAIPipeline } from '../pipelines/openai.pipeline'
+import type { PipelineOptions } from '../pipelines/base.pipeline'
 import {
-  translateBatchDetailed as translateDeepLBatch,
-  translateText as translateDeepL
+  translateText as translateDeepL,
+  translateBatchDetailed as translateDeepLBatch
 } from '../services/deepl.service'
 import { logError } from '../services/log.service'
 import { translateText as translateOpenAI } from '../services/openai.service'
+import { runTranslatePipeline } from '../services/translate.service'
 import { decodeEntities } from '../services/xml-entities.service'
 import { getActiveWindow } from '../utils/window'
 
@@ -44,8 +42,8 @@ interface BatchJobContext extends BatchPayload {
   getWindow: () => BrowserWindow | null
 }
 
-// Active jobs keyed by jobId - AbortController allows cancellation
-const activeJobs = new Map<string, AbortController>()
+// Active jobs keyed by jobId - cancel() sends cancel message to the worker
+const activeJobs = new Map<string, { cancel: () => void }>()
 
 export function registerTranslationHandlers(getWindow: () => BrowserWindow | null): void {
   ipcMain.handle('translation:start', async (_event, payload: TranslationStartPayload) => {
@@ -61,28 +59,26 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
       throw err
     }
     const jobId = randomUUID()
-    const controller = new AbortController()
-    activeJobs.set(jobId, controller)
 
-    const pipeline = buildPipeline(payload)
-
-    pipeline
-      .run({
-        jobId,
-        signal: controller.signal,
-        getWindow,
-        filePath: payload.filePath,
-        modName: payload.modName,
-        sourceLang: payload.sourceLang,
-        targetLang: payload.targetLang,
-        author: payload.author
-      })
-      .then(() => {
+    const { cancel } = runTranslatePipeline({
+      jobId,
+      ...payload,
+      onProgress: ({ current, total, source, target }) => {
+        const win = getActiveWindow(getWindow)
+        if (win) {
+          win.webContents.send('translation:progress', { jobId, current, total, source, target })
+        }
+      },
+      onDone: ({ outputPath }) => {
         activeJobs.delete(jobId)
-      })
-      .catch((err: Error) => {
+        const win = getActiveWindow(getWindow)
+        if (win) {
+          win.webContents.send('translation:done', { jobId, outputPath })
+        }
+      },
+      onError: ({ message }) => {
         activeJobs.delete(jobId)
-        logError('translation.start.pipeline', err, {
+        logError('translation.start.pipeline', new Error(message), {
           jobId,
           provider: payload.provider,
           sourceLang: payload.sourceLang,
@@ -91,18 +87,17 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         })
         const win = getActiveWindow(getWindow)
         if (win) {
-          win.webContents.send('translation:error', {
-            jobId,
-            message: err.message ?? String(err)
-          })
+          win.webContents.send('translation:error', { jobId, message })
         }
-      })
+      }
+    })
 
+    activeJobs.set(jobId, { cancel })
     return { jobId }
   })
 
   ipcMain.handle('translation:cancel', (_event, { jobId }: { jobId: string }) => {
-    activeJobs.get(jobId)?.abort()
+    activeJobs.get(jobId)?.cancel()
     activeJobs.delete(jobId)
   })
 
@@ -137,10 +132,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
 
   ipcMain.handle(
     'translation:batch',
-    async (
-      _event,
-      payload: BatchPayload
-    ): Promise<{ jobId: string }> => {
+    async (_event, payload: BatchPayload): Promise<{ jobId: string }> => {
       const { provider, sourceLang, targetLang } = payload
       let apiKey: string
       try {
@@ -152,7 +144,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
 
       const jobId = randomUUID()
       const controller = new AbortController()
-      activeJobs.set(jobId, controller)
+      activeJobs.set(jobId, { cancel: () => controller.abort() })
 
       void runBatchJob({
         ...payload,
@@ -194,24 +186,6 @@ function requirePayloadApiKey(payload: TranslationStartPayload): void {
 
 function providerLabel(provider: 'openai' | 'deepl'): string {
   return provider === 'deepl' ? 'DeepL' : 'OpenAI'
-}
-
-function buildPipeline(payload: TranslationStartPayload): BasePipeline {
-  switch (payload.provider) {
-    case 'deepl':
-      if (!payload.apiKey) throw new Error('DeepL API key is required')
-      return new DeepLPipeline(payload.apiKey)
-
-    case 'openai':
-      if (!payload.apiKey) throw new Error('OpenAI API key is required')
-      return new OpenAIPipeline(payload.apiKey, payload.model)
-
-    case 'manual':
-      return new ManualPipeline()
-
-    default:
-      throw new Error(`Unknown translation provider: ${payload.provider}`)
-  }
 }
 
 // Worker pool: runs fn over items with at most `concurrency` parallel executions
@@ -450,5 +424,7 @@ function throwIfAborted(signal?: AbortSignal): void {
 }
 
 function isAbortError(err: unknown): boolean {
-  return err instanceof Error && (err.name === 'AbortError' || err.message === 'Translation cancelled')
+  return (
+    err instanceof Error && (err.name === 'AbortError' || err.message === 'Translation cancelled')
+  )
 }

--- a/src/main/ipc/xml.ipc.ts
+++ b/src/main/ipc/xml.ipc.ts
@@ -1,26 +1,8 @@
-import path from 'node:path'
-import { ipcMain, type WebContents } from 'electron'
-import { getDictionaryTargetText } from '../database/repositories/dictionary.repo'
+import { ipcMain } from 'electron'
 import type { RepositoryRegistry } from '../database/repositories/registry'
-import { unpackMod } from '../services/lslib.service'
-import { decodeEntities, encodeEntities } from '../services/xml-entities.service'
-import {
-  findLocalizationXmls,
-  type LocalizationEntry,
-  parseLocalizationXml,
-  writeLocalizationXml
-} from '../services/xml-parser.service'
-import { extract } from '../services/zip.service'
-import { findPakFiles } from '../utils/findPakFiles'
-import { cleanupTempDir, createTempDir } from '../utils/tempDir'
-
-interface XmlEntry {
-  uid: string
-  version: string
-  source: string
-  target: string
-  matchType: 'none' | 'mod-text' | 'text' | 'manual'
-}
+import { encodeEntities } from '../services/xml-entities.service'
+import { loadXmlViaWorker, type XmlEntry } from '../services/xml-load.service'
+import { writeLocalizationXml } from '../services/xml-parser.service'
 
 interface LoadPayload {
   inputPath: string
@@ -34,104 +16,6 @@ interface ExportPayload {
   entries: XmlEntry[]
 }
 
-type XmlLoadProgress =
-  | { phase: 'unpacking' }
-  | { phase: 'parsing' }
-  | { phase: 'matching'; processed: number; total: number }
-
-function toUiEntry(entry: LocalizationEntry): Pick<XmlEntry, 'uid' | 'version' | 'source'> {
-  return {
-    uid: entry.contentuid,
-    version: entry.version,
-    source: decodeEntities(entry.text)
-  }
-}
-
-const MATCH_CHUNK = 500
-
-async function loadXml(
-  sender: WebContents,
-  repos: RepositoryRegistry,
-  payload: LoadPayload
-): Promise<XmlEntry[]> {
-  const { inputPath, sourceLang, targetLang, modName } = payload
-  const ext = path.extname(inputPath).toLowerCase()
-
-  let xmlPath: string
-  const tempDirs: string[] = []
-
-  try {
-    if (ext === '.xml') {
-      xmlPath = inputPath
-    } else if (ext === '.pak') {
-      sender.send('xml:load:progress', { phase: 'unpacking' } satisfies XmlLoadProgress)
-      const tempDir = createTempDir('icosa_xml')
-      tempDirs.push(tempDir)
-      await unpackMod(inputPath, tempDir)
-      const sourceFolder = languageFolder(repos, sourceLang)
-      const xmlFiles = findLocalizationXmls(tempDir, sourceFolder)
-      if (xmlFiles.length === 0)
-        throw new Error(`No XML found for language "${sourceFolder}" in pak`)
-      xmlPath = xmlFiles[0]
-    } else if (ext === '.zip') {
-      sender.send('xml:load:progress', { phase: 'unpacking' } satisfies XmlLoadProgress)
-      const archiveDir = createTempDir('icosa_zip')
-      tempDirs.push(archiveDir)
-      extract(inputPath, archiveDir)
-      const pakFiles = findPakFiles(archiveDir)
-      if (pakFiles.length === 0) throw new Error('No .pak file found inside zip')
-
-      const unpackedDir = createTempDir('icosa_pak')
-      tempDirs.push(unpackedDir)
-      await unpackMod(pakFiles[0], unpackedDir)
-      const sourceFolder = languageFolder(repos, sourceLang)
-      const xmlFiles = findLocalizationXmls(unpackedDir, sourceFolder)
-      if (xmlFiles.length === 0)
-        throw new Error(`No XML found for language "${sourceFolder}" in pak`)
-      xmlPath = xmlFiles[0]
-    } else {
-      throw new Error(`Unsupported file type: ${ext}. Use .xml, .pak, or .zip`)
-    }
-
-    sender.send('xml:load:progress', { phase: 'parsing' } satisfies XmlLoadProgress)
-    const localizationEntries = parseLocalizationXml(xmlPath)
-    const total = localizationEntries.length
-    const result: XmlEntry[] = new Array(total)
-
-    for (let i = 0; i < total; i += MATCH_CHUNK) {
-      const end = Math.min(i + MATCH_CHUNK, total)
-      for (let j = i; j < end; j++) {
-        const entry = localizationEntries[j]
-        const uiEntry = toUiEntry(entry)
-        const match = repos.dictionary.resolveMatch({
-          modName: modName ?? null,
-          uid: entry.contentuid,
-          sourceLang,
-          targetLang,
-          sourceText: entry.text
-        })
-        result[j] = match
-          ? {
-              ...uiEntry,
-              target: decodeEntities(getDictionaryTargetText(match.entry, sourceLang, targetLang)),
-              matchType: match.matchType
-            }
-          : { ...uiEntry, target: '', matchType: 'none' }
-      }
-      sender.send('xml:load:progress', {
-        phase: 'matching',
-        processed: end,
-        total
-      } satisfies XmlLoadProgress)
-      await new Promise<void>((resolve) => setImmediate(resolve))
-    }
-
-    return result
-  } finally {
-    for (const tempDir of tempDirs) cleanupTempDir(tempDir)
-  }
-}
-
 function exportXml(payload: ExportPayload): void {
   const { outputPath, entries } = payload
   const localizationEntries = entries.map((entry) => ({
@@ -142,14 +26,15 @@ function exportXml(payload: ExportPayload): void {
   writeLocalizationXml(localizationEntries, outputPath)
 }
 
-function languageFolder(repos: RepositoryRegistry, languageCode: string): string {
-  const language = repos.language.findByCode(languageCode)
-  return (language?.name ?? languageCode).replace(/[^a-zA-Z0-9]/g, '')
-}
-
 export function registerXmlHandlers(repos: RepositoryRegistry): void {
-  ipcMain.handle('xml:load', async (event, payload: LoadPayload) =>
-    loadXml(event.sender, repos, payload)
-  )
+  ipcMain.handle('xml:load', async (event, payload: LoadPayload) => {
+    const result = await loadXmlViaWorker({
+      ...payload,
+      repos,
+      onProgress: (p) => event.sender.send('xml:load:progress', p)
+    })
+    return result.entries
+  })
+
   ipcMain.handle('xml:export', (_event, payload: ExportPayload) => exportXml(payload))
 }

--- a/src/main/pipelines/base.pipeline.ts
+++ b/src/main/pipelines/base.pipeline.ts
@@ -1,9 +1,8 @@
 import fs from 'node:fs'
 import path from 'node:path'
-import type { BrowserWindow } from 'electron'
-import { getDb } from '../database/connection'
-import type { SimilarityRow } from '../database/repositories/dictionary.repo'
+import type { drizzle } from 'drizzle-orm/better-sqlite3'
 import {
+  type DictionaryMatchIndex,
   DictionaryRepository,
   getDictionaryTargetText
 } from '../database/repositories/dictionary.repo'
@@ -11,7 +10,7 @@ import { LanguageRepository } from '../database/repositories/language.repo'
 import { ModRepository } from '../database/repositories/mod.repo'
 import { packMod, unpackMod } from '../services/lslib.service'
 import { createMeta, readAttributeValue, sanitizeMetaFolder } from '../services/lsx-parser.service'
-import { findSimilar, type SimilarEntry } from '../services/similarity.service'
+import { type SimilarEntry, SimilarityIndex } from '../services/similarity.service'
 import {
   findLocalizationXmls,
   type LocalizationEntry,
@@ -21,7 +20,8 @@ import {
 import { createZip, extract } from '../services/zip.service'
 import { findPakFiles } from '../utils/findPakFiles'
 import { cleanupTempDir, createTempDir } from '../utils/tempDir'
-import { getActiveWindow } from '../utils/window'
+
+type AppDb = ReturnType<typeof drizzle>
 
 export interface PipelineOptions {
   filePath: string
@@ -34,7 +34,9 @@ export interface PipelineOptions {
 export interface PipelineContext extends PipelineOptions {
   jobId: string
   signal: AbortSignal
-  getWindow: () => BrowserWindow | null
+  db: AppDb
+  onProgress: (current: number, total: number, source: string, target: string) => void
+  onDone: (outputPath: string) => void
 }
 
 export interface TranslatedEntry extends LocalizationEntry {
@@ -47,7 +49,8 @@ export abstract class BasePipeline {
   private dictRepo!: DictionaryRepository
   private languageRepo!: LanguageRepository
   private modRepo!: ModRepository
-  private corpus: SimilarityRow[] = []
+  private similarityIndex!: SimilarityIndex
+  private matchIndex!: DictionaryMatchIndex
 
   abstract translate(
     text: string,
@@ -58,7 +61,7 @@ export abstract class BasePipeline {
 
   async run(ctx: PipelineContext): Promise<string> {
     this.ctx = ctx
-    const db = getDb()
+    const db = ctx.db
     this.dictRepo = new DictionaryRepository(db)
     this.languageRepo = new LanguageRepository(db)
     this.modRepo = new ModRepository(db)
@@ -72,14 +75,14 @@ export abstract class BasePipeline {
         return await this.runXml(ctx, outDir)
       }
 
-      // 1 — resolve .pak path (may need to unzip first)
+      // 1 - resolve .pak path (may need to unzip first)
       const pakPath = await this.resolvePak(ctx.filePath, tmpDir)
 
-      // 2 — unpack .pak
+      // 2 - unpack .pak
       const unpackedDir = path.join(tmpDir, 'unpacked')
       await unpackMod(pakPath, unpackedDir)
 
-      // 3 — find source XMLs
+      // 3 - find source XMLs
       const sourceFolder = this.languageFolder(ctx.sourceLang)
       const targetFolder = this.languageFolder(ctx.targetLang)
       const xmlFiles = findLocalizationXmls(unpackedDir, sourceFolder)
@@ -87,15 +90,17 @@ export abstract class BasePipeline {
         throw new Error(`No localization XMLs found for language '${sourceFolder}' in the mod`)
       }
 
-      // 4 — pre-load corpus for similarity search (once per run)
-      this.corpus = this.dictRepo.getAllForSimilarity(ctx.sourceLang, ctx.targetLang)
+      // 4 - pre-load similarity index and match index once per run
+      const corpusRows = this.dictRepo.getAllForSimilarity(ctx.sourceLang, ctx.targetLang)
+      this.similarityIndex = new SimilarityIndex(corpusRows)
+      this.matchIndex = this.dictRepo.loadMatchIndex(ctx.sourceLang, ctx.targetLang)
 
-      // 5 — count total entries for progress tracking
+      // 5 - count total entries for progress tracking
       const allEntries = xmlFiles.flatMap((f) => parseLocalizationXml(f))
       const total = allEntries.length
       let current = 0
 
-      // 6 — ensure mod record exists
+      // 6 - ensure mod record exists
       this.modRepo.upsert(ctx.modName)
 
       const metaSrc = findMetaLsx(unpackedDir)
@@ -126,13 +131,13 @@ export abstract class BasePipeline {
       // 8 - generate meta.lsx for the translated add-on
       this.updateMeta(metaSrc, modRoot, ctx, translatedModName)
 
-      // 9 — pack translated folder into .pak
+      // 9 - pack translated folder into .pak
       const packedDir = path.join(tmpDir, 'packed')
       fs.mkdirSync(packedDir, { recursive: true })
       const outPakPath = path.join(packedDir, `${ctx.modName}_${ctx.targetLang}.pak`)
       await packMod(packageRoot, outPakPath)
 
-      // 10 — wrap in .zip for distribution
+      // 10 - wrap in .zip for distribution
       const finalZip = path.join(path.dirname(ctx.filePath), `${ctx.modName}_${ctx.targetLang}.zip`)
       createZip(packedDir, finalZip)
 
@@ -145,7 +150,9 @@ export abstract class BasePipeline {
   }
 
   private async runXml(ctx: PipelineContext, outDir: string): Promise<string> {
-    this.corpus = this.dictRepo.getAllForSimilarity(ctx.sourceLang, ctx.targetLang)
+    const corpusRows = this.dictRepo.getAllForSimilarity(ctx.sourceLang, ctx.targetLang)
+    this.similarityIndex = new SimilarityIndex(corpusRows)
+    this.matchIndex = this.dictRepo.loadMatchIndex(ctx.sourceLang, ctx.targetLang)
     this.modRepo.upsert(ctx.modName)
 
     const entries = parseLocalizationXml(ctx.filePath)
@@ -195,22 +202,19 @@ export abstract class BasePipeline {
   private async resolveTranslation(entry: LocalizationEntry): Promise<string> {
     const { sourceLang, targetLang, modName } = this.ctx
 
-    const match = this.dictRepo.resolveMatch({
-      modName,
+    const match = this.matchIndex.resolve({
+      modName: modName ?? null,
       uid: entry.contentuid || null,
-      sourceLang,
-      targetLang,
       sourceText: entry.text
     })
     if (match) {
       return getDictionaryTargetText(match.entry, sourceLang, targetLang)
     }
 
-    // 3. not in cache → translate via subclass
-    const context = findSimilar(entry.text, this.corpus, 5)
+    // cache miss - translate via subclass
+    const context = this.similarityIndex.search(entry.text, 5)
     const translated = await this.translate(entry.text, sourceLang, targetLang, context)
 
-    // 2. save to dictionary
     this.dictRepo.upsert({
       sourceLang,
       targetLang,
@@ -220,8 +224,8 @@ export abstract class BasePipeline {
       uid: entry.contentuid || undefined
     })
 
-    // refresh corpus with the new entry
-    this.corpus.push({ source: entry.text, target: translated })
+    // - matchIndex is left slightly stale; the new entry lands on the next run
+    this.similarityIndex.add({ source: entry.text, target: translated })
 
     return translated
   }
@@ -267,23 +271,11 @@ export abstract class BasePipeline {
   }
 
   private emitProgress(current: number, total: number, source: string, target: string): void {
-    const win = getActiveWindow(this.ctx.getWindow)
-    if (win) {
-      win.webContents.send('translation:progress', {
-        jobId: this.ctx.jobId,
-        current,
-        total,
-        source,
-        target
-      })
-    }
+    this.ctx.onProgress(current, total, source, target)
   }
 
   private emitDone(outputPath: string): void {
-    const win = getActiveWindow(this.ctx.getWindow)
-    if (win) {
-      win.webContents.send('translation:done', { jobId: this.ctx.jobId, outputPath })
-    }
+    this.ctx.onDone(outputPath)
   }
 }
 

--- a/src/main/services/similarity.service.ts
+++ b/src/main/services/similarity.service.ts
@@ -7,22 +7,41 @@ export interface SimilarEntry {
   score: number
 }
 
+const FUSE_OPTIONS = {
+  keys: ['source'],
+  includeScore: true,
+  threshold: 0.6
+}
+
+export class SimilarityIndex {
+  private fuse: Fuse<SimilarityRow>
+  private count: number
+
+  constructor(corpus: SimilarityRow[]) {
+    this.fuse = new Fuse(corpus, FUSE_OPTIONS)
+    this.count = corpus.length
+  }
+
+  add(entry: SimilarityRow): void {
+    this.fuse.add(entry)
+    this.count++
+  }
+
+  search(text: string, limit = 5): SimilarEntry[] {
+    if (this.count === 0) return []
+    return this.fuse.search(text, { limit }).map((r) => ({
+      original: r.item.source,
+      translated: r.item.target,
+      score: r.score ?? 1
+    }))
+  }
+}
+
 export function findSimilar(
   sourceText: string,
   corpus: SimilarityRow[],
   limit = 5
 ): SimilarEntry[] {
   if (corpus.length === 0) return []
-
-  const fuse = new Fuse(corpus, {
-    keys: ['source'],
-    includeScore: true,
-    threshold: 0.6
-  })
-
-  return fuse.search(sourceText, { limit }).map((r) => ({
-    original: r.item.source,
-    translated: r.item.target,
-    score: r.score ?? 1
-  }))
+  return new SimilarityIndex(corpus).search(sourceText, limit)
 }

--- a/src/main/services/translate.service.ts
+++ b/src/main/services/translate.service.ts
@@ -1,0 +1,69 @@
+import path from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { app } from 'electron'
+import type {
+  TranslateWorkerInput,
+  TranslateWorkerProgress
+} from '../workers/translate.worker.runtime'
+
+export interface TranslatePipelineParams {
+  jobId: string
+  filePath: string
+  modName: string
+  sourceLang: string
+  targetLang: string
+  author?: string
+  provider: 'deepl' | 'openai' | 'manual'
+  apiKey?: string
+  model?: string
+  onProgress: (p: { current: number; total: number; source: string; target: string }) => void
+  onDone: (p: { outputPath: string }) => void
+  onError: (p: { message: string }) => void
+}
+
+export function runTranslatePipeline(params: TranslatePipelineParams): { cancel: () => void } {
+  const { onProgress, onDone, onError, ...rest } = params
+  const input: TranslateWorkerInput = {
+    ...rest,
+    dbPath: path.join(app.getPath('userData'), 'icosa.db')
+  }
+
+  let settled = false
+  const worker = new Worker(path.join(__dirname, 'translate.worker.js'), { workerData: input })
+
+  worker.on('message', (msg: TranslateWorkerProgress) => {
+    if (msg.phase === 'progress') {
+      onProgress({ current: msg.current, total: msg.total, source: msg.source, target: msg.target })
+    } else if (msg.phase === 'done') {
+      settled = true
+      worker.removeAllListeners()
+      onDone({ outputPath: msg.outputPath })
+    } else if (msg.phase === 'error') {
+      settled = true
+      worker.removeAllListeners()
+      onError({ message: msg.message })
+    }
+  })
+
+  worker.on('error', (err) => {
+    if (!settled) {
+      settled = true
+      onError({ message: err.message })
+    }
+  })
+
+  worker.on('exit', (code) => {
+    if (code !== 0 && !settled) {
+      settled = true
+      onError({ message: `translate worker exited with code ${code}` })
+    }
+  })
+
+  return {
+    cancel: () => {
+      worker.postMessage({ type: 'cancel' })
+      const t = setTimeout(() => worker.terminate(), 5000)
+      worker.once('exit', () => clearTimeout(t))
+    }
+  }
+}

--- a/src/main/services/xml-load.service.ts
+++ b/src/main/services/xml-load.service.ts
@@ -1,0 +1,59 @@
+import path from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { app } from 'electron'
+import type { RepositoryRegistry } from '../database/repositories/registry'
+import type {
+  XmlEntry,
+  XmlLoadProgress,
+  XmlLoadResult,
+  XmlLoadWorkerInput
+} from '../workers/xml-load.worker.runtime'
+
+export type { XmlEntry, XmlLoadResult }
+
+export type XmlLoadProgressUpdate = Exclude<XmlLoadProgress, { phase: 'done' } | { phase: 'error' }>
+
+export interface LoadXmlParams {
+  inputPath: string
+  sourceLang: string
+  targetLang: string
+  modName?: string
+  repos: RepositoryRegistry
+  onProgress?: (p: XmlLoadProgressUpdate) => void
+}
+
+function languageFolder(repos: RepositoryRegistry, languageCode: string): string {
+  const lang = repos.language.findByCode(languageCode)
+  return (lang?.name ?? languageCode).replace(/[^a-zA-Z0-9]/g, '')
+}
+
+function getDbPath(): string {
+  return path.join(app.getPath('userData'), 'icosa.db')
+}
+
+export function loadXmlViaWorker(params: LoadXmlParams): Promise<XmlLoadResult> {
+  const { repos, onProgress, ...rest } = params
+  const sourceFolder = languageFolder(repos, rest.sourceLang)
+  const input: XmlLoadWorkerInput = { ...rest, sourceFolder, dbPath: getDbPath() }
+
+  return new Promise<XmlLoadResult>((resolve, reject) => {
+    const worker = new Worker(path.join(__dirname, 'xml-load.worker.js'), { workerData: input })
+
+    worker.on('message', (msg: XmlLoadProgress) => {
+      if (msg.phase === 'done') {
+        resolve(msg.result)
+        return
+      }
+      if (msg.phase === 'error') {
+        reject(new Error(msg.message))
+        return
+      }
+      onProgress?.(msg)
+    })
+
+    worker.on('error', reject)
+    worker.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`xml-load worker exited with code ${code}`))
+    })
+  })
+}

--- a/src/main/workers/translate.worker.runtime.ts
+++ b/src/main/workers/translate.worker.runtime.ts
@@ -1,0 +1,78 @@
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import * as schema from '../database/schema'
+import type { BasePipeline } from '../pipelines/base.pipeline'
+import { DeepLPipeline } from '../pipelines/deepl.pipeline'
+import { ManualPipeline } from '../pipelines/manual.pipeline'
+import { OpenAIPipeline } from '../pipelines/openai.pipeline'
+
+export interface TranslateWorkerInput {
+  jobId: string
+  provider: 'deepl' | 'openai' | 'manual'
+  apiKey?: string
+  model?: string
+  filePath: string
+  modName: string
+  sourceLang: string
+  targetLang: string
+  author?: string
+  dbPath: string
+}
+
+export type TranslateWorkerProgress =
+  | { phase: 'progress'; current: number; total: number; source: string; target: string }
+  | { phase: 'done'; outputPath: string }
+  | { phase: 'error'; message: string }
+
+function buildPipeline(input: TranslateWorkerInput): BasePipeline {
+  switch (input.provider) {
+    case 'deepl':
+      if (!input.apiKey) throw new Error('DeepL API key is required')
+      return new DeepLPipeline(input.apiKey)
+    case 'openai':
+      if (!input.apiKey) throw new Error('OpenAI API key is required')
+      return new OpenAIPipeline(input.apiKey, input.model)
+    case 'manual':
+      return new ManualPipeline()
+    default:
+      throw new Error(`Unknown translation provider: ${input.provider}`)
+  }
+}
+
+export async function runTranslateWorker(
+  input: TranslateWorkerInput,
+  post: (msg: TranslateWorkerProgress) => void,
+  receiveCancel: (handler: () => void) => void
+): Promise<void> {
+  const controller = new AbortController()
+  receiveCancel(() => controller.abort())
+
+  const sqlite = new Database(input.dbPath)
+  sqlite.pragma('journal_mode = WAL')
+  sqlite.pragma('foreign_keys = ON')
+  sqlite.pragma('synchronous = NORMAL')
+  sqlite.pragma('cache_size = -64000')
+  sqlite.pragma('temp_store = MEMORY')
+  sqlite.pragma('mmap_size = 268435456')
+
+  try {
+    const db = drizzle(sqlite, { schema })
+    const pipeline = buildPipeline(input)
+
+    await pipeline.run({
+      jobId: input.jobId,
+      filePath: input.filePath,
+      modName: input.modName,
+      sourceLang: input.sourceLang,
+      targetLang: input.targetLang,
+      author: input.author,
+      signal: controller.signal,
+      db,
+      onProgress: (current, total, source, target) =>
+        post({ phase: 'progress', current, total, source, target }),
+      onDone: (outputPath) => post({ phase: 'done', outputPath })
+    })
+  } finally {
+    sqlite.close()
+  }
+}

--- a/src/main/workers/translate.worker.ts
+++ b/src/main/workers/translate.worker.ts
@@ -1,0 +1,36 @@
+import { parentPort, workerData } from 'node:worker_threads'
+import { runTranslateWorker, type TranslateWorkerInput } from './translate.worker.runtime'
+
+if (parentPort === null) {
+  throw new Error('translate.worker must be spawned via worker_threads')
+}
+
+const port = parentPort
+let cancelHandler: (() => void) | undefined
+
+port.on('message', (msg: unknown) => {
+  if (
+    msg !== null &&
+    typeof msg === 'object' &&
+    (msg as Record<string, unknown>).type === 'cancel'
+  ) {
+    cancelHandler?.()
+  }
+})
+
+;(async () => {
+  try {
+    await runTranslateWorker(
+      workerData as TranslateWorkerInput,
+      (msg) => port.postMessage(msg),
+      (handler) => {
+        cancelHandler = handler
+      }
+    )
+    process.exit(0)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    port.postMessage({ phase: 'error', message })
+    process.exit(1)
+  }
+})()

--- a/src/main/workers/xml-load.worker.runtime.ts
+++ b/src/main/workers/xml-load.worker.runtime.ts
@@ -1,0 +1,144 @@
+import path from 'node:path'
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import {
+  DictionaryRepository,
+  getDictionaryTargetText
+} from '../database/repositories/dictionary.repo'
+import * as schema from '../database/schema'
+import { unpackMod } from '../services/lslib.service'
+import { decodeEntities } from '../services/xml-entities.service'
+import {
+  findLocalizationXmls,
+  type LocalizationEntry,
+  parseLocalizationXml
+} from '../services/xml-parser.service'
+import { extract } from '../services/zip.service'
+import { findPakFiles } from '../utils/findPakFiles'
+import { cleanupTempDir, createTempDir } from '../utils/tempDir'
+
+export interface XmlLoadWorkerInput {
+  inputPath: string
+  sourceLang: string
+  targetLang: string
+  modName?: string
+  sourceFolder: string
+  dbPath: string
+}
+
+export interface XmlEntry {
+  uid: string
+  version: string
+  source: string
+  target: string
+  matchType: 'none' | 'mod-text' | 'text' | 'manual'
+}
+
+export interface XmlLoadResult {
+  entries: XmlEntry[]
+}
+
+export type XmlLoadProgress =
+  | { phase: 'unpacking' }
+  | { phase: 'parsing' }
+  | { phase: 'loading-cache' }
+  | { phase: 'matching'; processed: number; total: number }
+  | { phase: 'done'; result: XmlLoadResult }
+  | { phase: 'error'; message: string }
+
+const MATCH_CHUNK = 500
+
+function toUiEntry(entry: LocalizationEntry): Pick<XmlEntry, 'uid' | 'version' | 'source'> {
+  return {
+    uid: entry.contentuid,
+    version: entry.version,
+    source: decodeEntities(entry.text)
+  }
+}
+
+export async function runXmlLoadWorker(
+  input: XmlLoadWorkerInput,
+  post: (msg: XmlLoadProgress) => void
+): Promise<void> {
+  const sqlite = new Database(input.dbPath)
+  sqlite.pragma('journal_mode = WAL')
+  sqlite.pragma('foreign_keys = ON')
+  sqlite.pragma('synchronous = NORMAL')
+  sqlite.pragma('cache_size = -64000')
+  sqlite.pragma('temp_store = MEMORY')
+  sqlite.pragma('mmap_size = 268435456')
+
+  const tempDirs: string[] = []
+
+  try {
+    const db = drizzle(sqlite, { schema })
+    const { inputPath, sourceLang, targetLang, modName, sourceFolder } = input
+    const ext = path.extname(inputPath).toLowerCase()
+
+    let xmlPath: string
+
+    if (ext === '.xml') {
+      xmlPath = inputPath
+    } else if (ext === '.pak') {
+      post({ phase: 'unpacking' })
+      const tempDir = createTempDir('icosa_xml')
+      tempDirs.push(tempDir)
+      await unpackMod(inputPath, tempDir)
+      const xmlFiles = findLocalizationXmls(tempDir, sourceFolder)
+      if (xmlFiles.length === 0)
+        throw new Error(`No XML found for language "${sourceFolder}" in pak`)
+      xmlPath = xmlFiles[0]
+    } else if (ext === '.zip') {
+      post({ phase: 'unpacking' })
+      const archiveDir = createTempDir('icosa_zip')
+      tempDirs.push(archiveDir)
+      extract(inputPath, archiveDir)
+      const pakFiles = findPakFiles(archiveDir)
+      if (pakFiles.length === 0) throw new Error('No .pak file found inside zip')
+      const unpackedDir = createTempDir('icosa_pak')
+      tempDirs.push(unpackedDir)
+      await unpackMod(pakFiles[0], unpackedDir)
+      const xmlFiles = findLocalizationXmls(unpackedDir, sourceFolder)
+      if (xmlFiles.length === 0)
+        throw new Error(`No XML found for language "${sourceFolder}" in pak`)
+      xmlPath = xmlFiles[0]
+    } else {
+      throw new Error(`Unsupported file type: ${ext}. Use .xml, .pak, or .zip`)
+    }
+
+    post({ phase: 'parsing' })
+    const localizationEntries = parseLocalizationXml(xmlPath)
+    const total = localizationEntries.length
+    const result: XmlEntry[] = new Array(total)
+
+    post({ phase: 'loading-cache' })
+    const index = new DictionaryRepository(db).loadMatchIndex(sourceLang, targetLang)
+
+    for (let i = 0; i < total; i += MATCH_CHUNK) {
+      const end = Math.min(i + MATCH_CHUNK, total)
+      for (let j = i; j < end; j++) {
+        const entry = localizationEntries[j]
+        const uiEntry = toUiEntry(entry)
+        const match = index.resolve({
+          modName: modName ?? null,
+          uid: entry.contentuid,
+          sourceText: entry.text
+        })
+        result[j] = match
+          ? {
+              ...uiEntry,
+              target: decodeEntities(getDictionaryTargetText(match.entry, sourceLang, targetLang)),
+              matchType: match.matchType
+            }
+          : { ...uiEntry, target: '', matchType: 'none' }
+      }
+      post({ phase: 'matching', processed: end, total })
+      await new Promise<void>((resolve) => setImmediate(resolve))
+    }
+
+    post({ phase: 'done', result: { entries: result } })
+  } finally {
+    for (const tempDir of tempDirs) cleanupTempDir(tempDir)
+    sqlite.close()
+  }
+}

--- a/src/main/workers/xml-load.worker.ts
+++ b/src/main/workers/xml-load.worker.ts
@@ -1,0 +1,19 @@
+import { parentPort, workerData } from 'node:worker_threads'
+import { runXmlLoadWorker, type XmlLoadWorkerInput } from './xml-load.worker.runtime'
+
+if (parentPort === null) {
+  throw new Error('xml-load.worker must be spawned via worker_threads')
+}
+
+const port = parentPort
+
+;(async () => {
+  try {
+    await runXmlLoadWorker(workerData as XmlLoadWorkerInput, (msg) => port.postMessage(msg))
+    process.exit(0)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    port.postMessage({ phase: 'error', message })
+    process.exit(1)
+  }
+})()

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -344,6 +344,7 @@ export interface MergeApi {
 export type XmlLoadProgress =
   | { phase: 'unpacking' }
   | { phase: 'parsing' }
+  | { phase: 'loading-cache' }
   | { phase: 'matching'; processed: number; total: number }
 
 export interface XmlApi {

--- a/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
@@ -35,6 +35,9 @@ export function TranslateIdleScreen({ session }: TranslateIdleScreenProps): Reac
     if (loadingProgress.phase === 'unpacking')
       return t('setup.loadingUnpacking', { ns: 'translate' })
     if (loadingProgress.phase === 'parsing') return t('setup.loadingParsing', { ns: 'translate' })
+    // - phases: unpacking, parsing, loading-cache, matching
+    if (loadingProgress.phase === 'loading-cache')
+      return t('setup.loadingCache', { ns: 'translate' })
     if (loadingProgress.phase === 'matching')
       return t('setup.loadingMatching', {
         ns: 'translate',

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -52,6 +52,7 @@
     "loadingEditor": "Loading translation editor...",
     "loadingUnpacking": "Unpacking mod files…",
     "loadingParsing": "Parsing localization XML…",
+    "loadingCache": "Loading dictionary cache…",
     "loadingMatching": "Matching dictionary {{processed}} / {{total}}"
   },
   "routeSkeleton": {

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -52,6 +52,7 @@
     "loadingEditor": "Carregando editor de tradução...",
     "loadingUnpacking": "Descompactando arquivos do mod…",
     "loadingParsing": "Lendo XML de localização…",
+    "loadingCache": "Carregando cache do dicionário…",
     "loadingMatching": "Comparando dicionário {{processed}} / {{total}}"
   },
   "routeSkeleton": {


### PR DESCRIPTION
## Summary
- Eliminates UI freezes when loading mods with large dictionaries (tested with 230k entries): the matching phase now runs in a dedicated Node worker thread with an in-memory lookup index instead of 3 SQL queries per entry
- Moves the full translation pipeline (DeepL / OpenAI / Manual) to a worker thread so the main process stays responsive throughout a translation run; replaces per-entry Fuse.js index rebuilds with a persistent `SimilarityIndex`

## What changed
- `DictionaryRepository.loadMatchIndex` — bulk-loads a language pair into three Maps for O(1) resolve; replaces per-entry `resolveMatch` calls
- `SimilarityIndex` class — holds a single Fuse.js instance that grows via `.add()` instead of being rebuilt on every `findSimilar` call
- `xml-load.worker` + `xml-load.service` — xml:load handler now delegates to a worker (unpack → parse → load-cache → match); progress emits four phases including the new `loading-cache` phase visible in the UI
- `translate.worker` + `translate.service` — translation pipeline runs in a worker; cancellation preserved via `worker.postMessage({ type: 'cancel' })` and internal `AbortController`
- `BasePipeline` refactored to be Electron-free (no `getDb`, no `BrowserWindow`); accepts `db` and `onProgress`/`onDone` callbacks via context
- Renderer: loading overlay now shows a "Loading dictionary cache…" label between parsing and matching

## Version
- v1.4.0 (feat → minor bump)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds; `out/main/xml-load.worker.js` and `out/main/translate.worker.js` exist
- [x] Load a mod with a large dictionary (~230k entries): UI stays responsive, overlay shows all 4 phases (unpacking → parsing → loading dictionary cache → matching X/Y)
- [x] Run a Manual translation end-to-end: progress fires, output zip lands in expected location
- [x] Cancel a running translation mid-run: worker exits, temp dirs cleaned, no frozen frames