### PR TITLE
feat(mods): Manage Mods page with priority ordering, delete, and dictionary import worker

### DIFF
--- a/drizzle/0007_ordinary_rafael_vega.sql
+++ b/drizzle/0007_ordinary_rafael_vega.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `mod` ADD `priority` integer;

--- a/drizzle/meta/0007_snapshot.json
+++ b/drizzle/meta/0007_snapshot.json
@@ -1,0 +1,483 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "9f7d32f3-f9de-4542-90aa-c07cdd2a4ce7",
+  "prevId": "71b63901-7547-43ca-8a68-0a33def80716",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dictionary": {
+      "name": "dictionary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "language1": {
+          "name": "language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language2": {
+          "name": "language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1": {
+          "name": "text_language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language2": {
+          "name": "text_language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1_key": {
+          "name": "text_language1_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "text_language2_key": {
+          "name": "text_language2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mod_name": {
+          "name": "mod_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "dictionary_langs_idx": {
+          "name": "dictionary_langs_idx",
+          "columns": [
+            "language1",
+            "language2"
+          ],
+          "isUnique": false
+        },
+        "dictionary_langs_mod_idx": {
+          "name": "dictionary_langs_mod_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_mod_idx": {
+          "name": "dictionary_mod_idx",
+          "columns": [
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_match_idx": {
+          "name": "dictionary_match_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name",
+            "text_language1_key"
+          ],
+          "isUnique": false
+        },
+        "dictionary_match_uid_idx": {
+          "name": "dictionary_match_uid_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name",
+            "uid",
+            "text_language1_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "dictionary_language1_language_code_fk": {
+          "name": "dictionary_language1_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language1"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_language2_language_code_fk": {
+          "name": "dictionary_language2_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language2"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_mod_name_mod_name_fk": {
+          "name": "dictionary_mod_name_mod_name_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language": {
+      "name": "language",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "language_code_unique": {
+          "name": "language_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod": {
+      "name": "mod",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_strings": {
+          "name": "total_strings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_file_path": {
+          "name": "last_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_name_unique": {
+          "name": "mod_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod_meta": {
+      "name": "mod_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta_file_path": {
+          "name": "meta_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_major": {
+          "name": "version_major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_minor": {
+          "name": "version_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_revision": {
+          "name": "version_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_build": {
+          "name": "version_build",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version64": {
+          "name": "version64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_meta_mod_id_unique": {
+          "name": "mod_meta_mod_id_unique",
+          "columns": [
+            "mod_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mod_meta_mod_id_mod_id_fk": {
+          "name": "mod_meta_mod_id_mod_id_fk",
+          "tableFrom": "mod_meta",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -50,6 +50,13 @@
       "when": 1778982960726,
       "tag": "0006_fair_captain_universe",
       "breakpoints": true
+    },
+    {
+      "idx": 7,
+      "version": "6",
+      "when": 1779052024100,
+      "tag": "0007_ordinary_rafael_vega",
+      "breakpoints": true
     }
   ]
 }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.4.0
+buildVersion: 1.5.0
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -11,7 +11,8 @@ export default defineConfig({
           index: resolve('src/main/index.ts'),
           'merge.worker': resolve('src/main/workers/merge.worker.ts'),
           'translate.worker': resolve('src/main/workers/translate.worker.ts'),
-          'xml-load.worker': resolve('src/main/workers/xml-load.worker.ts')
+          'xml-load.worker': resolve('src/main/workers/xml-load.worker.ts'),
+          'import.worker': resolve('src/main/workers/import.worker.ts')
         }
       }
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,9 @@
     "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@electron-toolkit/preload": "^3.0.2",
     "@electron-toolkit/utils": "^4.0.0",
     "@tanstack/react-virtual": "^3.13.24",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,15 @@ importers:
 
   .:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.5)
       '@electron-toolkit/preload':
         specifier: ^3.0.2
         version: 3.0.2(electron@39.8.9)
@@ -358,6 +367,28 @@ packages:
   '@develar/schema-utils@2.6.5':
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -2558,6 +2589,9 @@ packages:
   truncate-utf8-bytes@1.0.2:
     resolution: {integrity: sha512-95Pu1QXQvruGEhv62XCMO3Mm90GscOCClvrIUwCM0PYOXK3kaF3l3sIHxx71ThJfcbM2O5Au6SO3AWCSEfW4mQ==}
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   tsx@4.21.0:
     resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
     engines: {node: '>=18.0.0'}
@@ -2914,6 +2948,31 @@ snapshots:
     dependencies:
       ajv: 6.15.0
       ajv-keywords: 3.5.2(ajv@6.15.0)
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react@19.2.5)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.5)
+      react: 19.2.5
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.5)':
+    dependencies:
+      react: 19.2.5
+      tslib: 2.8.1
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -4952,6 +5011,8 @@ snapshots:
   truncate-utf8-bytes@1.0.2:
     dependencies:
       utf8-byte-length: 1.0.5
+
+  tslib@2.8.1: {}
 
   tsx@4.21.0:
     dependencies:

--- a/src/main/database/repositories/dictionary.repo.ts
+++ b/src/main/database/repositories/dictionary.repo.ts
@@ -291,11 +291,12 @@ export class DictionaryRepository {
     return map
   }
 
-  // - modName param is reserved for future scoping; the index always covers the full language pair
+  // - modName reserved for future scoping; priorityMods (if set) are checked first before the current mod and global fallback
   loadMatchIndex(
     sourceLang: string,
     targetLang: string,
-    _modName?: string | null
+    _modName?: string | null,
+    priorityMods?: readonly string[]
   ): DictionaryMatchIndex {
     const [l1, l2, swapped] = normalizeLangs(sourceLang, targetLang)
 
@@ -338,14 +339,25 @@ export class DictionaryRepository {
       }
     }
 
+    // Normalize once at index-build time; never per resolve call
+    const normalizedPriority = (priorityMods ?? [])
+      .map((m) => m?.trim().toLowerCase())
+      .filter((m): m is string => !!m)
+
     return {
       byModUidKey,
       byModKey,
       byKey,
       resolve(params) {
-        const normalizedMod = params.modName?.trim().toLowerCase() || null
         const sourceKey = dictionaryTextKey(params.sourceText)
 
+        // Priority mods checked first in order (text only - UIDs are mod-local)
+        for (const pm of normalizedPriority) {
+          const entry = byModKey.get(`${pm}|${sourceKey}`)
+          if (entry) return { entry, matchType: 'mod-text' }
+        }
+
+        const normalizedMod = params.modName?.trim().toLowerCase() || null
         if (normalizedMod) {
           const uid = params.uid?.trim()
           if (uid) {
@@ -362,6 +374,49 @@ export class DictionaryRepository {
         return undefined
       }
     }
+  }
+
+  // Single-SELECT + batch INSERT/UPDATE alternative to N sequential upsert calls.
+  // Fast path requires all rows to share the same modName (non-null) and language pair.
+  // Falls back to per-row upsert when modName is absent.
+  bulkUpsert(rows: UpsertParams[]): void {
+    if (rows.length === 0) return
+    const { sourceLang, targetLang, modName } = rows[0]
+    const trimmedModName = modName?.trim() || null
+
+    if (!trimmedModName) {
+      for (const row of rows) this.upsert(row)
+      return
+    }
+
+    const [, , swapped] = normalizeLangs(sourceLang, targetLang)
+    const keyMap = this.loadKeyMap(sourceLang, targetLang, trimmedModName)
+    const targetColumn: 'language1' | 'language2' = swapped ? 'language1' : 'language2'
+
+    const toInsert: NewDictionaryEntry[] = []
+    const toUpdate: { id: number; targetText: string; targetTextKey: string; uid: string | null }[] =
+      []
+
+    for (const row of rows) {
+      const sourceText = normalizeDictionaryText(row.sourceText)
+      const targetText = normalizeDictionaryText(row.targetText)
+      const sourceKey = dictionaryTextKey(sourceText)
+      const existing = keyMap.get(sourceKey)
+
+      if (existing) {
+        toUpdate.push({
+          id: existing.id,
+          targetText,
+          targetTextKey: dictionaryTextKey(targetText),
+          uid: row.uid?.trim() || existing.uid
+        })
+      } else {
+        toInsert.push(this.toValues(row))
+      }
+    }
+
+    if (toInsert.length > 0) this.bulkInsert(toInsert)
+    if (toUpdate.length > 0) this.bulkUpdate(toUpdate, targetColumn)
   }
 
   // Multi-row VALUES INSERT in a single transaction. Chunks internally so the bound
@@ -447,6 +502,15 @@ export class DictionaryRepository {
           eq(dictionary.modName, modName)
         )
       )
+      .get() as { count: number } | undefined
+    return result?.count ?? 0
+  }
+
+  countAllByMod(modName: string): number {
+    const result = this.db
+      .select({ count: sql<number>`count(*)` })
+      .from(dictionary)
+      .where(eq(dictionary.modName, modName))
       .get() as { count: number } | undefined
     return result?.count ?? 0
   }

--- a/src/main/database/repositories/mod.repo.ts
+++ b/src/main/database/repositories/mod.repo.ts
@@ -1,6 +1,6 @@
-import { eq, sql } from 'drizzle-orm'
-import { drizzle } from 'drizzle-orm/better-sqlite3'
-import { type Mod, mod } from '../schema'
+import { asc, eq, isNotNull, sql } from 'drizzle-orm'
+import type { drizzle } from 'drizzle-orm/better-sqlite3'
+import { dictionary, type Mod, mod, modMeta } from '../schema'
 
 type AppDb = ReturnType<typeof drizzle>
 
@@ -17,12 +17,14 @@ export class ModRepository {
   }
 
   getAll(): Mod[] {
-    return this.db.select().from(mod).orderBy(mod.name).all() as Mod[]
+    return this.db.select().from(mod).orderBy(asc(mod.name)).all() as Mod[]
   }
 
   getAllNames(): string[] {
     return (
-      this.db.select({ name: mod.name }).from(mod).orderBy(mod.name).all() as { name: string }[]
+      this.db.select({ name: mod.name }).from(mod).orderBy(asc(mod.name)).all() as {
+        name: string
+      }[]
     ).map((r) => r.name)
   }
 
@@ -40,5 +42,91 @@ export class ModRepository {
         }
       })
       .run()
+  }
+
+  // Returns mod names ordered by priority ASC (1 = highest), then name for deterministic ties.
+  getPriorityOrdered(): string[] {
+    return (
+      this.db
+        .select({ name: mod.name })
+        .from(mod)
+        .where(isNotNull(mod.priority))
+        .orderBy(asc(mod.priority), asc(mod.name))
+        .all() as { name: string }[]
+    ).map((r) => r.name)
+  }
+
+  // Sets the priority for a single mod. Caller must call compactPriority if rebalancing is needed.
+  setPriority(name: string, priority: number | null): void {
+    this.db
+      .update(mod)
+      .set({ priority, updatedAt: sql`(datetime('now'))` })
+      .where(eq(mod.name, name))
+      .run()
+  }
+
+  // Rebalances all priority mods to contiguous 1..N slots, ordered by (priority ASC, name ASC).
+  compactPriority(): void {
+    this.db.transaction((tx) => {
+      const rows = tx
+        .select({ name: mod.name, priority: mod.priority })
+        .from(mod)
+        .where(isNotNull(mod.priority))
+        .orderBy(asc(mod.priority), asc(mod.name))
+        .all() as { name: string; priority: number }[]
+
+      for (let i = 0; i < rows.length; i++) {
+        const newPriority = i + 1
+        if (rows[i].priority !== newPriority) {
+          tx.update(mod)
+            .set({ priority: newPriority, updatedAt: sql`(datetime('now'))` })
+            .where(eq(mod.name, rows[i].name))
+            .run()
+        }
+      }
+    })
+  }
+
+  // Atomically assigns priority 1..N to orderedNames and NULL to all others.
+  reorderPriority(orderedNames: string[]): void {
+    this.db.transaction((tx) => {
+      tx.update(mod).set({ priority: null }).where(isNotNull(mod.priority)).run()
+      for (let i = 0; i < orderedNames.length; i++) {
+        tx.update(mod)
+          .set({ priority: i + 1, updatedAt: sql`(datetime('now'))` })
+          .where(eq(mod.name, orderedNames[i]))
+          .run()
+      }
+    })
+  }
+
+  // Deletes the mod row (cascades mod_meta) and its dictionary entries in one transaction.
+  // Physical file removal is handled by mod-delete.service.ts (task 02).
+  delete(name: string): { dictionaryRows: number; hadMeta: boolean } {
+    let dictionaryRows = 0
+    let hadMeta = false
+
+    this.db.transaction((tx) => {
+      const countRow = tx
+        .select({ count: sql<number>`count(*)` })
+        .from(dictionary)
+        .where(eq(dictionary.modName, name))
+        .get() as { count: number }
+      dictionaryRows = countRow.count
+
+      const metaRow = tx
+        .select({ id: modMeta.id })
+        .from(modMeta)
+        .where(
+          eq(modMeta.modId, tx.select({ id: mod.id }).from(mod).where(eq(mod.name, name)).limit(1))
+        )
+        .get() as { id: number } | undefined
+      hadMeta = metaRow != null
+
+      tx.delete(dictionary).where(eq(dictionary.modName, name)).run()
+      tx.delete(mod).where(eq(mod.name, name)).run()
+    })
+
+    return { dictionaryRows, hadMeta }
   }
 }

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -18,6 +18,7 @@ export const mod = sqliteTable('mod', {
   name: text('name').unique().notNull(),
   totalStrings: integer('total_strings').default(0),
   lastFilePath: text('last_file_path'),
+  priority: integer('priority'),
   ...timestamps
 })
 

--- a/src/main/ipc/dictionary.ipc.ts
+++ b/src/main/ipc/dictionary.ipc.ts
@@ -1,9 +1,11 @@
-import { ipcMain } from 'electron'
 import fs from 'node:fs'
 import path from 'node:path'
+import { ipcMain } from 'electron'
 import type { RepositoryRegistry } from '../database/repositories/registry'
+import { runImport } from '../services/import.service'
 import { findSimilar } from '../services/similarity.service'
-import { csvCell, parseCsv, parseCsvTable } from '../utils/csv'
+import { csvCell } from '../utils/csv'
+import { readImportCsv } from '../utils/dictionaryCsv'
 
 interface DictionaryFilters {
   text?: string
@@ -27,23 +29,6 @@ interface DictionaryMutationPayload {
   uid?: string | null
 }
 
-interface DictionaryImportRow {
-  sourceLang: string
-  targetLang: string
-  sourceText: string
-  targetText: string
-  modName: string | null
-  uid: string | null
-}
-
-const HEADER_ALIASES = {
-  sourceLang: ['language1', 'src_lang'],
-  targetLang: ['language2', 'tgt_lang'],
-  sourceText: ['text_language1', 'src'],
-  targetText: ['text_language2', 'tgt'],
-  modName: ['mod_name', 'mod'],
-  uid: ['uid']
-} as const
 
 export function registerDictionaryHandlers(repos: RepositoryRegistry): void {
   ipcMain.handle('dictionary:list', (_event, payload: DictionaryListPayload) => {
@@ -66,12 +51,16 @@ export function registerDictionaryHandlers(repos: RepositoryRegistry): void {
     }
   })
 
-  ipcMain.handle('dictionary:getAll', (_event, { lang1, lang2 }: { lang1: string; lang2: string }) =>
-    repos.dictionary.list({ sourceLang: lang1, targetLang: lang2 })
+  ipcMain.handle(
+    'dictionary:getAll',
+    (_event, { lang1, lang2 }: { lang1: string; lang2: string }) =>
+      repos.dictionary.list({ sourceLang: lang1, targetLang: lang2 })
   )
 
-  ipcMain.handle('dictionary:search', (_event, { text, lang1, lang2 }: { text: string; lang1: string; lang2: string }) =>
-    repos.dictionary.list({ text, sourceLang: lang1, targetLang: lang2 })
+  ipcMain.handle(
+    'dictionary:search',
+    (_event, { text, lang1, lang2 }: { text: string; lang1: string; lang2: string }) =>
+      repos.dictionary.list({ text, sourceLang: lang1, targetLang: lang2 })
   )
 
   ipcMain.handle('dictionary:create', (_event, entry: DictionaryMutationPayload) => {
@@ -93,6 +82,13 @@ export function registerDictionaryHandlers(repos: RepositoryRegistry): void {
     persistMod(repos, entry.modName)
     repos.dictionary.upsert(toRepoPayload(entry))
     return { success: true }
+  })
+
+  ipcMain.handle('dictionary:bulkUpsert', (_event, entries: DictionaryMutationPayload[]) => {
+    if (entries.length === 0) return { count: 0 }
+    persistMod(repos, entries[0].modName)
+    repos.dictionary.bulkUpsert(entries.map(toRepoPayload))
+    return { count: entries.length }
   })
 
   ipcMain.handle('dictionary:delete', (_event, { id }: { id: number }) => {
@@ -133,7 +129,7 @@ export function registerDictionaryHandlers(repos: RepositoryRegistry): void {
     'dictionary:previewImport',
     (_event, { filePath, format }: { filePath: string; format: 'csv' | 'xlsx' }) => {
       if (format === 'xlsx') throw new Error('XLSX import not yet supported')
-      const preview = readImportFile(filePath)
+      const preview = readImportCsv(filePath)
       return {
         headers: preview.headers,
         totalRows: preview.rows.length,
@@ -144,25 +140,12 @@ export function registerDictionaryHandlers(repos: RepositoryRegistry): void {
 
   ipcMain.handle(
     'dictionary:import',
-    (_event, { filePath, format }: { filePath: string; format: 'csv' | 'xlsx' }) => {
+    async (event, { filePath, format }: { filePath: string; format: 'csv' | 'xlsx' }) => {
       if (format === 'xlsx') throw new Error('XLSX import not yet supported')
-      const preview = readImportFile(filePath)
-      let count = 0
-
-      for (const row of preview.rows) {
-        if (!row.sourceLang || !row.targetLang || !row.sourceText || !row.targetText) continue
-        persistMod(repos, row.modName)
-        repos.dictionary.upsert({
-          sourceLang: row.sourceLang,
-          targetLang: row.targetLang,
-          sourceText: row.sourceText,
-          targetText: row.targetText,
-          modName: row.modName,
-          uid: row.uid
-        })
-        count++
-      }
-
+      const count = await runImport({
+        filePath,
+        onProgress: (p) => event.sender.send('dictionary:import:progress', p)
+      })
       return { count }
     }
   )
@@ -216,39 +199,4 @@ function toRepoPayload(entry: DictionaryMutationPayload) {
 
 function persistMod(repos: RepositoryRegistry, modName?: string | null): void {
   if (modName?.trim()) repos.mod.upsert(modName.trim())
-}
-
-function readImportFile(filePath: string): {
-  headers: string[]
-  rows: DictionaryImportRow[]
-} {
-  const content = fs.readFileSync(filePath, 'utf-8')
-  const rawRows = parseCsv(content)
-  const { headers } = parseCsvTable(content)
-
-  return {
-    headers,
-    rows: rawRows.map(normalizeImportRow)
-  }
-}
-
-function normalizeImportRow(row: Record<string, string>): DictionaryImportRow {
-  return {
-    sourceLang: readColumn(row, HEADER_ALIASES.sourceLang),
-    targetLang: readColumn(row, HEADER_ALIASES.targetLang),
-    sourceText: readColumn(row, HEADER_ALIASES.sourceText),
-    targetText: readColumn(row, HEADER_ALIASES.targetText),
-    modName: readColumn(row, HEADER_ALIASES.modName) || null,
-    uid: readColumn(row, HEADER_ALIASES.uid) || null
-  }
-}
-
-function readColumn(
-  row: Record<string, string>,
-  aliases: readonly string[]
-): string {
-  for (const alias of aliases) {
-    if (alias in row) return row[alias]?.trim() ?? ''
-  }
-  return ''
 }

--- a/src/main/ipc/mod.ipc.ts
+++ b/src/main/ipc/mod.ipc.ts
@@ -4,11 +4,13 @@ import { app, ipcMain } from 'electron'
 import type { RepositoryRegistry } from '../database/repositories/registry'
 import { packMod, unpackMod } from '../services/lslib.service'
 import type { MetaInfo } from '../services/lsx-parser.service'
+import { deleteMod } from '../services/mod-delete.service'
 import {
   completeTranslationImport as completeImport,
   discardTranslationInput,
   exportTranslatedPackage,
   getMetaForMod,
+  getStoredModDir,
   prepareTranslationInput,
   upsertMetaForMod
 } from '../services/translation-import.service'
@@ -164,4 +166,42 @@ export function registerModHandlers(repos: RepositoryRegistry): void {
       return { storedPath: destPath }
     }
   )
+
+  ipcMain.handle('mod:delete', async (_e, { modName }: { modName: string }) =>
+    deleteMod({ modName, db: repos.db })
+  )
+
+  ipcMain.handle('mod:previewDelete', (_e, { modName }: { modName: string }) => {
+    const folderPath = getStoredModDir(modName)
+    const folderExists = fs.existsSync(folderPath)
+    const dictionaryRows = repos.dictionary.countAllByMod(modName)
+    return { dictionaryRows, folderPath, folderExists }
+  })
+
+  ipcMain.handle(
+    'mod:setPriority',
+    (_e, { modName, priority }: { modName: string; priority: number | null }) => {
+      repos.mod.setPriority(modName, priority)
+      repos.mod.compactPriority()
+      return { success: true }
+    }
+  )
+
+  ipcMain.handle('mod:reorderPriority', (_e, { orderedNames }: { orderedNames: string[] }) => {
+    repos.mod.reorderPriority(orderedNames)
+    return { success: true }
+  })
+
+  ipcMain.handle('mod:listWithPriority', (_e, params?: { lang1?: string; lang2?: string }) => {
+    const mods = repos.mod.getAll()
+    const { lang1, lang2 } = params ?? {}
+    return mods.map((m) => ({
+      name: m.name,
+      totalStrings: m.totalStrings ?? 0,
+      translatedStrings: lang1 && lang2 ? repos.dictionary.countByMod(m.name, lang1, lang2) : 0,
+      lastFilePath: m.lastFilePath ?? null,
+      updatedAt: m.updatedAt ?? null,
+      priority: m.priority ?? null
+    }))
+  })
 }

--- a/src/main/pipelines/base.pipeline.ts
+++ b/src/main/pipelines/base.pipeline.ts
@@ -93,7 +93,13 @@ export abstract class BasePipeline {
       // 4 - pre-load similarity index and match index once per run
       const corpusRows = this.dictRepo.getAllForSimilarity(ctx.sourceLang, ctx.targetLang)
       this.similarityIndex = new SimilarityIndex(corpusRows)
-      this.matchIndex = this.dictRepo.loadMatchIndex(ctx.sourceLang, ctx.targetLang)
+      const priorityMods = this.modRepo.getPriorityOrdered()
+      this.matchIndex = this.dictRepo.loadMatchIndex(
+        ctx.sourceLang,
+        ctx.targetLang,
+        null,
+        priorityMods
+      )
 
       // 5 - count total entries for progress tracking
       const allEntries = xmlFiles.flatMap((f) => parseLocalizationXml(f))
@@ -152,7 +158,13 @@ export abstract class BasePipeline {
   private async runXml(ctx: PipelineContext, outDir: string): Promise<string> {
     const corpusRows = this.dictRepo.getAllForSimilarity(ctx.sourceLang, ctx.targetLang)
     this.similarityIndex = new SimilarityIndex(corpusRows)
-    this.matchIndex = this.dictRepo.loadMatchIndex(ctx.sourceLang, ctx.targetLang)
+    const priorityMods = this.modRepo.getPriorityOrdered()
+    this.matchIndex = this.dictRepo.loadMatchIndex(
+      ctx.sourceLang,
+      ctx.targetLang,
+      null,
+      priorityMods
+    )
     this.modRepo.upsert(ctx.modName)
 
     const entries = parseLocalizationXml(ctx.filePath)

--- a/src/main/services/import.service.ts
+++ b/src/main/services/import.service.ts
@@ -1,0 +1,43 @@
+import path from 'node:path'
+import { Worker } from 'node:worker_threads'
+import { app } from 'electron'
+import type { ImportProgress, ImportWorkerInput } from '../workers/import.worker.runtime'
+
+export type { ImportProgress }
+
+export type ImportProgressUpdate = Exclude<ImportProgress, { phase: 'done' } | { phase: 'error' }>
+
+export interface RunImportParams {
+  filePath: string
+  onProgress?: (p: ImportProgressUpdate) => void
+}
+
+export function runImport(params: RunImportParams): Promise<number> {
+  const { onProgress, filePath } = params
+  const input: ImportWorkerInput = { filePath, dbPath: getDbPath() }
+
+  return new Promise<number>((resolve, reject) => {
+    const worker = new Worker(path.join(__dirname, 'import.worker.js'), { workerData: input })
+
+    worker.on('message', (msg: ImportProgress) => {
+      if (msg.phase === 'done') {
+        resolve(msg.count)
+        return
+      }
+      if (msg.phase === 'error') {
+        reject(new Error(msg.message))
+        return
+      }
+      onProgress?.(msg)
+    })
+
+    worker.on('error', reject)
+    worker.on('exit', (code) => {
+      if (code !== 0) reject(new Error(`import worker exited with code ${code}`))
+    })
+  })
+}
+
+function getDbPath(): string {
+  return path.join(app.getPath('userData'), 'icosa.db')
+}

--- a/src/main/services/mod-delete.service.ts
+++ b/src/main/services/mod-delete.service.ts
@@ -1,0 +1,43 @@
+// SQL transaction runs first; filesystem removal runs after and is best-effort (logged on failure, never rethrows).
+import fs from 'node:fs/promises'
+import type { drizzle } from 'drizzle-orm/better-sqlite3'
+import { ModRepository } from '../database/repositories/mod.repo'
+import { logError } from './log.service'
+import { getStoredModDir } from './translation-import.service'
+
+type AppDb = ReturnType<typeof drizzle>
+
+export interface DeleteModResult {
+  modName: string
+  dictionaryRows: number
+  hadMeta: boolean
+  folderRemoved: boolean
+  folderPath: string
+}
+
+export interface DeleteModInput {
+  modName: string
+  db: AppDb
+}
+
+export async function deleteMod(input: DeleteModInput): Promise<DeleteModResult> {
+  const { modName, db } = input
+  const modRepo = new ModRepository(db)
+  const folderPath = getStoredModDir(modName)
+
+  const { dictionaryRows, hadMeta } = modRepo.delete(modName)
+
+  let folderRemoved = false
+  try {
+    await fs.access(folderPath)
+    await fs.rm(folderPath, { recursive: true })
+    folderRemoved = true
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException).code
+    if (code !== 'ENOENT') {
+      logError('mod-delete: failed to remove folder', err, { modName, folderPath })
+    }
+  }
+
+  return { modName, dictionaryRows, hadMeta, folderRemoved, folderPath }
+}

--- a/src/main/services/translation-import.service.ts
+++ b/src/main/services/translation-import.service.ts
@@ -362,7 +362,7 @@ function readOriginalXmlName(
   return fileName.toLowerCase().endsWith('.xml') ? fileName : `${fallbackFolder}.xml`
 }
 
-function getStoredModDir(modName: string): string {
+export function getStoredModDir(modName: string): string {
   return path.join(app.getPath('userData'), 'icosa', 'mods', sanitizeStoredModName(modName))
 }
 

--- a/src/main/utils/dictionaryCsv.ts
+++ b/src/main/utils/dictionaryCsv.ts
@@ -1,0 +1,45 @@
+import fs from 'node:fs'
+import { parseCsv, parseCsvTable } from './csv'
+
+export interface DictionaryImportRow {
+  sourceLang: string
+  targetLang: string
+  sourceText: string
+  targetText: string
+  modName: string | null
+  uid: string | null
+}
+
+const HEADER_ALIASES = {
+  sourceLang: ['language1', 'src_lang'],
+  targetLang: ['language2', 'tgt_lang'],
+  sourceText: ['text_language1', 'src'],
+  targetText: ['text_language2', 'tgt'],
+  modName: ['mod_name', 'mod'],
+  uid: ['uid']
+} as const
+
+export function readImportCsv(filePath: string): { headers: string[]; rows: DictionaryImportRow[] } {
+  const content = fs.readFileSync(filePath, 'utf-8')
+  const rawRows = parseCsv(content)
+  const { headers } = parseCsvTable(content)
+  return { headers, rows: rawRows.map(normalizeRow) }
+}
+
+function normalizeRow(row: Record<string, string>): DictionaryImportRow {
+  return {
+    sourceLang: readColumn(row, HEADER_ALIASES.sourceLang),
+    targetLang: readColumn(row, HEADER_ALIASES.targetLang),
+    sourceText: readColumn(row, HEADER_ALIASES.sourceText),
+    targetText: readColumn(row, HEADER_ALIASES.targetText),
+    modName: readColumn(row, HEADER_ALIASES.modName) || null,
+    uid: readColumn(row, HEADER_ALIASES.uid) || null
+  }
+}
+
+function readColumn(row: Record<string, string>, aliases: readonly string[]): string {
+  for (const alias of aliases) {
+    if (alias in row) return row[alias]?.trim() ?? ''
+  }
+  return ''
+}

--- a/src/main/workers/import.worker.runtime.ts
+++ b/src/main/workers/import.worker.runtime.ts
@@ -1,0 +1,167 @@
+import Database from 'better-sqlite3'
+import { drizzle } from 'drizzle-orm/better-sqlite3'
+import { DictionaryRepository } from '../database/repositories/dictionary.repo'
+import { ModRepository } from '../database/repositories/mod.repo'
+import type { NewDictionaryEntry } from '../database/schema'
+import * as schema from '../database/schema'
+import { dictionaryTextKey, normalizeDictionaryText } from '../utils/dictionaryText'
+import { readImportCsv } from '../utils/dictionaryCsv'
+import { normalizeLangs } from '../utils/languages'
+
+export interface ImportWorkerInput {
+  filePath: string
+  dbPath: string
+}
+
+export type ImportProgress =
+  | { phase: 'reading' }
+  | { phase: 'parsing' }
+  | { phase: 'writing'; processed: number; total: number }
+  | { phase: 'done'; count: number }
+  | { phase: 'error'; message: string }
+
+interface PendingInsert extends NewDictionaryEntry {}
+interface PendingUpdate {
+  id: number
+  targetText: string
+  targetTextKey: string
+  uid: string | null
+}
+
+const WRITE_CHUNK = 500
+
+export async function runImportWorker(
+  input: ImportWorkerInput,
+  post: (msg: ImportProgress) => void
+): Promise<void> {
+  const sqlite = new Database(input.dbPath)
+  sqlite.pragma('journal_mode = WAL')
+  sqlite.pragma('foreign_keys = ON')
+  sqlite.pragma('synchronous = NORMAL')
+  sqlite.pragma('cache_size = -64000')
+  sqlite.pragma('temp_store = MEMORY')
+  sqlite.pragma('mmap_size = 268435456')
+
+  try {
+    const db = drizzle(sqlite, { schema })
+    const dictRepo = new DictionaryRepository(db)
+    const modRepo = new ModRepository(db)
+
+    post({ phase: 'reading' })
+    const { rows: csvRows } = readImportCsv(input.filePath)
+
+    post({ phase: 'parsing' })
+    const valid = csvRows.filter(
+      (r) => r.sourceLang && r.targetLang && r.sourceText && r.targetText
+    )
+
+    // Group rows by (sourceLang, targetLang, modName) to use loadKeyMap per group
+    const groups = new Map<
+      string,
+      { sourceLang: string; targetLang: string; modName: string | null; rows: typeof valid }
+    >()
+    for (const row of valid) {
+      const key = `${row.sourceLang}|${row.targetLang}|${row.modName ?? ''}`
+      if (!groups.has(key)) {
+        groups.set(key, { sourceLang: row.sourceLang, targetLang: row.targetLang, modName: row.modName, rows: [] })
+      }
+      groups.get(key)!.rows.push(row)
+    }
+
+    const total = valid.length
+    let processed = 0
+
+    for (const group of groups.values()) {
+      const { sourceLang, targetLang, modName, rows } = group
+      const trimmedModName = modName?.trim() || null
+
+      // Ensure mod FK row exists
+      if (trimmedModName) modRepo.upsert(trimmedModName)
+
+      const [, , swapped] = normalizeLangs(sourceLang, targetLang)
+      const targetColumn: 'language1' | 'language2' = swapped ? 'language1' : 'language2'
+
+      const toInsert: PendingInsert[] = []
+      const toUpdate: PendingUpdate[] = []
+
+      if (trimmedModName) {
+        const keyMap = dictRepo.loadKeyMap(sourceLang, targetLang, trimmedModName)
+
+        for (const row of rows) {
+          const sourceText = normalizeDictionaryText(row.sourceText)
+          const targetText = normalizeDictionaryText(row.targetText)
+          if (!sourceText || !targetText) continue
+          const sourceKey = dictionaryTextKey(sourceText)
+          const existing = keyMap.get(sourceKey)
+
+          if (existing) {
+            toUpdate.push({
+              id: existing.id,
+              targetText,
+              targetTextKey: dictionaryTextKey(targetText),
+              uid: row.uid?.trim() || existing.uid
+            })
+          } else {
+            toInsert.push(buildEntry(sourceLang, targetLang, swapped, sourceText, targetText, trimmedModName, row.uid))
+          }
+        }
+      } else {
+        // Null modName - build inserts only (no mod-scoped key map available)
+        for (const row of rows) {
+          const sourceText = normalizeDictionaryText(row.sourceText)
+          const targetText = normalizeDictionaryText(row.targetText)
+          if (!sourceText || !targetText) continue
+          toInsert.push(buildEntry(sourceLang, targetLang, swapped, sourceText, targetText, null, row.uid))
+        }
+      }
+
+      // Chunked inserts with progress + event-loop yield
+      for (let i = 0; i < toInsert.length; i += WRITE_CHUNK) {
+        const slice = toInsert.slice(i, i + WRITE_CHUNK)
+        dictRepo.bulkInsert(slice)
+        processed += slice.length
+        post({ phase: 'writing', processed, total })
+        await new Promise<void>((resolve) => setImmediate(resolve))
+      }
+
+      // Chunked updates with progress + event-loop yield
+      for (let i = 0; i < toUpdate.length; i += WRITE_CHUNK) {
+        const slice = toUpdate.slice(i, i + WRITE_CHUNK)
+        dictRepo.bulkUpdate(slice, targetColumn)
+        processed += slice.length
+        post({ phase: 'writing', processed, total })
+        await new Promise<void>((resolve) => setImmediate(resolve))
+      }
+    }
+
+    post({ phase: 'done', count: processed })
+  } finally {
+    sqlite.close()
+  }
+}
+
+// Mirrors DictionaryRepository.toValues — must stay in sync with normalizeLangs invariant.
+function buildEntry(
+  sourceLang: string,
+  targetLang: string,
+  swapped: boolean,
+  sourceText: string,
+  targetText: string,
+  modName: string | null,
+  uid: string | null | undefined
+): NewDictionaryEntry {
+  // swapped=true means sourceLang > targetLang alphabetically, so l1=targetLang, l2=sourceLang
+  const l1 = swapped ? targetLang : sourceLang
+  const l2 = swapped ? sourceLang : targetLang
+  const [text1, text2] = swapped ? [targetText, sourceText] : [sourceText, targetText]
+  return {
+    language1: l1,
+    language2: l2,
+    textLanguage1: text1,
+    textLanguage2: text2,
+    textLanguage1Key: dictionaryTextKey(text1),
+    textLanguage2Key: dictionaryTextKey(text2),
+    modName: modName || null,
+    uid: uid?.trim() || null
+  }
+}

--- a/src/main/workers/import.worker.ts
+++ b/src/main/workers/import.worker.ts
@@ -1,0 +1,19 @@
+import { parentPort, workerData } from 'node:worker_threads'
+import { type ImportWorkerInput, runImportWorker } from './import.worker.runtime'
+
+if (parentPort === null) {
+  throw new Error('import.worker must be spawned via worker_threads')
+}
+
+const port = parentPort
+
+;(async () => {
+  try {
+    await runImportWorker(workerData as ImportWorkerInput, (msg) => port.postMessage(msg))
+    process.exit(0)
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e)
+    port.postMessage({ phase: 'error', message })
+    process.exit(1)
+  }
+})()

--- a/src/main/workers/xml-load.worker.runtime.ts
+++ b/src/main/workers/xml-load.worker.runtime.ts
@@ -5,6 +5,7 @@ import {
   DictionaryRepository,
   getDictionaryTargetText
 } from '../database/repositories/dictionary.repo'
+import { ModRepository } from '../database/repositories/mod.repo'
 import * as schema from '../database/schema'
 import { unpackMod } from '../services/lslib.service'
 import { decodeEntities } from '../services/xml-entities.service'
@@ -112,7 +113,13 @@ export async function runXmlLoadWorker(
     const result: XmlEntry[] = new Array(total)
 
     post({ phase: 'loading-cache' })
-    const index = new DictionaryRepository(db).loadMatchIndex(sourceLang, targetLang)
+    const priorityMods = new ModRepository(db).getPriorityOrdered()
+    const index = new DictionaryRepository(db).loadMatchIndex(
+      sourceLang,
+      targetLang,
+      null,
+      priorityMods
+    )
 
     for (let i = 0; i < total; i += MATCH_CHUNK) {
       const end = Math.min(i + MATCH_CHUNK, total)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -105,6 +105,24 @@ export interface ModInfo {
   updatedAt: string | null
 }
 
+export interface ModWithPriority extends ModInfo {
+  priority: number | null
+}
+
+export interface DeleteModResult {
+  modName: string
+  dictionaryRows: number
+  hadMeta: boolean
+  folderRemoved: boolean
+  folderPath: string
+}
+
+export interface DeleteModPreview {
+  dictionaryRows: number
+  folderPath: string
+  folderExists: boolean
+}
+
 export interface ModMeta {
   metaFilePath: string
   name: string
@@ -240,6 +258,11 @@ export interface TranslationApi {
   onBatchError(cb: (data: TranslationBatchErrorEvent) => void): UnsubscribeFn
 }
 
+export type DictionaryImportProgressUpdate =
+  | { phase: 'reading' }
+  | { phase: 'parsing' }
+  | { phase: 'writing'; processed: number; total: number }
+
 export interface DictionaryApi {
   list(params: DictionaryListParams): Promise<DictionaryListResult>
   getAll(params: { lang1: string; lang2: string }): Promise<DictionaryEntry[]>
@@ -247,12 +270,14 @@ export interface DictionaryApi {
   create(entry: UpsertDictionaryPayload): Promise<{ success: boolean }>
   update(params: { id: number; entry: UpsertDictionaryPayload }): Promise<{ success: boolean }>
   upsert(entry: UpsertDictionaryPayload): Promise<{ success: boolean }>
+  bulkUpsert(entries: UpsertDictionaryPayload[]): Promise<{ count: number }>
   delete(params: { id: number }): Promise<{ success: boolean }>
   previewImport(params: {
     filePath: string
     format: 'csv' | 'xlsx'
   }): Promise<DictionaryImportPreview>
   import(params: { filePath: string; format: 'csv' | 'xlsx' }): Promise<{ count: number }>
+  onImportProgress(cb: (data: DictionaryImportProgressUpdate) => void): () => void
   export(params: {
     filters: DictionaryFilters
     format: 'csv' | 'xlsx'
@@ -310,6 +335,11 @@ export interface ModApi {
     meta: ModMeta
     bg3LanguageFolder: string
   }): Promise<{ outputPath: string }>
+  delete(params: { modName: string }): Promise<DeleteModResult>
+  previewDelete(params: { modName: string }): Promise<DeleteModPreview>
+  setPriority(params: { modName: string; priority: number | null }): Promise<{ success: boolean }>
+  reorderPriority(params: { orderedNames: string[] }): Promise<{ success: boolean }>
+  listWithPriority(params?: { lang1?: string; lang2?: string }): Promise<ModWithPriority[]>
 }
 
 export interface MergeResult {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -117,6 +117,17 @@ const api: AppApi = {
       uid?: string | null
     }): Promise<{ success: boolean }> => ipcRenderer.invoke('dictionary:upsert', entry),
 
+    bulkUpsert: (
+      entries: {
+        language1: string
+        language2: string
+        textLanguage1: string
+        textLanguage2: string
+        modName?: string | null
+        uid?: string | null
+      }[]
+    ): Promise<{ count: number }> => ipcRenderer.invoke('dictionary:bulkUpsert', entries),
+
     delete: (params: { id: number }): Promise<{ success: boolean }> =>
       ipcRenderer.invoke('dictionary:delete', params),
 
@@ -125,6 +136,10 @@ const api: AppApi = {
 
     import: (params: { filePath: string; format: 'csv' | 'xlsx' }): Promise<{ count: number }> =>
       ipcRenderer.invoke('dictionary:import', params),
+
+    onImportProgress: (
+      cb: (data: import('./api-types').DictionaryImportProgressUpdate) => void
+    ): UnsubscribeFn => on('dictionary:import:progress', cb),
 
     export: (params: {
       filters: {
@@ -245,7 +260,21 @@ const api: AppApi = {
         version64: string
       }
       bg3LanguageFolder: string
-    }): Promise<{ outputPath: string }> => ipcRenderer.invoke('mod:exportTranslatedPackage', params)
+    }): Promise<{ outputPath: string }> =>
+      ipcRenderer.invoke('mod:exportTranslatedPackage', params),
+
+    delete: (params: { modName: string }) => ipcRenderer.invoke('mod:delete', params),
+
+    previewDelete: (params: { modName: string }) => ipcRenderer.invoke('mod:previewDelete', params),
+
+    setPriority: (params: { modName: string; priority: number | null }) =>
+      ipcRenderer.invoke('mod:setPriority', params),
+
+    reorderPriority: (params: { orderedNames: string[] }) =>
+      ipcRenderer.invoke('mod:reorderPriority', params),
+
+    listWithPriority: (params?: { lang1?: string; lang2?: string }) =>
+      ipcRenderer.invoke('mod:listWithPriority', params)
   },
 
   xml: {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -5,6 +5,7 @@ import { TranslationSessionProvider } from './context/TranslationSession'
 import { DictionaryPage } from './pages/DictionaryPage'
 import { EntryEditPage } from './pages/EntryEditPage'
 import { ExtractPage } from './pages/ExtractPage'
+import { ManageModsPage } from './pages/ManageModsPage'
 import { MergeToolPage } from './pages/MergeToolPage'
 import { PackagePage } from './pages/PackagePage'
 import { SettingsPage } from './pages/SettingsPage'
@@ -28,6 +29,7 @@ function App(): React.JSX.Element {
             <Route path="/translate/entry/:uid" element={<EntryEditPage />} />
           </Route>
           <Route path="/dictionary" element={<DictionaryPage />} />
+          <Route path="/mods" element={<ManageModsPage />} />
           <Route path="/extract" element={<ExtractPage />} />
           <Route path="/package" element={<PackagePage />} />
           <Route path="/merge" element={<MergeToolPage />} />

--- a/src/renderer/src/components/dictionary/DictionaryImportModal.tsx
+++ b/src/renderer/src/components/dictionary/DictionaryImportModal.tsx
@@ -1,5 +1,5 @@
 import { FileSpreadsheet, Upload } from 'lucide-react'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import { ModalShell } from '@/components/shared/ModalShell'
 import { getLocalizedErrorMessage } from '@/i18n/errors'
@@ -22,6 +22,8 @@ export function DictionaryImportModal({
   const [preview, setPreview] = useState<DictionaryImportPreview | null>(null)
   const [loading, setLoading] = useState(false)
   const [importing, setImporting] = useState(false)
+  const [importProgress, setImportProgress] = useState<{ processed: number; total: number } | null>(null)
+  const unsubRef = useRef<(() => void) | null>(null)
 
   useEffect(() => {
     if (!open) {
@@ -29,6 +31,9 @@ export function DictionaryImportModal({
       setPreview(null)
       setLoading(false)
       setImporting(false)
+      setImportProgress(null)
+      unsubRef.current?.()
+      unsubRef.current = null
     }
   }, [open])
 
@@ -56,6 +61,14 @@ export function DictionaryImportModal({
   const handleImport = async () => {
     if (!filePath) return
     setImporting(true)
+    setImportProgress(null)
+
+    unsubRef.current = window.api.dictionary.onImportProgress((p) => {
+      if (p.phase === 'writing') {
+        setImportProgress({ processed: p.processed, total: p.total })
+      }
+    })
+
     try {
       const result = await window.api.dictionary.import({ filePath, format: 'csv' })
       toast.success(t('dictionary.imported', { ns: 'toasts', count: result.count }))
@@ -64,7 +77,10 @@ export function DictionaryImportModal({
     } catch (error) {
       toast.error(getLocalizedErrorMessage(error, t))
     } finally {
+      unsubRef.current?.()
+      unsubRef.current = null
       setImporting(false)
+      setImportProgress(null)
     }
   }
 
@@ -92,17 +108,41 @@ export function DictionaryImportModal({
             className="inline-flex h-8 cursor-pointer items-center gap-1.5 rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400 disabled:cursor-not-allowed disabled:opacity-40"
           >
             <Upload size={13} />
-            {importing
-              ? t('importModal.importing', { ns: 'dictionary' })
-              : t('importModal.importCount', {
-                  ns: 'dictionary',
-                  count: preview?.totalRows ?? 0
-                })}
+            {importing && importProgress
+              ? `${importProgress.processed.toLocaleString()} / ${importProgress.total.toLocaleString()}`
+              : importing
+                ? t('importModal.importing', { ns: 'dictionary' })
+                : t('importModal.importCount', {
+                    ns: 'dictionary',
+                    count: preview?.totalRows ?? 0
+                  })}
           </button>
         </>
       }
     >
       <div className="flex flex-col gap-4">
+        {importing && (
+          <div className="space-y-1.5">
+            <div className="flex justify-between text-xs text-neutral-500">
+              <span>{importProgress ? t('importModal.importing', { ns: 'dictionary' }) : '...'}</span>
+              {importProgress && (
+                <span className="font-mono">
+                  {importProgress.processed.toLocaleString()} / {importProgress.total.toLocaleString()}
+                </span>
+              )}
+            </div>
+            <div className="h-1.5 w-full overflow-hidden rounded-full bg-[#1f2329]">
+              <div
+                className="h-full rounded-full bg-amber-500 transition-all duration-200"
+                style={{
+                  width: importProgress
+                    ? `${Math.round((importProgress.processed / importProgress.total) * 100)}%`
+                    : '0%'
+                }}
+              />
+            </div>
+          </div>
+        )}
         <button
           type="button"
           onClick={handleSelectFile}

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Languages, Merge, Package, PackageOpen, Settings } from 'lucide-react'
+import { BookOpen, Boxes, Languages, Merge, Package, PackageOpen, Settings } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { cn } from '@/lib/utils'
@@ -6,12 +6,15 @@ import { cn } from '@/lib/utils'
 const NAV_ITEMS = [
   { to: '/translate', icon: Languages, labelKey: 'translate', kbd: 'Ctrl 1' },
   { to: '/dictionary', icon: BookOpen, labelKey: 'dictionary', kbd: 'Ctrl 2' },
-  { to: '/merge', icon: Merge, labelKey: 'merge', kbd: 'Ctrl 3' },
-  { to: '/extract', icon: PackageOpen, labelKey: 'extract', kbd: 'Ctrl 4' },
-  { to: '/package', icon: Package, labelKey: 'package', kbd: 'Ctrl 5' }
+  { to: '/mods', icon: Boxes, labelKey: 'mods', kbd: 'Ctrl 3' },
+  { to: '/merge', icon: Merge, labelKey: 'merge', kbd: 'Ctrl 4' },
+  { to: '/extract', icon: PackageOpen, labelKey: 'extract', kbd: 'Ctrl 5' },
+  { to: '/package', icon: Package, labelKey: 'package', kbd: 'Ctrl 6' }
 ] as const
 
-const FOOTER_ITEMS = [{ to: '/settings', icon: Settings, labelKey: 'settings', kbd: 'Ctrl 6' }] as const
+const FOOTER_ITEMS = [
+  { to: '/settings', icon: Settings, labelKey: 'settings', kbd: 'Ctrl 7' }
+] as const
 
 function NavItem({
   to,
@@ -66,13 +69,25 @@ export function Sidebar(): React.JSX.Element {
     >
       <nav className="flex flex-1 flex-col gap-0.5 px-2 py-3">
         {NAV_ITEMS.map((item) => (
-          <NavItem key={item.to} to={item.to} icon={item.icon} kbd={item.kbd} label={t(item.labelKey)} />
+          <NavItem
+            key={item.to}
+            to={item.to}
+            icon={item.icon}
+            kbd={item.kbd}
+            label={t(item.labelKey)}
+          />
         ))}
       </nav>
 
       <div className="border-t border-[#1f2329] px-2 py-3">
         {FOOTER_ITEMS.map((item) => (
-          <NavItem key={item.to} to={item.to} icon={item.icon} kbd={item.kbd} label={t(item.labelKey)} />
+          <NavItem
+            key={item.to}
+            to={item.to}
+            icon={item.icon}
+            kbd={item.kbd}
+            label={t(item.labelKey)}
+          />
         ))}
       </div>
     </aside>

--- a/src/renderer/src/components/mods/DeleteModConfirm.tsx
+++ b/src/renderer/src/components/mods/DeleteModConfirm.tsx
@@ -1,0 +1,110 @@
+import { AlertTriangle } from 'lucide-react'
+import { useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { DeleteModPreview, DeleteModResult } from '@/types'
+
+interface DeleteModConfirmProps {
+  open: boolean
+  modName: string | null
+  onClose: () => void
+  onConfirmed: (result: DeleteModResult) => void
+}
+
+export function DeleteModConfirm({
+  open,
+  modName,
+  onClose,
+  onConfirmed
+}: DeleteModConfirmProps): React.JSX.Element | null {
+  const { t } = useAppTranslation('mods')
+
+  const [preview, setPreview] = useState<DeleteModPreview | null>(null)
+  const [loadingPreview, setLoadingPreview] = useState(false)
+  const [submitting, setSubmitting] = useState(false)
+
+  useEffect(() => {
+    if (!open || !modName) return
+
+    setLoadingPreview(true)
+    setPreview(null)
+
+    window.api.mod
+      .previewDelete({ modName })
+      .then((data) => {
+        setPreview(data)
+      })
+      .catch(() => {
+        toast.error(t('toast.deleteFailed'))
+        onClose()
+      })
+      .finally(() => {
+        setLoadingPreview(false)
+      })
+  }, [open, modName, t, onClose])
+
+  async function handleConfirm() {
+    if (!modName) return
+
+    setSubmitting(true)
+    try {
+      const result = await window.api.mod.delete({ modName })
+      toast.success(t('toast.deleted', { name: modName }))
+      onConfirmed(result)
+      onClose()
+    } catch {
+      toast.error(t('toast.deleteFailed'))
+    } finally {
+      setSubmitting(false)
+    }
+  }
+
+  const disabled = loadingPreview || submitting
+
+  return (
+    <ModalShell
+      open={open}
+      title={t('delete.title')}
+      sizeClassName="max-w-md"
+      icon={<AlertTriangle size={16} />}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            {t('delete.cancel')}
+          </button>
+          <button
+            type="button"
+            onClick={handleConfirm}
+            disabled={disabled}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-red-500/40 bg-red-500/10 px-3 text-xs font-semibold text-red-200 transition-colors hover:bg-red-500/20 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            {t('delete.confirm')}
+          </button>
+        </>
+      }
+    >
+      <div className="space-y-3">
+        <p className="text-sm text-neutral-300">{t('delete.subject', { name: modName })}</p>
+        {loadingPreview ? (
+          <div className="h-16 animate-pulse rounded bg-[#1f2329]" />
+        ) : preview ? (
+          <ul className="list-inside list-disc space-y-1 rounded border border-[#1f2329] bg-[#0f1114] p-3 text-sm text-neutral-400">
+            <li>{t('delete.impactRows', { count: preview.dictionaryRows })}</li>
+            <li>
+              {preview.folderExists
+                ? t('delete.impactFolder', { path: preview.folderPath })
+                : t('delete.impactFolderMissing')}
+            </li>
+          </ul>
+        ) : null}
+        <p className="text-xs font-medium text-red-400">{t('delete.irreversible')}</p>
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/renderer/src/components/mods/FallbackModRow.tsx
+++ b/src/renderer/src/components/mods/FallbackModRow.tsx
@@ -1,0 +1,55 @@
+import { ArrowUpToLine, Trash2 } from 'lucide-react'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { ModWithPriority } from '@/types'
+
+interface FallbackModRowProps {
+  mod: ModWithPriority
+  onPromote: () => void
+  onDelete: () => void
+}
+
+export function FallbackModRow({
+  mod,
+  onPromote,
+  onDelete
+}: FallbackModRowProps): React.JSX.Element {
+  const { t } = useAppTranslation('mods')
+  const initial = mod.name.charAt(0).toUpperCase()
+
+  return (
+    <div className="grid grid-cols-[auto_1fr_auto_auto] gap-3 items-center px-4 py-3 hover:bg-[#131518] transition-colors border-b border-[#1f2329] last:border-b-0">
+      {/* left - avatar letter */}
+      <span className="w-8 h-8 rounded bg-[#1f2329] flex items-center justify-center text-xs font-medium text-neutral-400 shrink-0">
+        {initial}
+      </span>
+
+      {/* center - name and string count */}
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-neutral-200 truncate">{mod.name}</p>
+        {mod.totalStrings != null && (
+          <p className="text-xs text-neutral-500">{mod.totalStrings.toLocaleString()} entries</p>
+        )}
+      </div>
+
+      {/* promote button */}
+      <button
+        type="button"
+        onClick={onPromote}
+        title={t('actions.promote')}
+        className="text-neutral-400 hover:text-amber-400 hover:bg-amber-500/10 p-1.5 rounded transition-colors cursor-pointer"
+      >
+        <ArrowUpToLine size={15} />
+      </button>
+
+      {/* delete button */}
+      <button
+        type="button"
+        onClick={onDelete}
+        title={t('actions.delete')}
+        className="text-neutral-500 hover:text-red-400 hover:bg-red-500/10 p-1.5 rounded transition-colors cursor-pointer"
+      >
+        <Trash2 size={15} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/mods/ModListEmpty.tsx
+++ b/src/renderer/src/components/mods/ModListEmpty.tsx
@@ -1,0 +1,9 @@
+interface ModListEmptyProps {
+  message: string
+}
+
+export function ModListEmpty({ message }: ModListEmptyProps): React.JSX.Element {
+  return (
+    <div className="flex items-center justify-center py-10 text-sm text-neutral-500">{message}</div>
+  )
+}

--- a/src/renderer/src/components/mods/PriorityModRow.tsx
+++ b/src/renderer/src/components/mods/PriorityModRow.tsx
@@ -1,0 +1,166 @@
+import { useSortable } from '@dnd-kit/sortable'
+import { CSS } from '@dnd-kit/utilities'
+import { ArrowDownToLine, ChevronDown, ChevronUp, GripVertical, Trash2 } from 'lucide-react'
+import { useEffect, useRef, useState } from 'react'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { ModWithPriority } from '@/types'
+
+interface PriorityModRowProps {
+  mod: ModWithPriority
+  index: number
+  total: number
+  onMoveUp: () => void
+  onMoveDown: () => void
+  onSetPosition: (position: number) => void
+  onDemote: () => void
+  onDelete: () => void
+  isSearchActive?: boolean
+}
+
+export function PriorityModRow({
+  mod,
+  index,
+  total,
+  onMoveUp,
+  onMoveDown,
+  onSetPosition,
+  onDemote,
+  onDelete,
+  isSearchActive
+}: PriorityModRowProps): React.JSX.Element {
+  const { t } = useAppTranslation('mods')
+  const [draft, setDraft] = useState<string>(String(index + 1))
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: mod.name
+  })
+
+  const style: React.CSSProperties = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.5 : 1,
+    zIndex: isDragging ? 10 : undefined
+  }
+
+  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setDraft(e.target.value)
+  }
+
+  const commitPosition = () => {
+    const parsed = Number.parseInt(draft, 10)
+    if (Number.isNaN(parsed)) {
+      setDraft(String(index + 1))
+      return
+    }
+    const clamped = Math.max(1, Math.min(total, parsed))
+    setDraft(String(clamped))
+    onSetPosition(clamped)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      commitPosition()
+      inputRef.current?.blur()
+    } else if (e.key === 'Escape') {
+      setDraft(String(index + 1))
+      inputRef.current?.blur()
+    }
+  }
+
+  // Keep draft in sync when index changes externally (e.g. after a move)
+  const committingRef = useRef(false)
+  useEffect(() => {
+    if (!committingRef.current) {
+      setDraft(String(index + 1))
+    }
+    committingRef.current = false
+  }, [index])
+
+  const isFirst = index === 0
+  const isLast = index === total - 1
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={style}
+      {...attributes}
+      className={`grid grid-cols-[auto_1fr_auto_auto] gap-3 items-center px-4 py-3 hover:bg-[#131518] transition-colors border-b border-[#1f2329] last:border-b-0${isDragging ? ' shadow-lg ring-1 ring-amber-500/30' : ''}`}
+    >
+      {/* left controls */}
+      <div className="flex items-center gap-1">
+        <span
+          className={`inline-flex shrink-0${isSearchActive ? ' cursor-not-allowed opacity-40' : ' cursor-grab text-neutral-600'}`}
+          {...(!isSearchActive ? listeners : undefined)}
+        >
+          <GripVertical size={16} />
+        </span>
+        <button
+          type="button"
+          onClick={onMoveUp}
+          disabled={isFirst}
+          title={t('actions.moveUp')}
+          className={
+            isFirst
+              ? 'p-1 rounded text-neutral-700 cursor-not-allowed'
+              : 'p-1 rounded text-neutral-400 hover:text-neutral-200 hover:bg-[#1f2329] transition-colors cursor-pointer'
+          }
+        >
+          <ChevronUp size={14} />
+        </button>
+        <button
+          type="button"
+          onClick={onMoveDown}
+          disabled={isLast}
+          title={t('actions.moveDown')}
+          className={
+            isLast
+              ? 'p-1 rounded text-neutral-700 cursor-not-allowed'
+              : 'p-1 rounded text-neutral-400 hover:text-neutral-200 hover:bg-[#1f2329] transition-colors cursor-pointer'
+          }
+        >
+          <ChevronDown size={14} />
+        </button>
+        <input
+          ref={inputRef}
+          type="text"
+          inputMode="numeric"
+          value={draft}
+          onChange={handleInputChange}
+          onBlur={commitPosition}
+          onKeyDown={handleKeyDown}
+          title={t('actions.positionLabel')}
+          className="w-10 text-center text-xs bg-[#0f1114] border border-[#1f2329] rounded px-1 py-0.5 text-neutral-300 focus:outline-none focus:border-amber-500/50"
+        />
+      </div>
+
+      {/* center - name and string count */}
+      <div className="min-w-0">
+        <p className="text-sm font-medium text-neutral-200 truncate">{mod.name}</p>
+        {mod.totalStrings != null && (
+          <p className="text-xs text-neutral-500">{mod.totalStrings.toLocaleString()} entries</p>
+        )}
+      </div>
+
+      {/* demote button */}
+      <button
+        type="button"
+        onClick={onDemote}
+        title={t('actions.demote')}
+        className="text-neutral-400 hover:text-amber-400 hover:bg-amber-500/10 p-1.5 rounded transition-colors cursor-pointer"
+      >
+        <ArrowDownToLine size={15} />
+      </button>
+
+      {/* delete button */}
+      <button
+        type="button"
+        onClick={onDelete}
+        title={t('actions.delete')}
+        className="text-neutral-500 hover:text-red-400 hover:bg-red-500/10 p-1.5 rounded transition-colors cursor-pointer"
+      >
+        <Trash2 size={15} />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/features/merge/components/MergeBottomBar.tsx
+++ b/src/renderer/src/features/merge/components/MergeBottomBar.tsx
@@ -52,16 +52,16 @@ export function MergeBottomBar({
       <div className="mx-auto flex max-w-220 flex-col gap-2 rounded-xl border border-neutral-700 bg-[#131518] px-4 py-3 shadow-xl">
         {showProgress && (
           <div className="space-y-1.5">
-            <div className="h-2 rounded-full bg-[#1d2127]">
-              {progressPct !== undefined ? (
+            {progressPct !== undefined ? (
+              <div className="h-2 rounded-full bg-[#1d2127]">
                 <div
                   className="h-full rounded-full bg-amber-400/80 transition-[width] duration-200"
                   style={{ width: `${progressPct}%` }}
                 />
-              ) : (
-                <div className="h-full w-2/3 animate-pulse rounded-full bg-amber-400/80" />
-              )}
-            </div>
+              </div>
+            ) : (
+              <div className="h-2 animate-pulse rounded-full bg-amber-400/30" />
+            )}
             <p className="text-xs text-neutral-400">{progressLabel()}</p>
           </div>
         )}

--- a/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateIdleScreen.tsx
@@ -188,25 +188,16 @@ export function TranslateIdleScreen({ session }: TranslateIdleScreenProps): Reac
                 <Loader2 size={18} className="animate-spin text-amber-400" />
                 <div className="text-sm font-semibold text-neutral-200">{loadingLabel}</div>
               </div>
-              <div className="space-y-2">
+              {loadingProgress?.phase === 'matching' && loadingProgress.total > 0 && (
                 <div className="h-2 rounded-full bg-[#1d2127]">
-                  {loadingProgress?.phase === 'matching' && loadingProgress.total > 0 ? (
-                    <div
-                      className="h-full rounded-full bg-amber-400/80 transition-[width] duration-200"
-                      style={{
-                        width: `${(loadingProgress.processed / loadingProgress.total) * 100}%`
-                      }}
-                    />
-                  ) : (
-                    <div className="h-full w-2/3 animate-pulse rounded-full bg-amber-400/80" />
-                  )}
+                  <div
+                    className="h-full rounded-full bg-amber-400/80 transition-[width] duration-200"
+                    style={{
+                      width: `${(loadingProgress.processed / loadingProgress.total) * 100}%`
+                    }}
+                  />
                 </div>
-                <div className="grid gap-2">
-                  <div className="h-8 animate-pulse rounded-lg bg-[#1a1d22]" />
-                  <div className="h-8 animate-pulse rounded-lg bg-[#1a1d22]" />
-                  <div className="h-8 animate-pulse rounded-lg bg-[#1a1d22]" />
-                </div>
-              </div>
+              )}
             </div>
           </div>
         )}

--- a/src/renderer/src/features/translate/hooks/useDictionarySave.ts
+++ b/src/renderer/src/features/translate/hooks/useDictionarySave.ts
@@ -40,16 +40,16 @@ export function useDictionarySave(session: TranslationSession) {
 
     setIsSaving(true)
     try {
-      for (const entry of toSave) {
-        await window.api.dictionary.upsert({
+      await window.api.dictionary.bulkUpsert(
+        toSave.map((entry) => ({
           language1: sourceLang,
           language2: targetLang,
           textLanguage1: encodeEntities(entry.source),
           textLanguage2: encodeEntities(entry.target),
           modName: modName || null,
           uid: entry.uid || null
-        })
-      }
+        }))
+      )
       toast.success(t('translate.savedCount', { ns: 'toasts', count: toSave.length }))
     } catch (err) {
       toast.error(getLocalizedErrorMessage(err, t))

--- a/src/renderer/src/hooks/useKeyboardShortcuts.ts
+++ b/src/renderer/src/hooks/useKeyboardShortcuts.ts
@@ -4,10 +4,11 @@ import { useNavigate } from 'react-router-dom'
 const SHORTCUTS: Record<string, string> = {
   '1': '/translate',
   '2': '/dictionary',
-  '3': '/merge',
-  '4': '/extract',
-  '5': '/package',
-  '6': '/settings'
+  '3': '/mods',
+  '4': '/merge',
+  '5': '/extract',
+  '6': '/package',
+  '7': '/settings'
 }
 
 export function useKeyboardShortcuts(): void {

--- a/src/renderer/src/hooks/useManageMods.ts
+++ b/src/renderer/src/hooks/useManageMods.ts
@@ -1,0 +1,182 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { DeleteModPreview, DeleteModResult, ModWithPriority } from '@/types'
+
+export function useManageMods() {
+  const { t } = useAppTranslation('mods')
+  const [mods, setMods] = useState<ModWithPriority[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const refetch = useCallback(async () => {
+    try {
+      const result = await window.api.mod.listWithPriority()
+      setMods(result)
+      setError(null)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setError(message)
+    }
+  }, [])
+
+  useEffect(() => {
+    setLoading(true)
+    refetch().finally(() => setLoading(false))
+  }, [refetch])
+
+  const promote = useCallback(
+    async (name: string) => {
+      const prioritized = mods.filter((mod) => mod.priority !== null)
+      const maxPriority = prioritized.reduce((max, mod) => Math.max(max, mod.priority ?? 0), 0)
+      const nextSlot = maxPriority + 1
+
+      try {
+        await window.api.mod.setPriority({ modName: name, priority: nextSlot })
+        await refetch()
+        toast.success(t('toast.promoted', { name }))
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+      }
+    },
+    [mods, refetch, t]
+  )
+
+  const demote = useCallback(
+    async (name: string) => {
+      try {
+        await window.api.mod.setPriority({ modName: name, priority: null })
+        await refetch()
+        toast.success(t('toast.demoted', { name }))
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+      }
+    },
+    [refetch, t]
+  )
+
+  const moveUp = useCallback(
+    async (name: string) => {
+      const prioritized = mods
+        .filter((mod) => mod.priority !== null)
+        .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+
+      const index = prioritized.findIndex((mod) => mod.name === name)
+      if (index <= 0) return
+
+      const swapped = [...prioritized]
+      ;[swapped[index - 1], swapped[index]] = [swapped[index], swapped[index - 1]]
+      const orderedNames = swapped.map((mod) => mod.name)
+
+      try {
+        await window.api.mod.reorderPriority({ orderedNames })
+        await refetch()
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+      }
+    },
+    [mods, refetch, t]
+  )
+
+  const moveDown = useCallback(
+    async (name: string) => {
+      const prioritized = mods
+        .filter((mod) => mod.priority !== null)
+        .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+
+      const index = prioritized.findIndex((mod) => mod.name === name)
+      if (index < 0 || index >= prioritized.length - 1) return
+
+      const swapped = [...prioritized]
+      ;[swapped[index], swapped[index + 1]] = [swapped[index + 1], swapped[index]]
+      const orderedNames = swapped.map((mod) => mod.name)
+
+      try {
+        await window.api.mod.reorderPriority({ orderedNames })
+        await refetch()
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+      }
+    },
+    [mods, refetch, t]
+  )
+
+  const setPosition = useCallback(
+    async (name: string, position: number) => {
+      const prioritized = mods
+        .filter((mod) => mod.priority !== null)
+        .sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0))
+
+      const count = prioritized.length
+      if (count === 0) return
+
+      const clamped = Math.max(1, Math.min(count, position))
+      const withoutTarget = prioritized.filter((mod) => mod.name !== name)
+      withoutTarget.splice(clamped - 1, 0, { name } as ModWithPriority)
+      const orderedNames = withoutTarget.map((mod) => mod.name)
+
+      try {
+        await window.api.mod.reorderPriority({ orderedNames })
+        await refetch()
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+      }
+    },
+    [mods, refetch, t]
+  )
+
+  const reorder = useCallback(
+    async (orderedNames: string[]) => {
+      try {
+        await window.api.mod.reorderPriority({ orderedNames })
+        await refetch()
+        toast.success(t('toast.reordered'))
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+      }
+    },
+    [refetch, t]
+  )
+
+  const deleteMod = useCallback(
+    async (name: string): Promise<DeleteModResult | null> => {
+      try {
+        const result = await window.api.mod.delete({ modName: name })
+        await refetch()
+        toast.success(t('toast.deleted', { name }))
+        return result
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+        return null
+      }
+    },
+    [refetch, t]
+  )
+
+  const previewDelete = useCallback(
+    async (name: string): Promise<DeleteModPreview | null> => {
+      try {
+        return await window.api.mod.previewDelete({ modName: name })
+      } catch {
+        toast.error(t('toast.deleteFailed'))
+        return null
+      }
+    },
+    [t]
+  )
+
+  return {
+    mods,
+    loading,
+    error,
+    refetch,
+    promote,
+    demote,
+    moveUp,
+    moveDown,
+    setPosition,
+    reorder,
+    deleteMod,
+    previewDelete
+  }
+}

--- a/src/renderer/src/i18n/resources.ts
+++ b/src/renderer/src/i18n/resources.ts
@@ -3,6 +3,7 @@ import dictionaryEn from '@/locales/en/dictionary.json'
 import errorsEn from '@/locales/en/errors.json'
 import extractEn from '@/locales/en/extract.json'
 import mergeEn from '@/locales/en/merge.json'
+import modsEn from '@/locales/en/mods.json'
 import packageEn from '@/locales/en/package.json'
 import settingsEn from '@/locales/en/settings.json'
 import sidebarEn from '@/locales/en/sidebar.json'
@@ -13,6 +14,7 @@ import dictionaryPtBr from '@/locales/pt-BR/dictionary.json'
 import errorsPtBr from '@/locales/pt-BR/errors.json'
 import extractPtBr from '@/locales/pt-BR/extract.json'
 import mergePtBr from '@/locales/pt-BR/merge.json'
+import modsPtBr from '@/locales/pt-BR/mods.json'
 import packagePtBr from '@/locales/pt-BR/package.json'
 import settingsPtBr from '@/locales/pt-BR/settings.json'
 import sidebarPtBr from '@/locales/pt-BR/sidebar.json'
@@ -26,6 +28,7 @@ export const translationNamespaces = [
   'translate',
   'dictionary',
   'merge',
+  'mods',
   'package',
   'extract',
   'errors',
@@ -40,6 +43,7 @@ export const resources = {
     translate: translateEn,
     dictionary: dictionaryEn,
     merge: mergeEn,
+    mods: modsEn,
     package: packageEn,
     extract: extractEn,
     errors: errorsEn,
@@ -52,6 +56,7 @@ export const resources = {
     translate: translatePtBr,
     dictionary: dictionaryPtBr,
     merge: mergePtBr,
+    mods: modsPtBr,
     package: packagePtBr,
     extract: extractPtBr,
     errors: errorsPtBr,

--- a/src/renderer/src/locales/en/mods.json
+++ b/src/renderer/src/locales/en/mods.json
@@ -1,0 +1,42 @@
+{
+  "title": "Manage Mods",
+  "subtitle": "Delete mods and set the dictionary lookup priority.",
+  "searchPlaceholder": "Search mod...",
+  "priority": {
+    "heading": "Priority order",
+    "empty": "No priority mods yet. Promote a mod from the list below.",
+    "infoTitle": "Dictionary lookup priority",
+    "infoBody": "Mods listed here are consulted first, in order, when translating. Position 1 is the highest priority."
+  },
+  "fallback": {
+    "heading": "Other mods",
+    "empty": "No mods found."
+  },
+  "actions": {
+    "promote": "Promote to priority",
+    "demote": "Remove from priority",
+    "moveUp": "Move up",
+    "moveDown": "Move down",
+    "delete": "Delete mod",
+    "positionLabel": "Position",
+    "dragDisabledWhileSearch": "Clear search to reorder"
+  },
+  "delete": {
+    "title": "Delete mod",
+    "subject": "Are you sure you want to delete the mod {{name}}?",
+    "impactRows_one": "{{count}} dictionary entry will be removed.",
+    "impactRows_other": "{{count}} dictionary entries will be removed.",
+    "impactFolder": "Folder {{path}} will be deleted.",
+    "impactFolderMissing": "No mod folder on disk.",
+    "irreversible": "This action cannot be undone.",
+    "confirm": "Delete mod and entries",
+    "cancel": "Cancel"
+  },
+  "toast": {
+    "deleted": "Mod \"{{name}}\" deleted.",
+    "promoted": "Mod \"{{name}}\" promoted.",
+    "demoted": "Mod \"{{name}}\" removed from priority.",
+    "reordered": "Priority order updated.",
+    "deleteFailed": "Failed to delete mod."
+  }
+}

--- a/src/renderer/src/locales/en/sidebar.json
+++ b/src/renderer/src/locales/en/sidebar.json
@@ -1,6 +1,7 @@
 {
   "translate": "Translate",
   "dictionary": "Dictionary",
+  "mods": "Manage Mods",
   "merge": "Merge translations",
   "extract": "Extract mod",
   "package": "Create package",

--- a/src/renderer/src/locales/pt-BR/mods.json
+++ b/src/renderer/src/locales/pt-BR/mods.json
@@ -1,0 +1,42 @@
+{
+  "title": "Gerenciar Mods",
+  "subtitle": "Exclua mods e defina a prioridade de carregamento do dicionário.",
+  "searchPlaceholder": "Buscar mod...",
+  "priority": {
+    "heading": "Ordem de prioridade",
+    "empty": "Nenhum mod com prioridade. Promova um mod da lista abaixo.",
+    "infoTitle": "Prioridade de carregamento do dicionário",
+    "infoBody": "Os mods listados aqui são consultados primeiro, em ordem, ao traduzir. A posição 1 tem a maior prioridade."
+  },
+  "fallback": {
+    "heading": "Outros mods",
+    "empty": "Nenhum mod encontrado."
+  },
+  "actions": {
+    "promote": "Adicionar à prioridade",
+    "demote": "Remover da prioridade",
+    "moveUp": "Mover para cima",
+    "moveDown": "Mover para baixo",
+    "delete": "Excluir mod",
+    "positionLabel": "Posição",
+    "dragDisabledWhileSearch": "Limpe a busca para reordenar"
+  },
+  "delete": {
+    "title": "Excluir mod",
+    "subject": "Tem certeza que deseja excluir o mod {{name}}?",
+    "impactRows_one": "{{count}} entrada do dicionário será removida.",
+    "impactRows_other": "{{count}} entradas do dicionário serão removidas.",
+    "impactFolder": "A pasta {{path}} será excluída.",
+    "impactFolderMissing": "Nenhuma pasta de mod no disco.",
+    "irreversible": "Esta ação não pode ser desfeita.",
+    "confirm": "Excluir mod e entradas",
+    "cancel": "Cancelar"
+  },
+  "toast": {
+    "deleted": "Mod \"{{name}}\" excluído.",
+    "promoted": "Mod \"{{name}}\" promovido.",
+    "demoted": "Mod \"{{name}}\" removido da prioridade.",
+    "reordered": "Ordem de prioridade atualizada.",
+    "deleteFailed": "Falha ao excluir o mod."
+  }
+}

--- a/src/renderer/src/locales/pt-BR/sidebar.json
+++ b/src/renderer/src/locales/pt-BR/sidebar.json
@@ -1,6 +1,7 @@
 {
   "translate": "Traduzir",
   "dictionary": "Dicionário",
+  "mods": "Gerenciar mods",
   "merge": "Mesclar traduções",
   "extract": "Extrair mod",
   "package": "Criar pacote",

--- a/src/renderer/src/pages/ManageModsPage.tsx
+++ b/src/renderer/src/pages/ManageModsPage.tsx
@@ -28,7 +28,7 @@ const ROW_HEIGHT = 56
 
 export function ManageModsPage(): React.JSX.Element {
   const { t } = useAppTranslation('mods')
-  const { mods, loading, promote, demote, moveUp, moveDown, setPosition, reorder } = useManageMods()
+  const { mods, loading, refetch, promote, demote, moveUp, moveDown, setPosition, reorder } = useManageMods()
 
   const [searchQuery, setSearchQuery] = useState('')
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
@@ -96,6 +96,7 @@ export function ManageModsPage(): React.JSX.Element {
 
   const handleDeleteConfirmed = (_result: DeleteModResult) => {
     setDeleteTarget(null)
+    void refetch()
   }
 
   const isSearchActive = query.length > 0

--- a/src/renderer/src/pages/ManageModsPage.tsx
+++ b/src/renderer/src/pages/ManageModsPage.tsx
@@ -1,0 +1,271 @@
+import {
+  closestCenter,
+  DndContext,
+  type DragEndEvent,
+  KeyboardSensor,
+  PointerSensor,
+  useSensor,
+  useSensors
+} from '@dnd-kit/core'
+import {
+  arrayMove,
+  SortableContext,
+  sortableKeyboardCoordinates,
+  verticalListSortingStrategy
+} from '@dnd-kit/sortable'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { Boxes, Info, Search } from 'lucide-react'
+import { useMemo, useRef, useState } from 'react'
+import { DeleteModConfirm } from '@/components/mods/DeleteModConfirm'
+import { FallbackModRow } from '@/components/mods/FallbackModRow'
+import { ModListEmpty } from '@/components/mods/ModListEmpty'
+import { PriorityModRow } from '@/components/mods/PriorityModRow'
+import { useManageMods } from '@/hooks/useManageMods'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { DeleteModResult } from '@/types'
+
+const ROW_HEIGHT = 56
+
+export function ManageModsPage(): React.JSX.Element {
+  const { t } = useAppTranslation('mods')
+  const { mods, loading, promote, demote, moveUp, moveDown, setPosition, reorder } = useManageMods()
+
+  const [searchQuery, setSearchQuery] = useState('')
+  const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
+
+  const query = searchQuery.trim().toLowerCase()
+
+  const prioritized = useMemo(
+    () =>
+      mods.filter((m) => m.priority != null).sort((a, b) => (a.priority ?? 0) - (b.priority ?? 0)),
+    [mods]
+  )
+
+  const fallback = useMemo(
+    () =>
+      mods
+        .filter((m) => m.priority == null)
+        .sort((a, b) => a.name.localeCompare(b.name, undefined, { sensitivity: 'base' })),
+    [mods]
+  )
+
+  const prioritizedFiltered = useMemo(
+    () => prioritized.filter((m) => !query || m.name.toLowerCase().includes(query)),
+    [prioritized, query]
+  )
+
+  const fallbackFiltered = useMemo(
+    () => fallback.filter((m) => !query || m.name.toLowerCase().includes(query)),
+    [fallback, query]
+  )
+
+  // - dnd-kit sensors with a 4px activation threshold to avoid accidental drags
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 4 } }),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates })
+  )
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event
+    if (!over || active.id === over.id) return
+    const oldIndex = prioritized.findIndex((m) => m.name === active.id)
+    const newIndex = prioritized.findIndex((m) => m.name === over.id)
+    const next = arrayMove(prioritized, oldIndex, newIndex)
+    void reorder(next.map((m) => m.name))
+  }
+
+  // - priority section scroll ref + virtualizer
+  const priorityScrollRef = useRef<HTMLDivElement>(null)
+  const priorityVirtualizer = useVirtualizer({
+    count: prioritizedFiltered.length,
+    getScrollElement: () => priorityScrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5
+  })
+
+  // - fallback section scroll ref + virtualizer
+  const fallbackScrollRef = useRef<HTMLDivElement>(null)
+  const fallbackVirtualizer = useVirtualizer({
+    count: fallbackFiltered.length,
+    getScrollElement: () => fallbackScrollRef.current,
+    estimateSize: () => ROW_HEIGHT,
+    overscan: 5
+  })
+
+  const prioritySectionHeight = Math.max(160, Math.min(prioritized.length * ROW_HEIGHT, 360))
+
+  const handleDeleteConfirmed = (_result: DeleteModResult) => {
+    setDeleteTarget(null)
+  }
+
+  const isSearchActive = query.length > 0
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-[#0f1114]">
+      {/* header */}
+      <header className="flex items-center justify-between border-b border-[#1f2329] px-5 py-3">
+        <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2">
+            <Boxes size={18} className="text-amber-500" />
+            <span className="text-base font-semibold text-neutral-200">{t('title')}</span>
+          </div>
+          <span className="text-sm text-neutral-500">{t('subtitle')}</span>
+        </div>
+
+        <div className="flex h-8 w-56 items-center gap-2 rounded-md border border-[#1f2329] bg-[#131518] px-3 focus-within:border-amber-500/50">
+          <Search size={13} className="shrink-0 text-neutral-500" />
+          <input
+            value={searchQuery}
+            onChange={(event) => setSearchQuery(event.target.value)}
+            placeholder={t('searchPlaceholder')}
+            className="min-w-0 flex-1 bg-transparent text-sm text-neutral-200 placeholder:text-neutral-600 focus:outline-none"
+          />
+        </div>
+      </header>
+
+      {/* info banner */}
+      <div className="mx-5 mt-4 flex gap-3 rounded-lg border border-amber-500/20 bg-amber-500/10 p-4">
+        <Info size={16} className="mt-0.5 shrink-0 text-amber-500" />
+        <div className="text-sm">
+          <p className="font-semibold text-amber-400">{t('priority.infoTitle')}</p>
+          <p className="mt-0.5 text-neutral-400">{t('priority.infoBody')}</p>
+        </div>
+      </div>
+
+      {/* content */}
+      <div className="icosa-scroll flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto px-5 py-4">
+        {/* priority section */}
+        <section className="flex flex-col">
+          <div className="mb-2 flex items-center gap-2">
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-amber-500">
+              {t('priority.heading')} &mdash; {prioritized.length} mods
+            </h2>
+            {query && prioritizedFiltered.length !== prioritized.length && (
+              <span className="text-xs text-neutral-500">
+                ({prioritizedFiltered.length} matching)
+              </span>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="rounded-lg border border-[#1f2329] bg-[#131518] px-4 py-6 text-center text-sm text-neutral-500">
+              &hellip;
+            </div>
+          ) : (
+            <div
+              className="overflow-hidden rounded-lg border border-[#1f2329] bg-[#0c0d0f]"
+              style={{ maxHeight: `${prioritySectionHeight}px` }}
+            >
+              <DndContext
+                sensors={sensors}
+                collisionDetection={closestCenter}
+                onDragEnd={handleDragEnd}
+              >
+                <SortableContext
+                  items={prioritized.map((m) => m.name)}
+                  strategy={verticalListSortingStrategy}
+                >
+                  <div ref={priorityScrollRef} className="icosa-scroll h-full overflow-y-auto">
+                    {prioritizedFiltered.length === 0 ? (
+                      <ModListEmpty message={t('priority.empty')} />
+                    ) : (
+                      <div
+                        style={{ height: priorityVirtualizer.getTotalSize(), position: 'relative' }}
+                      >
+                        {priorityVirtualizer.getVirtualItems().map((virtualItem) => {
+                          const mod = prioritizedFiltered[virtualItem.index]
+                          return (
+                            <div
+                              key={mod.name}
+                              style={{
+                                position: 'absolute',
+                                top: 0,
+                                left: 0,
+                                width: '100%',
+                                transform: `translateY(${virtualItem.start}px)`
+                              }}
+                            >
+                              <PriorityModRow
+                                mod={mod}
+                                index={virtualItem.index}
+                                total={prioritizedFiltered.length}
+                                onMoveUp={() => moveUp(mod.name)}
+                                onMoveDown={() => moveDown(mod.name)}
+                                onSetPosition={(pos) => setPosition(mod.name, pos)}
+                                onDemote={() => demote(mod.name)}
+                                onDelete={() => setDeleteTarget(mod.name)}
+                                isSearchActive={isSearchActive}
+                              />
+                            </div>
+                          )
+                        })}
+                      </div>
+                    )}
+                  </div>
+                </SortableContext>
+              </DndContext>
+            </div>
+          )}
+        </section>
+
+        {/* fallback section */}
+        <section className="flex min-h-0 flex-1 flex-col">
+          <div className="mb-2 flex items-center gap-2">
+            <h2 className="text-xs font-semibold uppercase tracking-widest text-neutral-500">
+              {t('fallback.heading')} &mdash; {fallback.length} mods
+            </h2>
+            {query && fallbackFiltered.length !== fallback.length && (
+              <span className="text-xs text-neutral-500">({fallbackFiltered.length} matching)</span>
+            )}
+          </div>
+
+          {loading ? (
+            <div className="rounded-lg border border-[#1f2329] bg-[#131518] px-4 py-6 text-center text-sm text-neutral-500">
+              &hellip;
+            </div>
+          ) : (
+            <div
+              ref={fallbackScrollRef}
+              className="icosa-scroll min-h-0 flex-1 overflow-y-auto rounded-lg border border-[#1f2329] bg-[#0c0d0f]"
+            >
+              {fallbackFiltered.length === 0 ? (
+                <ModListEmpty message={t('fallback.empty')} />
+              ) : (
+                <div style={{ height: fallbackVirtualizer.getTotalSize(), position: 'relative' }}>
+                  {fallbackVirtualizer.getVirtualItems().map((virtualItem) => {
+                    const mod = fallbackFiltered[virtualItem.index]
+                    return (
+                      <div
+                        key={mod.name}
+                        style={{
+                          position: 'absolute',
+                          top: 0,
+                          left: 0,
+                          width: '100%',
+                          transform: `translateY(${virtualItem.start}px)`
+                        }}
+                      >
+                        <FallbackModRow
+                          mod={mod}
+                          onPromote={() => promote(mod.name)}
+                          onDelete={() => setDeleteTarget(mod.name)}
+                        />
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          )}
+        </section>
+      </div>
+
+      <DeleteModConfirm
+        open={deleteTarget != null}
+        modName={deleteTarget}
+        onClose={() => setDeleteTarget(null)}
+        onConfirmed={handleDeleteConfirmed}
+      />
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a new **Manage Mods** sidebar tab (Ctrl+3) that lets the user delete mods (with full cleanup of dictionary rows, mod_meta, and the on-disk folder) and set a priority order for dictionary lookup. Priority mods are consulted in sequence before the mod being translated and the global fallback, using the existing O(1) `loadMatchIndex` architecture — no performance regression.
- Optimises the dictionary **import** pipeline: CSV parsing and bulk upsert now run in a dedicated Node worker thread (same pattern as merge and translate workers), emitting granular progress events so the UI shows a real-time progress bar instead of blocking the main process.
- Optimises **Save All** on the translate page: replaces N sequential `dictionary:upsert` IPC calls with a single `dictionary:bulkUpsert` call that uses `loadKeyMap` + `bulkInsert`/`bulkUpdate` in one transaction.
- Fixes indeterminate progress bars in merge and translate loading screens (replaced `w-2/3 animate-pulse` with a full-track glow that does not snap backward when the writing phase starts).

## Version
- v1.5.0 (bump reason: new user-visible feature — Manage Mods page + import worker)

## What changed

### Backend
- `drizzle/0007_*`: `ALTER TABLE mod ADD priority INTEGER` (nullable, migration auto-runs on startup)
- `ModRepository`: `getPriorityOrdered`, `setPriority`, `compactPriority`, `reorderPriority`, `delete`
- `mod-delete.service.ts`: orchestrates SQL transaction (dictionary rows → mod row, cascade mod_meta) then best-effort `fs.rm` on the mod folder
- `DictionaryRepository.loadMatchIndex`: 4th param `priorityMods?: readonly string[]`; resolve checks priority mods via `byModKey` before the current mod and global fallback
- `DictionaryRepository.bulkUpsert`: single `loadKeyMap` SELECT + batch insert/update instead of N per-row upserts
- `BasePipeline` + `xml-load.worker.runtime`: fetch `getPriorityOrdered()` and pass to `loadMatchIndex` at run start
- `import.worker.ts/runtime.ts` + `import.service.ts`: worker that groups CSV rows by `(sourceLang, targetLang, modName)`, calls `loadKeyMap` per group, writes in 500-row chunks with `setImmediate` yields
- `dictionary.ipc.ts`: `dictionary:import` handler is now async and pushes `dictionary:import:progress` events; `dictionary:bulkUpsert` added
- `mod.ipc.ts`: `mod:delete`, `mod:previewDelete`, `mod:setPriority`, `mod:reorderPriority`, `mod:listWithPriority`

### Frontend
- New route `/mods` → `ManageModsPage`; sidebar item at position 3 (Ctrl+3), existing shortcuts shift to Ctrl 4–7
- Two TanStack Virtual lists: priority (ordered, draggable via `@dnd-kit`) + fallback (alphabetical); search filters both simultaneously
- Priority list controls: chevron up/down, numeric position input (`type="text" inputMode="numeric"`, no browser spinner), drag handle
- `DeleteModConfirm` modal: fetches `mod:previewDelete` on open, shows dictionary row count and folder path
- `DictionaryImportModal`: real-time progress bar subscribed to `dictionary:import:progress`
- `useDictionarySave.saveAll`: switched to `window.api.dictionary.bulkUpsert`
- Progress bar fixes: merge bottom bar and translate loading overlay no longer show a fixed-width indeterminate bar that snaps backward when the writing phase begins

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm build` succeeds; `out/main/import.worker.js` exists
- [x] **Manage Mods**: open tab, promote 3 mods to priority, reorder via arrows / numeric input / drag-and-drop, confirm order persists after refresh
- [x] **Delete mod**: confirm modal shows correct dictionary row count and folder path; after confirm the row disappears and `SELECT COUNT(*) FROM dictionary WHERE mod_name = ?` returns 0
- [x] **Priority lookup**: mark a mod as priority, load a mod on the Translate page whose source text overlaps — confirm target is filled from the priority mod; demote and reload, confirm fallback to the current mod
- [x] **CSV import**: import a large CSV; UI stays responsive, progress bar fills correctly, import completes without freezing
- [x] **Save All (translate page)**: save a session with many entries; no UI freeze, single IPC round-trip observable in DevTools
- [x] **Merge progress bar**: run a merge, confirm bar starts at 0 in the writing phase (no backward snap)
- [x] **Translate loading**: load a mod, confirm initial phases show only spinner + text (no skeleton or indeterminate bar)