### PR TITLE
feat(translate): add Google Translate V2 provider

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.5.0
+buildVersion: 1.6.0
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/scripts/test-google-translate.mjs
+++ b/scripts/test-google-translate.mjs
@@ -1,0 +1,118 @@
+// Smoke test for the Google Translate v2 REST API.
+//
+// Usage: node --env-file=.env scripts/test-google-translate.mjs
+//
+// Requires GOOGLE_API_KEY in .env. Hits the real API with tiny throwaway
+// phrases (total < 100 chars) to verify single, batch, tag preservation,
+// and error paths. Self-contained: no imports from src/.
+
+const GOOGLE_API_URL = 'https://translation.googleapis.com/language/translate/v2'
+
+const apiKey = process.env.GOOGLE_API_KEY
+if (!apiKey) {
+  console.error(
+    'GOOGLE_API_KEY is not set. Run with: node --env-file=.env scripts/test-google-translate.mjs'
+  )
+  process.exit(1)
+}
+
+let charsSent = 0
+const failures = []
+
+async function request(texts, sourceLang, targetLang, key) {
+  charsSent += texts.reduce((s, t) => s + t.length, 0)
+  const url = `${GOOGLE_API_URL}?key=${encodeURIComponent(key)}`
+  const body = JSON.stringify({
+    q: texts,
+    source: sourceLang.toLowerCase(),
+    target: targetLang.toLowerCase(),
+    format: 'html'
+  })
+
+  const response = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body
+  })
+
+  if (!response.ok) {
+    const detail = await response.text().catch(() => response.statusText)
+    const err = new Error(`Google API error ${response.status}: ${detail}`)
+    err.status = response.status
+    throw err
+  }
+
+  const data = await response.json()
+  return data.data.translations.map((t) => t.translatedText)
+}
+
+function assert(cond, msg) {
+  if (!cond) {
+    console.error(`  FAIL: ${msg}`)
+    failures.push(msg)
+  }
+}
+
+// Test 1: single string
+console.log('[1/4] Single string translation...')
+try {
+  const result = await request(['hi'], 'en', 'pt-BR', apiKey)
+  console.log(`      result: ${JSON.stringify(result)}`)
+  assert(Array.isArray(result) && result.length === 1, 'expected single-element array')
+  assert(typeof result[0] === 'string' && result[0].length > 0, 'expected non-empty string')
+} catch (err) {
+  console.error(`  FAIL: ${err.message}`)
+  failures.push(`test1: ${err.message}`)
+}
+
+// Test 2: HTML tag preservation
+console.log('[2/4] Tag preservation...')
+try {
+  const result = await request(['hello <b>world</b>'], 'en', 'pt-BR', apiKey)
+  console.log(`      result: ${JSON.stringify(result)}`)
+  assert(result[0].includes('<b>'), 'expected <b> in output')
+  assert(result[0].includes('</b>'), 'expected </b> in output')
+} catch (err) {
+  console.error(`  FAIL: ${err.message}`)
+  failures.push(`test2: ${err.message}`)
+}
+
+// Test 3: batch
+console.log('[3/4] Batch of 5...')
+try {
+  const result = await request(['cat', 'dog', 'sun', 'sky', 'tree'], 'en', 'pt-BR', apiKey)
+  console.log(`      result: ${JSON.stringify(result)}`)
+  assert(
+    Array.isArray(result) && result.length === 5,
+    `expected array of length 5, got ${result.length}`
+  )
+} catch (err) {
+  console.error(`  FAIL: ${err.message}`)
+  failures.push(`test3: ${err.message}`)
+}
+
+// Test 4: error path
+console.log('[4/4] Invalid key rejection...')
+try {
+  const result = await request(['bad'], 'en', 'pt-BR', 'INVALID_KEY_XYZ')
+  console.error(`  FAIL: expected throw, got ${JSON.stringify(result)}`)
+  failures.push('test4: expected error, request succeeded')
+} catch (err) {
+  console.log(`      status: ${err.status}`)
+  console.log(`      message: ${err.message.slice(0, 80)}`)
+  assert(
+    typeof err.status === 'number' && err.status >= 400 && err.status < 500,
+    `expected 4xx status, got ${err.status}`
+  )
+}
+
+console.log('')
+console.log(`Total chars sent: ${charsSent}`)
+if (failures.length === 0) {
+  console.log('PASS')
+  process.exit(0)
+} else {
+  console.error(`FAIL (${failures.length} issue(s))`)
+  for (const f of failures) console.error(`  - ${f}`)
+  process.exit(1)
+}

--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -8,13 +8,17 @@ import {
   translateText as translateDeepL,
   translateBatchDetailed as translateDeepLBatch
 } from '../services/deepl.service'
+import {
+  translateText as translateGoogle,
+  translateBatchDetailed as translateGoogleBatch
+} from '../services/google.service'
 import { logError } from '../services/log.service'
 import { translateText as translateOpenAI } from '../services/openai.service'
-import { runTranslatePipeline } from '../services/translate.service'
+import { runTranslatePipeline, type TranslatePipelineParams } from '../services/translate.service'
 import { decodeEntities } from '../services/xml-entities.service'
 import { getActiveWindow } from '../utils/window'
 
-export type TranslationProvider = 'openai' | 'deepl' | 'manual'
+export type TranslationProvider = 'openai' | 'deepl' | 'google' | 'manual'
 
 export interface TranslationStartPayload extends PipelineOptions {
   provider: TranslationProvider
@@ -24,7 +28,7 @@ export interface TranslationStartPayload extends PipelineOptions {
 
 interface BatchPayload {
   entries: { uid: string; source: string }[]
-  provider: 'openai' | 'deepl'
+  provider: 'openai' | 'deepl' | 'google'
   sourceLang: string
   targetLang: string
 }
@@ -63,6 +67,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
     const { cancel } = runTranslatePipeline({
       jobId,
       ...payload,
+      provider: payload.provider as TranslatePipelineParams['provider'],
       onProgress: ({ current, total, source, target }) => {
         const win = getActiveWindow(getWindow)
         if (win) {
@@ -106,7 +111,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
     async (
       _event,
       payload: {
-        provider: 'openai' | 'deepl'
+        provider: 'openai' | 'deepl' | 'google'
         text: string
         sourceLang: string
         targetLang: string
@@ -117,6 +122,9 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         const apiKey = requireStoredApiKey(provider)
         if (provider === 'deepl') {
           return decodeEntities(await translateDeepL(text, sourceLang, targetLang, apiKey))
+        }
+        if (provider === 'google') {
+          return decodeEntities(await translateGoogle(text, sourceLang, targetLang, apiKey))
         }
         return decodeEntities(await translateOpenAI(text, sourceLang, targetLang, apiKey))
       } catch (err) {
@@ -161,9 +169,10 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
   )
 }
 
-function readApiKey(provider: 'openai' | 'deepl'): string | null {
+function readApiKey(provider: 'openai' | 'deepl' | 'google'): string | null {
   const db = getDb()
-  const key = provider === 'deepl' ? 'deepl_key' : 'openai_key'
+  const key =
+    provider === 'deepl' ? 'deepl_key' : provider === 'google' ? 'google_key' : 'openai_key'
   const row = db.select().from(config).where(eq(config.key, key)).get() as
     | { key: string; value: string | null }
     | undefined
@@ -171,7 +180,7 @@ function readApiKey(provider: 'openai' | 'deepl'): string | null {
   return value.length > 0 ? value : null
 }
 
-function requireStoredApiKey(provider: 'openai' | 'deepl'): string {
+function requireStoredApiKey(provider: 'openai' | 'deepl' | 'google'): string {
   const apiKey = readApiKey(provider)
   if (!apiKey) throw new Error(`${providerLabel(provider)} API key not configured. Go to Settings.`)
   return apiKey
@@ -184,8 +193,10 @@ function requirePayloadApiKey(payload: TranslationStartPayload): void {
   }
 }
 
-function providerLabel(provider: 'openai' | 'deepl'): string {
-  return provider === 'deepl' ? 'DeepL' : 'OpenAI'
+function providerLabel(provider: 'openai' | 'deepl' | 'google'): string {
+  if (provider === 'deepl') return 'DeepL'
+  if (provider === 'google') return 'Google'
+  return 'OpenAI'
 }
 
 // Worker pool: runs fn over items with at most `concurrency` parallel executions
@@ -216,6 +227,8 @@ async function runBatchJob(ctx: BatchJobContext): Promise<void> {
   try {
     if (ctx.provider === 'deepl') {
       await runDeepLBatchJob(ctx, summary)
+    } else if (ctx.provider === 'google') {
+      await runGoogleBatchJob(ctx, summary)
     } else {
       await runOpenAIBatchJob(ctx, summary)
     }
@@ -302,6 +315,78 @@ async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Pr
         logError(
           'translation.batch.deepl.entry',
           new Error(pending.error ?? 'DeepL batch entry failed'),
+          {
+            jobId: ctx.jobId,
+            uid: pending.entry.uid,
+            sourceLang: ctx.sourceLang,
+            targetLang: ctx.targetLang,
+            source: pending.entry.source
+          }
+        )
+        emitBatchProgress(ctx.getWindow, {
+          jobId: ctx.jobId,
+          uid: pending.entry.uid,
+          completed: summary.translated + summary.failed,
+          total: summary.total,
+          target: null,
+          error: pending.error
+        })
+      }
+      return
+    }
+
+    pendingEntries = nextPending.map((pending) => pending.entry)
+  }
+}
+
+async function runGoogleBatchJob(ctx: BatchJobContext, summary: BatchSummary): Promise<void> {
+  let pendingEntries = [...ctx.entries]
+
+  while (pendingEntries.length > 0) {
+    throwIfAborted(ctx.signal)
+
+    const results = await translateGoogleBatch(
+      pendingEntries.map((entry) => entry.source),
+      ctx.sourceLang,
+      ctx.targetLang,
+      ctx.apiKey,
+      ctx.signal
+    )
+
+    let roundSuccesses = 0
+    const nextPending: Array<{ entry: BatchPayload['entries'][number]; error?: string }> = []
+
+    for (const result of results) {
+      const entry = pendingEntries[result.index]
+      if (!entry) continue
+
+      if (result.translated != null) {
+        roundSuccesses++
+        summary.translated++
+        emitBatchProgress(ctx.getWindow, {
+          jobId: ctx.jobId,
+          uid: entry.uid,
+          completed: summary.translated + summary.failed,
+          total: summary.total,
+          target: decodeEntities(result.translated)
+        })
+        continue
+      }
+
+      nextPending.push({ entry, error: result.error })
+    }
+
+    if (nextPending.length === 0) {
+      summary.failed = 0
+      return
+    }
+
+    if (roundSuccesses === 0) {
+      for (const pending of nextPending) {
+        summary.failed++
+        logError(
+          'translation.batch.google.entry',
+          new Error(pending.error ?? 'Google batch entry failed'),
           {
             jobId: ctx.jobId,
             uid: pending.entry.uid,

--- a/src/main/pipelines/google.pipeline.ts
+++ b/src/main/pipelines/google.pipeline.ts
@@ -1,0 +1,12 @@
+import { BasePipeline } from './base.pipeline'
+import { translateText } from '../services/google.service'
+
+export class GooglePipeline extends BasePipeline {
+  constructor(private readonly apiKey: string) {
+    super()
+  }
+
+  async translate(text: string, sourceLang: string, targetLang: string): Promise<string> {
+    return translateText(text, sourceLang, targetLang, this.apiKey)
+  }
+}

--- a/src/main/services/google.service.ts
+++ b/src/main/services/google.service.ts
@@ -1,0 +1,152 @@
+import type { BatchTranslationResult } from './deepl.service'
+import { logError } from './log.service'
+import { decodeEntities } from './xml-entities.service'
+
+export type { BatchTranslationResult }
+
+const GOOGLE_API_URL = 'https://translation.googleapis.com/language/translate/v2'
+const GOOGLE_CHUNK_SIZE = 100
+const MAX_RETRIES = 3
+
+class GoogleApiError extends Error {
+  constructor(
+    public readonly status: number,
+    detail: string
+  ) {
+    super(`Google API error ${status}: ${detail}`)
+  }
+}
+
+function toGoogleLang(code: string): string {
+  return code.toLowerCase()
+}
+
+export async function translateText(
+  text: string,
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string,
+  signal?: AbortSignal
+): Promise<string> {
+  const translated = await requestGoogle([text], sourceLang, targetLang, apiKey, signal)
+  const first = translated[0]
+  if (first == null) {
+    throw new Error('Google response did not include the translated text')
+  }
+  return decodeEntities(first)
+}
+
+export async function translateBatchDetailed(
+  texts: string[],
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string,
+  signal?: AbortSignal
+): Promise<BatchTranslationResult[]> {
+  const results: BatchTranslationResult[] = []
+
+  for (let offset = 0; offset < texts.length; offset += GOOGLE_CHUNK_SIZE) {
+    const chunk = texts.slice(offset, offset + GOOGLE_CHUNK_SIZE)
+    try {
+      const translated = await requestGoogle(chunk, sourceLang, targetLang, apiKey, signal)
+      translated.forEach((value, i) => {
+        results.push({ index: offset + i, translated: decodeEntities(value) })
+      })
+    } catch (err) {
+      logError('google.batch.chunk', err, {
+        offset,
+        size: chunk.length,
+        chars: chunk.reduce((s, t) => s + t.length, 0)
+      })
+      if (isFatalBatchError(err)) {
+        throw err
+      }
+
+      for (let i = 0; i < chunk.length; i++) {
+        try {
+          const translated = await translateText(chunk[i], sourceLang, targetLang, apiKey, signal)
+          results.push({ index: offset + i, translated })
+        } catch (entryErr) {
+          if (isFatalBatchError(entryErr)) throw entryErr
+          logError('google.batch.entry', entryErr, { index: offset + i, sourceLang, targetLang })
+          results.push({
+            index: offset + i,
+            translated: null,
+            error: entryErr instanceof Error ? entryErr.message : String(entryErr)
+          })
+        }
+      }
+    }
+  }
+
+  return results
+}
+
+async function requestGoogle(
+  texts: string[],
+  sourceLang: string,
+  targetLang: string,
+  apiKey: string,
+  signal?: AbortSignal
+): Promise<string[]> {
+  const url = `${GOOGLE_API_URL}?key=${encodeURIComponent(apiKey)}`
+  const body = JSON.stringify({
+    q: texts,
+    source: toGoogleLang(sourceLang),
+    target: toGoogleLang(targetLang),
+    format: 'html'
+  })
+
+  for (let attempt = 1; attempt <= MAX_RETRIES; attempt++) {
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body,
+      signal
+    })
+
+    if (response.ok) {
+      const data = (await response.json()) as {
+        data: { translations: { translatedText: string }[] }
+      }
+      return data.data.translations.map((item) => item.translatedText)
+    }
+
+    const detail = await response.text().catch(() => response.statusText)
+    const error = new GoogleApiError(response.status, detail)
+    if ([400, 401, 403].includes(response.status)) throw error
+    if (response.status !== 429 || attempt === MAX_RETRIES) throw error
+    logError('google.rateLimit', error, { attempt, total: texts.length })
+    await delay(500 * attempt, signal)
+  }
+
+  throw new Error('Google request failed')
+}
+
+function delay(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => {
+      signal?.removeEventListener('abort', onAbort)
+      resolve()
+    }, ms)
+
+    const onAbort = () => {
+      clearTimeout(timer)
+      signal?.removeEventListener('abort', onAbort)
+      reject(signal?.reason ?? new Error('Translation cancelled'))
+    }
+
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+  })
+}
+
+function isFatalBatchError(err: unknown): boolean {
+  return err instanceof GoogleApiError && [400, 401, 403].includes(err.status)
+}

--- a/src/main/services/translate.service.ts
+++ b/src/main/services/translate.service.ts
@@ -13,7 +13,7 @@ export interface TranslatePipelineParams {
   sourceLang: string
   targetLang: string
   author?: string
-  provider: 'deepl' | 'openai' | 'manual'
+  provider: 'deepl' | 'google' | 'openai' | 'manual'
   apiKey?: string
   model?: string
   onProgress: (p: { current: number; total: number; source: string; target: string }) => void

--- a/src/main/workers/translate.worker.runtime.ts
+++ b/src/main/workers/translate.worker.runtime.ts
@@ -3,12 +3,13 @@ import { drizzle } from 'drizzle-orm/better-sqlite3'
 import * as schema from '../database/schema'
 import type { BasePipeline } from '../pipelines/base.pipeline'
 import { DeepLPipeline } from '../pipelines/deepl.pipeline'
+import { GooglePipeline } from '../pipelines/google.pipeline'
 import { ManualPipeline } from '../pipelines/manual.pipeline'
 import { OpenAIPipeline } from '../pipelines/openai.pipeline'
 
 export interface TranslateWorkerInput {
   jobId: string
-  provider: 'deepl' | 'openai' | 'manual'
+  provider: 'deepl' | 'google' | 'openai' | 'manual'
   apiKey?: string
   model?: string
   filePath: string
@@ -29,6 +30,9 @@ function buildPipeline(input: TranslateWorkerInput): BasePipeline {
     case 'deepl':
       if (!input.apiKey) throw new Error('DeepL API key is required')
       return new DeepLPipeline(input.apiKey)
+    case 'google':
+      if (!input.apiKey) throw new Error('Google Translate API key is required')
+      return new GooglePipeline(input.apiKey)
     case 'openai':
       if (!input.apiKey) throw new Error('OpenAI API key is required')
       return new OpenAIPipeline(input.apiKey, input.model)

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -161,6 +161,7 @@ export interface CompleteTranslationImportResult {
 export type ConfigKey =
   | 'openai_key'
   | 'deepl_key'
+  | 'google_key'
   | 'last_source_lang'
   | 'last_target_lang'
   | 'app_language'

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1,7 +1,7 @@
 import type { ElectronAPI } from '@electron-toolkit/preload'
 
 export type UnsubscribeFn = () => void
-export type TranslationProvider = 'openai' | 'deepl' | 'manual'
+export type TranslationProvider = 'openai' | 'deepl' | 'google' | 'manual'
 
 export interface TranslationStartPayload {
   provider: TranslationProvider
@@ -242,14 +242,14 @@ export interface TranslationApi {
   onDone(cb: (data: TranslationDoneEvent) => void): UnsubscribeFn
   onError(cb: (data: TranslationErrorEvent) => void): UnsubscribeFn
   single(payload: {
-    provider: 'openai' | 'deepl'
+    provider: 'openai' | 'deepl' | 'google'
     text: string
     sourceLang: string
     targetLang: string
   }): Promise<string>
   batch(payload: {
     entries: { uid: string; source: string }[]
-    provider: 'openai' | 'deepl'
+    provider: 'openai' | 'deepl' | 'google'
     sourceLang: string
     targetLang: string
   }): Promise<{ jobId: string }>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -46,7 +46,7 @@ const api: AppApi = {
       on('translation:error', cb),
 
     single: (payload: {
-      provider: 'openai' | 'deepl'
+      provider: 'openai' | 'deepl' | 'google'
       text: string
       sourceLang: string
       targetLang: string
@@ -54,7 +54,7 @@ const api: AppApi = {
 
     batch: (payload: {
       entries: { uid: string; source: string }[]
-      provider: 'openai' | 'deepl'
+      provider: 'openai' | 'deepl' | 'google'
       sourceLang: string
       targetLang: string
     }): Promise<{ jobId: string }> => ipcRenderer.invoke('translation:batch', payload),

--- a/src/renderer/src/components/translation/BatchActionBar.tsx
+++ b/src/renderer/src/components/translation/BatchActionBar.tsx
@@ -6,6 +6,7 @@ interface BatchActionBarProps {
   batchCompleted: number
   batchTotal: number
   onTranslateDeepL: () => void
+  onTranslateGoogle: () => void
   // onTranslateGPT: () => void
   onCancelTranslation: () => void
   onClearSelection: () => void
@@ -17,6 +18,7 @@ export function BatchActionBar({
   batchCompleted,
   batchTotal,
   onTranslateDeepL,
+  onTranslateGoogle,
   // onTranslateGPT,
   onCancelTranslation,
   onClearSelection,
@@ -58,6 +60,13 @@ export function BatchActionBar({
             className="cursor-pointer rounded-md bg-blue-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-blue-700"
           >
             {t('batchBar.translateWithDeepL', { ns: 'translate' })}
+          </button>
+          <button
+            type="button"
+            onClick={onTranslateGoogle}
+            className="cursor-pointer rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white transition-colors hover:bg-red-700"
+          >
+            {t('batchBar.translateWithGoogle', { ns: 'translate' })}
           </button>
           {/* <button
             type="button"

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -88,6 +88,7 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
         batchCompleted={batch.batchCompleted}
         batchTotal={batch.batchTotal}
         onTranslateDeepL={() => batch.batchTranslate('deepl')}
+        onTranslateGoogle={() => batch.batchTranslate('google')}
         // onTranslateGPT={() => batch.batchTranslate('openai')}
         onCancelTranslation={batch.cancelBatch}
         onClearSelection={session.clearSelection}

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -27,7 +27,7 @@ export function useBatchTranslation(session: TranslationSession) {
   const batchErrorsRef = useRef<Map<string, string>>(new Map())
   const pendingAllEntriesRef = useRef<BatchEntry[]>([])
   const pendingUntranslatedEntriesRef = useRef<BatchEntry[]>([])
-  const pendingProviderRef = useRef<'openai' | 'deepl'>('deepl')
+  const pendingProviderRef = useRef<'openai' | 'deepl' | 'google'>('deepl')
   const { sourceLang, targetLang, updateEntry, clearSelection, selectEntries } = session
 
   const clearListeners = useCallback(() => {
@@ -64,7 +64,7 @@ export function useBatchTranslation(session: TranslationSession) {
   }, [clearListeners])
 
   const dispatchBatchEntries = useCallback(
-    async (entriesToSend: BatchEntry[], provider: 'openai' | 'deepl') => {
+    async (entriesToSend: BatchEntry[], provider: 'openai' | 'deepl' | 'google') => {
       pendingUidsRef.current = new Set(entriesToSend.map((e) => e.uid))
       batchErrorsRef.current = new Map()
       setBatchCompleted(0)
@@ -217,7 +217,7 @@ export function useBatchTranslation(session: TranslationSession) {
   }, [])
 
   const batchTranslate = useCallback(
-    async (provider: 'openai' | 'deepl') => {
+    async (provider: 'openai' | 'deepl' | 'google') => {
       if (isBatchTranslating) return
 
       const materialized = materializeSelectedEntries(session)

--- a/src/renderer/src/locales/en/settings.json
+++ b/src/renderer/src/locales/en/settings.json
@@ -10,6 +10,7 @@
   },
   "fields": {
     "deeplKey": "DeepL API key",
+    "googleKey": "Google Translate API key",
     "defaultAuthor": "Default author",
     "defaultSourceLanguage": "Default source language",
     "defaultTargetLanguage": "Default target language",

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -104,6 +104,7 @@
     "translating": "Translating {{completed}} / {{total}}",
     "stop": "Stop",
     "translateWithDeepL": "Translate with DeepL",
+    "translateWithGoogle": "Translate with Google",
     "clearSelection": "Clear selection",
     "noSelection": "No entries selected",
     "cancelled": "{{translated}} of {{total}} entries translated before cancellation",

--- a/src/renderer/src/locales/pt-BR/settings.json
+++ b/src/renderer/src/locales/pt-BR/settings.json
@@ -10,6 +10,7 @@
   },
   "fields": {
     "deeplKey": "Chave da API DeepL",
+    "googleKey": "Chave da API do Google Translate",
     "defaultAuthor": "Autor padrão",
     "defaultSourceLanguage": "Idioma de origem padrão",
     "defaultTargetLanguage": "Idioma de destino padrão",

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -104,6 +104,7 @@
     "translating": "Traduzindo {{completed}} / {{total}}",
     "stop": "Parar",
     "translateWithDeepL": "Traduzir com DeepL",
+    "translateWithGoogle": "Traduzir com Google",
     "clearSelection": "Limpar seleção",
     "noSelection": "Nenhuma entrada selecionada",
     "cancelled": "{{translated}} de {{total}} entradas traduzidas antes do cancelamento",

--- a/src/renderer/src/pages/SettingsPage.tsx
+++ b/src/renderer/src/pages/SettingsPage.tsx
@@ -162,6 +162,20 @@ export function SettingsPage(): React.JSX.Element {
               label: t('fields.deeplKey')
             })}
           />
+          <SettingField
+            label={t('fields.googleKey')}
+            configKey="google_key"
+            value={config['google_key'] ?? ''}
+            onSave={set}
+            type="password"
+            placeholder="AIza..."
+            saveLabel={t('buttons.save')}
+            savedLabel={t('buttons.saved')}
+            successMessage={t('settings.saved', {
+              ns: 'toasts',
+              label: t('fields.googleKey')
+            })}
+          />
         </SettingsCard>
 
         <SettingsCard title={t('sections.language')}>


### PR DESCRIPTION
## Summary
- Adds Google Translate V2 as a fourth translation provider alongside DeepL, OpenAI and Manual, using plain `fetch` (no SDK) to keep the bundle lean
- New red **Translate with Google** button in the batch action bar; new API key field in Settings; full pipeline support for single translations, batch jobs and full-mod translation runs via `translation:start`

## Version
- v1.6.0 (bump reason: new user-visible feature)

## Implementation notes
- Service (`google.service.ts`): sequential batches of 100, 3 retries with 500 ms × attempt backoff, fatal on 400/401/403, tag safety via `format: 'html'` (Google preserves inline XML/HTML natively — no placeholder layer needed)
- Config key: `google_key` in the `config` table, consistent with `deepl_key` / `openai_key`
- All provider type unions widened across `api-types.ts`, `preload/index.ts`, `translation.ipc.ts`, `translate.service.ts` and `translate.worker.runtime.ts`
- Smoke test script at `scripts/test-google-translate.mjs` (`node --env-file=.env scripts/test-google-translate.mjs`); currently blocked by an IP allowlist on the `.env` key — resolve in Google Cloud Console before running

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Settings → paste Google API key → save → field persists
- [x] Translate page → select entries → click red **Translate with Google** → progress toast appears, translations populate
- [x] Re-translate same selection → "already translated" dialog gates the request
- [x] Cancel mid-batch → job aborts cleanly
- [x] Full-mod translation via `translation:start` with provider `google` routes through `GooglePipeline`
- [x] Run `node --env-file=.env scripts/test-google-translate.mjs` once IP allowlist is resolved → prints `PASS`, total chars sent < 100