### PR TITLE
feat(metrics): add Metrics page with usage tracking, quota gating and translation history

### DIFF
--- a/drizzle/0008_clean_princess_powerful.sql
+++ b/drizzle/0008_clean_princess_powerful.sql
@@ -1,0 +1,28 @@
+CREATE TABLE `translation_run` (
+	`id` integer PRIMARY KEY AUTOINCREMENT NOT NULL,
+	`job_id` text,
+	`service` text NOT NULL,
+	`mod_name` text,
+	`source_lang` text NOT NULL,
+	`target_lang` text NOT NULL,
+	`entries_total` integer DEFAULT 0 NOT NULL,
+	`entries_translated` integer DEFAULT 0 NOT NULL,
+	`chars_consumed` integer DEFAULT 0 NOT NULL,
+	`started_at` text NOT NULL,
+	`finished_at` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')),
+	`updated_at` text DEFAULT (datetime('now')),
+	FOREIGN KEY (`mod_name`) REFERENCES `mod`(`name`) ON UPDATE no action ON DELETE no action
+);
+--> statement-breakpoint
+CREATE INDEX `translation_run_finished_idx` ON `translation_run` (`finished_at`);--> statement-breakpoint
+CREATE INDEX `translation_run_service_finished_idx` ON `translation_run` (`service`,`finished_at`);--> statement-breakpoint
+CREATE INDEX `translation_run_mod_idx` ON `translation_run` (`mod_name`);--> statement-breakpoint
+CREATE TABLE `translation_usage` (
+	`service` text PRIMARY KEY NOT NULL,
+	`consumed_chars` integer DEFAULT 0 NOT NULL,
+	`char_limit` integer DEFAULT 500000 NOT NULL,
+	`renewal_at` text NOT NULL,
+	`created_at` text DEFAULT (datetime('now')),
+	`updated_at` text DEFAULT (datetime('now'))
+);

--- a/drizzle/meta/0008_snapshot.json
+++ b/drizzle/meta/0008_snapshot.json
@@ -1,0 +1,682 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "8c794ae4-0e17-4130-bddf-7f760f4e3e22",
+  "prevId": "9f7d32f3-f9de-4542-90aa-c07cdd2a4ce7",
+  "tables": {
+    "config": {
+      "name": "config",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "dictionary": {
+      "name": "dictionary",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "language1": {
+          "name": "language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "language2": {
+          "name": "language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1": {
+          "name": "text_language1",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language2": {
+          "name": "text_language2",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "text_language1_key": {
+          "name": "text_language1_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "text_language2_key": {
+          "name": "text_language2_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "mod_name": {
+          "name": "mod_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "uid": {
+          "name": "uid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "dictionary_langs_idx": {
+          "name": "dictionary_langs_idx",
+          "columns": [
+            "language1",
+            "language2"
+          ],
+          "isUnique": false
+        },
+        "dictionary_langs_mod_idx": {
+          "name": "dictionary_langs_mod_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_mod_idx": {
+          "name": "dictionary_mod_idx",
+          "columns": [
+            "mod_name"
+          ],
+          "isUnique": false
+        },
+        "dictionary_match_idx": {
+          "name": "dictionary_match_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name",
+            "text_language1_key"
+          ],
+          "isUnique": false
+        },
+        "dictionary_match_uid_idx": {
+          "name": "dictionary_match_uid_idx",
+          "columns": [
+            "language1",
+            "language2",
+            "mod_name",
+            "uid",
+            "text_language1_key"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "dictionary_language1_language_code_fk": {
+          "name": "dictionary_language1_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language1"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_language2_language_code_fk": {
+          "name": "dictionary_language2_language_code_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "language",
+          "columnsFrom": [
+            "language2"
+          ],
+          "columnsTo": [
+            "code"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        },
+        "dictionary_mod_name_mod_name_fk": {
+          "name": "dictionary_mod_name_mod_name_fk",
+          "tableFrom": "dictionary",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "language": {
+      "name": "language",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "code": {
+          "name": "code",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "language_code_unique": {
+          "name": "language_code_unique",
+          "columns": [
+            "code"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod": {
+      "name": "mod",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "total_strings": {
+          "name": "total_strings",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": 0
+        },
+        "last_file_path": {
+          "name": "last_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "priority": {
+          "name": "priority",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_name_unique": {
+          "name": "mod_name_unique",
+          "columns": [
+            "name"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "mod_meta": {
+      "name": "mod_meta",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "mod_id": {
+          "name": "mod_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meta_file_path": {
+          "name": "meta_file_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "folder": {
+          "name": "folder",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "author": {
+          "name": "author",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "uuid": {
+          "name": "uuid",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_major": {
+          "name": "version_major",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_minor": {
+          "name": "version_minor",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_revision": {
+          "name": "version_revision",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version_build": {
+          "name": "version_build",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "version64": {
+          "name": "version64",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "mod_meta_mod_id_unique": {
+          "name": "mod_meta_mod_id_unique",
+          "columns": [
+            "mod_id"
+          ],
+          "isUnique": true
+        }
+      },
+      "foreignKeys": {
+        "mod_meta_mod_id_mod_id_fk": {
+          "name": "mod_meta_mod_id_mod_id_fk",
+          "tableFrom": "mod_meta",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translation_run": {
+      "name": "translation_run",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "job_id": {
+          "name": "job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "mod_name": {
+          "name": "mod_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_lang": {
+          "name": "source_lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "target_lang": {
+          "name": "target_lang",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "entries_total": {
+          "name": "entries_total",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "entries_translated": {
+          "name": "entries_translated",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chars_consumed": {
+          "name": "chars_consumed",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "finished_at": {
+          "name": "finished_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {
+        "translation_run_finished_idx": {
+          "name": "translation_run_finished_idx",
+          "columns": [
+            "finished_at"
+          ],
+          "isUnique": false
+        },
+        "translation_run_service_finished_idx": {
+          "name": "translation_run_service_finished_idx",
+          "columns": [
+            "service",
+            "finished_at"
+          ],
+          "isUnique": false
+        },
+        "translation_run_mod_idx": {
+          "name": "translation_run_mod_idx",
+          "columns": [
+            "mod_name"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {
+        "translation_run_mod_name_mod_name_fk": {
+          "name": "translation_run_mod_name_mod_name_fk",
+          "tableFrom": "translation_run",
+          "tableTo": "mod",
+          "columnsFrom": [
+            "mod_name"
+          ],
+          "columnsTo": [
+            "name"
+          ],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "translation_usage": {
+      "name": "translation_usage",
+      "columns": {
+        "service": {
+          "name": "service",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "consumed_chars": {
+          "name": "consumed_chars",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "char_limit": {
+          "name": "char_limit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 500000
+        },
+        "renewal_at": {
+          "name": "renewal_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "(datetime('now'))"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1779052024100,
       "tag": "0007_ordinary_rafael_vega",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1779133579328,
+      "tag": "0008_clean_princess_powerful",
+      "breakpoints": true
     }
   ]
 }

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.6.0
+buildVersion: 1.7.0
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "react-i18next": "^17.0.7",
     "react-resizable-panels": "^4.11.0",
     "react-router-dom": "^7.14.2",
+    "recharts": "^3.8.1",
     "sonner": "^2.0.7",
     "tailwind-merge": "^3.5.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.6.0",
+  "version": "1.7.0",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       react-router-dom:
         specifier: ^7.14.2
         version: 7.14.2(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      recharts:
+        specifier: ^3.8.1
+        version: 3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.6)(react@19.2.5)(redux@5.0.1)
       sonner:
         specifier: ^2.0.7
         version: 2.0.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -937,6 +940,17 @@ packages:
   '@node-rs/helper@1.6.0':
     resolution: {integrity: sha512-2OTh/tokcLA1qom1zuCJm2gQzaZljCCbtX1YCrwRVd/toz7KxaDRFeLTAPwhs8m9hWgzrBn5rShRm6IaZofCPw==}
 
+  '@reduxjs/toolkit@2.12.0':
+    resolution: {integrity: sha512-KiT+RzZbp6mQET+Mg+h2c97+9j1sNflUxQkIHI7Yuzf6Peu+OYpmkn6nbHWmLLWj+1ZODUJFwGZ7gx3L9R9EOw==}
+    peerDependencies:
+      react: ^16.9.0 || ^17.0.0 || ^18 || ^19
+      react-redux: ^7.2.1 || ^8.1.3 || ^9.0.0
+    peerDependenciesMeta:
+      react:
+        optional: true
+      react-redux:
+        optional: true
+
   '@rolldown/pluginutils@1.0.0-rc.3':
     resolution: {integrity: sha512-eybk3TjzzzV97Dlj5c+XrBFW57eTNhzod66y9HrBlzJ6NsCrWCp/2kaPS3K9wJmurBC0Tdw4yPjXKZqlznim3Q==}
 
@@ -1082,6 +1096,12 @@ packages:
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
     engines: {node: '>=10'}
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@standard-schema/utils@0.3.0':
+    resolution: {integrity: sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==}
+
   '@szmarczak/http-timer@4.0.6':
     resolution: {integrity: sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w==}
     engines: {node: '>=10'}
@@ -1210,6 +1230,33 @@ packages:
   '@types/cacheable-request@6.0.3':
     resolution: {integrity: sha512-IQ3EbTzGxIigb1I3qPZc1rWJnH0BmSKv5QYTalEwweFvyBDLSAe24zP0le/hyi7ecGfZVlIVAg4BZqb8WBwKqw==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -1244,6 +1291,9 @@ packages:
 
   '@types/responselike@1.0.3':
     resolution: {integrity: sha512-H/+L+UkTV33uf49PH5pCAUBVPNj2nDBXTN+qS1dOwyyg24l3CcicicCA7ca+HMvJBZcFgl5r8e+RR6elsb4Lyw==}
+
+  '@types/use-sync-external-store@0.0.6':
+    resolution: {integrity: sha512-zFDAD+tlpf2r4asuHEj0XH6pY6i0g5NeAHPn+15wk3BV6JA69eERFXC1gyGThDkVa1zCyKr5jox1+2LbV/AMLg==}
 
   '@types/verror@1.10.11':
     resolution: {integrity: sha512-RlDm9K7+o5stv0Co8i8ZRGxDbrTxhJtgjqjFyVh/tXQyl/rYtTKlnTvZ88oSTeYREWurwx20Js4kTuKCsFkUtg==}
@@ -1493,6 +1543,50 @@ packages:
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
 
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1501,6 +1595,9 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
 
   decompress-response@6.0.0:
     resolution: {integrity: sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==}
@@ -1725,6 +1822,9 @@ packages:
     resolution: {integrity: sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==}
     engines: {node: '>= 0.4'}
 
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
+
   es6-error@4.1.1:
     resolution: {integrity: sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg==}
 
@@ -1750,6 +1850,9 @@ packages:
   escape-string-regexp@4.0.0:
     resolution: {integrity: sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==}
     engines: {node: '>=10'}
+
+  eventemitter3@5.0.4:
+    resolution: {integrity: sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==}
 
   expand-template@2.0.3:
     resolution: {integrity: sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==}
@@ -1953,6 +2056,12 @@ packages:
   ieee754@1.2.1:
     resolution: {integrity: sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==}
 
+  immer@10.2.0:
+    resolution: {integrity: sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw==}
+
+  immer@11.1.8:
+    resolution: {integrity: sha512-/tbkHMW7y10Lx6i1crLjD4/OhNkRG+Fo7byZHtah0547nIeXYcpIXaUh0IAQY6gO5459qpGGYapcEOHtFXkIuA==}
+
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
     deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
@@ -1962,6 +2071,10 @@ packages:
 
   ini@1.3.8:
     resolution: {integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
@@ -2352,6 +2465,21 @@ packages:
       typescript:
         optional: true
 
+  react-is@19.2.6:
+    resolution: {integrity: sha512-XjBR15BhXuylgWGuslhDKqlSayuqvqBX91BP8pauG8kd1zY8kotkNWbXksTCNRarse4kuGbe2kIY05ARtwNIvw==}
+
+  react-redux@9.3.0:
+    resolution: {integrity: sha512-KQopgqFo/p/fgmAs5qz6p5RWaNAzq40WAu7fJIXnQpYxFPbJYtsJPWvGeF2rOBaY/kEuV77AVsX8TsQzKm+A/g==}
+    peerDependencies:
+      '@types/react': ^18.2.25 || ^19
+      react: ^18.0 || ^19
+      redux: ^5.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      redux:
+        optional: true
+
   react-refresh@0.18.0:
     resolution: {integrity: sha512-QgT5//D3jfjJb6Gsjxv0Slpj23ip+HtOpnNgnb2S5zU3CB26G/IDPGoy4RJB42wzFE46DRsstbW6tKHoKbhAxw==}
     engines: {node: '>=0.10.0'}
@@ -2391,6 +2519,22 @@ packages:
     resolution: {integrity: sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==}
     engines: {node: '>= 6'}
 
+  recharts@3.8.1:
+    resolution: {integrity: sha512-mwzmO1s9sFL0TduUpwndxCUNoXsBw3u3E/0+A+cLcrSfQitSG62L32N69GhqUrrT5qKcAE3pCGVINC6pqkBBQg==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-is: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redux-thunk@3.1.0:
+    resolution: {integrity: sha512-NW2r5T6ksUKXCabzhL9z+h206HQw/NJkcLm1GPImRQ8IzfXwRGqjVhKJGauHirT0DAuyy6hjdnMZaRoAcy0Klw==}
+    peerDependencies:
+      redux: ^5.0.0
+
+  redux@5.0.1:
+    resolution: {integrity: sha512-M9/ELqF6fy8FwmkpnF0S3YKOqMyoWJ4+CS5Efg2ct3oY9daQvd/Pc71FpGZsVsbl3Cpb+IIcjBDUnnyBdQbq4w==}
+
   require-directory@2.1.1:
     resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
     engines: {node: '>=0.10.0'}
@@ -2398,6 +2542,9 @@ packages:
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
+
+  reselect@5.1.1:
+    resolution: {integrity: sha512-K/BG6eIky/SBpzfHZv/dd+9JBFiS4SWV7FIujVyJRux6e45+73RaUHXLmIR1f7WOMaQ0U1km6qwklRQxpJJY0w==}
 
   resolve-alpn@1.2.1:
     resolution: {integrity: sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==}
@@ -2575,6 +2722,9 @@ packages:
   tiny-async-pool@1.3.0:
     resolution: {integrity: sha512-01EAw5EDrcVrdgyCLgoSPvqznC0sVxDSVeiOz09FUpjh71G79VCqneOr+xvt7T1r76CF6ZZfPjHorN2+d+3mqA==}
 
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
   tinyglobby@0.2.16:
     resolution: {integrity: sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==}
     engines: {node: '>=12.0.0'}
@@ -2647,6 +2797,9 @@ packages:
   verror@1.10.1:
     resolution: {integrity: sha512-veufcmxri4e3XSrT0xwfUR7kguIkaxBeosDg00yDWhk49wdwkSUrvvsm7nc75e1PUyvIeZj6nS8VQRYz2/S4Xg==}
     engines: {node: '>=0.6.0'}
+
+  victory-vendor@37.3.6:
+    resolution: {integrity: sha512-SbPDPdDBYp+5MJHhBCAyI7wKM3d5ivekigc2Dk2s7pgbZ9wIgIBYGVw4zGHBml/qTFbexrofXW6Gu4noGxrOwQ==}
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -3357,6 +3510,18 @@ snapshots:
     dependencies:
       '@napi-rs/triples': 1.2.0
 
+  '@reduxjs/toolkit@2.12.0(react-redux@9.3.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@standard-schema/utils': 0.3.0
+      immer: 11.1.8
+      redux: 5.0.1
+      redux-thunk: 3.1.0(redux@5.0.1)
+      reselect: 5.1.1
+    optionalDependencies:
+      react: 19.2.5
+      react-redux: 9.3.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
+
   '@rolldown/pluginutils@1.0.0-rc.3': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.2':
@@ -3435,6 +3600,10 @@ snapshots:
     optional: true
 
   '@sindresorhus/is@4.6.0': {}
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@standard-schema/utils@0.3.0': {}
 
   '@szmarczak/http-timer@4.0.6':
     dependencies:
@@ -3552,6 +3721,30 @@ snapshots:
       '@types/node': 22.19.17
       '@types/responselike': 1.0.3
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -3591,6 +3784,8 @@ snapshots:
   '@types/responselike@1.0.3':
     dependencies:
       '@types/node': 22.19.17
+
+  '@types/use-sync-external-store@0.0.6': {}
 
   '@types/verror@1.10.11':
     optional: true
@@ -3881,9 +4076,49 @@ snapshots:
 
   csstype@3.2.3: {}
 
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  decimal.js-light@2.5.1: {}
 
   decompress-response@6.0.0:
     dependencies:
@@ -4074,6 +4309,8 @@ snapshots:
       has-tostringtag: 1.0.2
       hasown: 2.0.3
 
+  es-toolkit@1.46.1: {}
+
   es6-error@4.1.1:
     optional: true
 
@@ -4164,6 +4401,8 @@ snapshots:
 
   escape-string-regexp@4.0.0:
     optional: true
+
+  eventemitter3@5.0.4: {}
 
   expand-template@2.0.3: {}
 
@@ -4400,6 +4639,10 @@ snapshots:
 
   ieee754@1.2.1: {}
 
+  immer@10.2.0: {}
+
+  immer@11.1.8: {}
+
   inflight@1.0.6:
     dependencies:
       once: 1.4.0
@@ -4408,6 +4651,8 @@ snapshots:
   inherits@2.0.4: {}
 
   ini@1.3.8: {}
+
+  internmap@2.0.3: {}
 
   is-fullwidth-code-point@3.0.0: {}
 
@@ -4753,6 +4998,17 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       typescript: 5.9.3
 
+  react-is@19.2.6: {}
+
+  react-redux@9.3.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1):
+    dependencies:
+      '@types/use-sync-external-store': 0.0.6
+      react: 19.2.5
+      use-sync-external-store: 1.6.0(react@19.2.5)
+    optionalDependencies:
+      '@types/react': 19.2.14
+      redux: 5.0.1
+
   react-refresh@0.18.0: {}
 
   react-resizable-panels@4.11.0(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
@@ -4788,11 +5044,39 @@ snapshots:
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
 
+  recharts@3.8.1(@types/react@19.2.14)(react-dom@19.2.5(react@19.2.5))(react-is@19.2.6)(react@19.2.5)(redux@5.0.1):
+    dependencies:
+      '@reduxjs/toolkit': 2.12.0(react-redux@9.3.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1))(react@19.2.5)
+      clsx: 2.1.1
+      decimal.js-light: 2.5.1
+      es-toolkit: 1.46.1
+      eventemitter3: 5.0.4
+      immer: 10.2.0
+      react: 19.2.5
+      react-dom: 19.2.5(react@19.2.5)
+      react-is: 19.2.6
+      react-redux: 9.3.0(@types/react@19.2.14)(react@19.2.5)(redux@5.0.1)
+      reselect: 5.1.1
+      tiny-invariant: 1.3.3
+      use-sync-external-store: 1.6.0(react@19.2.5)
+      victory-vendor: 37.3.6
+    transitivePeerDependencies:
+      - '@types/react'
+      - redux
+
+  redux-thunk@3.1.0(redux@5.0.1):
+    dependencies:
+      redux: 5.0.1
+
+  redux@5.0.1: {}
+
   require-directory@2.1.1: {}
 
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
+
+  reselect@5.1.1: {}
 
   resolve-alpn@1.2.1: {}
 
@@ -4997,6 +5281,8 @@ snapshots:
     dependencies:
       semver: 5.7.2
 
+  tiny-invariant@1.3.3: {}
+
   tinyglobby@0.2.16:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -5062,6 +5348,23 @@ snapshots:
       core-util-is: 1.0.2
       extsprintf: 1.4.1
     optional: true
+
+  victory-vendor@37.3.6:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
 
   vite@7.3.2(@types/node@22.19.17)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:

--- a/src/main/database/repositories/registry.ts
+++ b/src/main/database/repositories/registry.ts
@@ -1,8 +1,10 @@
 import type { getDb } from '../connection'
 import { DictionaryRepository } from './dictionary.repo'
 import { LanguageRepository } from './language.repo'
-import { ModMetaRepository } from './mod-meta.repo'
 import { ModRepository } from './mod.repo'
+import { ModMetaRepository } from './mod-meta.repo'
+import { TranslationRunRepository } from './translation-run.repo'
+import { TranslationUsageRepository } from './translation-usage.repo'
 
 type AppDb = ReturnType<typeof getDb>
 
@@ -12,6 +14,8 @@ export interface RepositoryRegistry {
   language: LanguageRepository
   mod: ModRepository
   modMeta: ModMetaRepository
+  translationUsage: TranslationUsageRepository
+  translationRun: TranslationRunRepository
 }
 
 export function createRepositoryRegistry(db: AppDb): RepositoryRegistry {
@@ -20,6 +24,8 @@ export function createRepositoryRegistry(db: AppDb): RepositoryRegistry {
     dictionary: new DictionaryRepository(db),
     language: new LanguageRepository(db),
     mod: new ModRepository(db),
-    modMeta: new ModMetaRepository(db)
+    modMeta: new ModMetaRepository(db),
+    translationUsage: new TranslationUsageRepository(db),
+    translationRun: new TranslationRunRepository(db)
   }
 }

--- a/src/main/database/repositories/translation-run.repo.ts
+++ b/src/main/database/repositories/translation-run.repo.ts
@@ -1,0 +1,120 @@
+import { and, desc, gte, lte, type SQL, sql } from 'drizzle-orm'
+import type { drizzle } from 'drizzle-orm/better-sqlite3'
+import { type NewTranslationRun, type TranslationRun, translationRun } from '../schema'
+
+type AppDb = ReturnType<typeof drizzle>
+
+export interface ListRecentParams {
+  limit: number
+  service?: TranslationRun['service']
+  from?: string
+  to?: string
+}
+
+export interface AggregateByDayParams {
+  from: string
+  to: string
+  service?: TranslationRun['service']
+}
+
+export interface DayAggregate {
+  date: string
+  entries: number
+  chars: number
+  runs: number
+}
+
+export interface AggregateByModParams {
+  from: string
+  to: string
+  service?: TranslationRun['service']
+}
+
+export interface ModAggregate {
+  modName: string | null
+  entries: number
+  runs: number
+}
+
+export class TranslationRunRepository {
+  constructor(private db: AppDb) {}
+
+  create(input: NewTranslationRun): TranslationRun {
+    return this.db.insert(translationRun).values(input).returning().get() as TranslationRun
+  }
+
+  listRecent(params: ListRecentParams): TranslationRun[] {
+    const conditions = this.buildConditions(params.service, params.from, params.to)
+
+    const query =
+      conditions.length > 0
+        ? this.db
+            .select()
+            .from(translationRun)
+            .where(and(...conditions))
+            .orderBy(desc(translationRun.finishedAt))
+            .limit(params.limit)
+        : this.db
+            .select()
+            .from(translationRun)
+            .orderBy(desc(translationRun.finishedAt))
+            .limit(params.limit)
+
+    return query.all() as TranslationRun[]
+  }
+
+  aggregateByDay(params: AggregateByDayParams): DayAggregate[] {
+    const conditions = this.buildConditions(params.service, params.from, params.to)
+
+    const baseQuery = this.db
+      .select({
+        date: sql<string>`date(${translationRun.finishedAt})`,
+        entries: sql<number>`sum(${translationRun.entriesTranslated})`,
+        chars: sql<number>`sum(${translationRun.charsConsumed})`,
+        runs: sql<number>`count(*)`
+      })
+      .from(translationRun)
+
+    const query =
+      conditions.length > 0
+        ? baseQuery
+            .where(and(...conditions))
+            .groupBy(sql`date(${translationRun.finishedAt})`)
+            .orderBy(sql`date(${translationRun.finishedAt})`)
+        : baseQuery
+            .groupBy(sql`date(${translationRun.finishedAt})`)
+            .orderBy(sql`date(${translationRun.finishedAt})`)
+
+    return query.all() as DayAggregate[]
+  }
+
+  aggregateByMod(params: AggregateByModParams): ModAggregate[] {
+    const conditions = this.buildConditions(params.service, params.from, params.to)
+
+    const baseQuery = this.db
+      .select({
+        modName: translationRun.modName,
+        entries: sql<number>`sum(${translationRun.entriesTranslated})`,
+        runs: sql<number>`count(*)`
+      })
+      .from(translationRun)
+
+    const query =
+      conditions.length > 0
+        ? baseQuery
+            .where(and(...conditions))
+            .groupBy(translationRun.modName)
+            .orderBy(desc(sql`count(*)`))
+        : baseQuery.groupBy(translationRun.modName).orderBy(desc(sql`count(*)`))
+
+    return query.all() as ModAggregate[]
+  }
+
+  private buildConditions(service?: TranslationRun['service'], from?: string, to?: string): SQL[] {
+    const conditions: SQL[] = []
+    if (service) conditions.push(sql`${translationRun.service} = ${service}`)
+    if (from) conditions.push(gte(translationRun.finishedAt, from) as SQL)
+    if (to) conditions.push(lte(translationRun.finishedAt, to) as SQL)
+    return conditions
+  }
+}

--- a/src/main/database/repositories/translation-usage.repo.ts
+++ b/src/main/database/repositories/translation-usage.repo.ts
@@ -1,0 +1,119 @@
+import { eq, sql } from 'drizzle-orm'
+import type { drizzle } from 'drizzle-orm/better-sqlite3'
+import { type TranslationUsage, translationUsage } from '../schema'
+
+type AppDb = ReturnType<typeof drizzle>
+type Service = 'deepl' | 'google'
+
+export interface UpsertDefaultsOptions {
+  charLimit: number
+  renewalAt: string
+}
+
+export class TranslationUsageRepository {
+  constructor(private db: AppDb) {}
+
+  findByService(service: Service): TranslationUsage | undefined {
+    return this.db
+      .select()
+      .from(translationUsage)
+      .where(eq(translationUsage.service, service))
+      .get() as TranslationUsage | undefined
+  }
+
+  // Insert with supplied defaults if missing; return existing row as-is if present.
+  upsertDefaults(service: Service, options: UpsertDefaultsOptions): TranslationUsage {
+    const existing = this.findByService(service)
+    if (existing) return existing
+
+    this.db
+      .insert(translationUsage)
+      .values({
+        service,
+        charLimit: options.charLimit,
+        renewalAt: options.renewalAt,
+        consumedChars: 0
+      })
+      .run()
+
+    return this.findByService(service) as TranslationUsage
+  }
+
+  setLimit(service: Service, charLimit: number): TranslationUsage {
+    this.db
+      .update(translationUsage)
+      .set({ charLimit, updatedAt: sql`(datetime('now'))` })
+      .where(eq(translationUsage.service, service))
+      .run()
+
+    return this.findByService(service) as TranslationUsage
+  }
+
+  setRenewalAt(service: Service, renewalAt: string): TranslationUsage {
+    this.db
+      .update(translationUsage)
+      .set({ renewalAt, updatedAt: sql`(datetime('now'))` })
+      .where(eq(translationUsage.service, service))
+      .run()
+
+    return this.findByService(service) as TranslationUsage
+  }
+
+  // Allow zero; throw on negative.
+  setConsumed(service: Service, consumedChars: number): TranslationUsage {
+    if (consumedChars < 0) {
+      throw new Error(`consumedChars must be >= 0, got ${consumedChars}`)
+    }
+
+    this.db
+      .update(translationUsage)
+      .set({ consumedChars, updatedAt: sql`(datetime('now'))` })
+      .where(eq(translationUsage.service, service))
+      .run()
+
+    return this.findByService(service) as TranslationUsage
+  }
+
+  // Atomically increment consumed_chars. Throw on negative delta.
+  addConsumed(service: Service, delta: number): TranslationUsage {
+    if (delta < 0) {
+      throw new Error(`delta must be >= 0, got ${delta}`)
+    }
+
+    return this.db.transaction((tx) => {
+      tx.update(translationUsage)
+        .set({
+          consumedChars: sql`${translationUsage.consumedChars} + ${delta}`,
+          updatedAt: sql`(datetime('now'))`
+        })
+        .where(eq(translationUsage.service, service))
+        .run()
+
+      return tx
+        .select()
+        .from(translationUsage)
+        .where(eq(translationUsage.service, service))
+        .get() as TranslationUsage
+    })
+  }
+
+  // Reset consumed to 0 and advance the renewal date, atomically.
+  reset(service: Service, nextRenewalAt: string): TranslationUsage {
+    return this.db.transaction((tx) => {
+      tx.update(translationUsage)
+        .set({
+          consumedChars: 0,
+          renewalAt: nextRenewalAt,
+          updatedAt: sql`(datetime('now'))`
+        })
+        .where(eq(translationUsage.service, service))
+        .run()
+
+      return tx
+        .select()
+        .from(translationUsage)
+        .where(eq(translationUsage.service, service))
+        .get() as TranslationUsage
+    })
+  }
+}

--- a/src/main/database/schema.ts
+++ b/src/main/database/schema.ts
@@ -91,9 +91,47 @@ export const config = sqliteTable('config', {
   value: text('value')
 })
 
+export const translationUsage = sqliteTable('translation_usage', {
+  service: text('service').primaryKey(),
+  consumedChars: integer('consumed_chars').notNull().default(0),
+  charLimit: integer('char_limit').notNull().default(500000),
+  renewalAt: text('renewal_at').notNull(),
+  ...timestamps
+})
+
+export const translationRun = sqliteTable(
+  'translation_run',
+  {
+    id: integer('id').primaryKey({ autoIncrement: true }),
+    jobId: text('job_id'),
+    service: text('service').notNull(),
+    modName: text('mod_name').references(() => mod.name),
+    sourceLang: text('source_lang').notNull(),
+    targetLang: text('target_lang').notNull(),
+    entriesTotal: integer('entries_total').notNull().default(0),
+    entriesTranslated: integer('entries_translated').notNull().default(0),
+    charsConsumed: integer('chars_consumed').notNull().default(0),
+    startedAt: text('started_at').notNull(),
+    finishedAt: text('finished_at').notNull(),
+    ...timestamps
+  },
+  (table) => ({
+    translation_run_finished_idx: index('translation_run_finished_idx').on(table.finishedAt),
+    translation_run_service_finished_idx: index('translation_run_service_finished_idx').on(
+      table.service,
+      table.finishedAt
+    ),
+    translation_run_mod_idx: index('translation_run_mod_idx').on(table.modName)
+  })
+)
+
 export type Language = typeof language.$inferSelect
 export type Mod = typeof mod.$inferSelect
 export type ModMeta = typeof modMeta.$inferSelect
 export type NewModMeta = typeof modMeta.$inferInsert
 export type DictionaryEntry = typeof dictionary.$inferSelect
 export type NewDictionaryEntry = typeof dictionary.$inferInsert
+export type TranslationUsage = typeof translationUsage.$inferSelect
+export type NewTranslationUsage = typeof translationUsage.$inferInsert
+export type TranslationRun = typeof translationRun.$inferSelect
+export type NewTranslationRun = typeof translationRun.$inferInsert

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -73,7 +73,7 @@ app.whenReady().then(() => {
   const usageService = createUsageService(repos)
 
   registerWindowHandlers(getWindow)
-  registerTranslationHandlers(getWindow)
+  registerTranslationHandlers(getWindow, repos, usageService)
   registerDictionaryHandlers(repos)
   registerLanguageHandlers(repos)
   registerLogHandlers()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -11,11 +11,13 @@ import { registerFsHandlers } from './ipc/fs.ipc'
 import { registerLanguageHandlers } from './ipc/language.ipc'
 import { registerLogHandlers } from './ipc/log.ipc'
 import { registerMergeHandlers } from './ipc/merge.ipc'
+import { registerMetricsHandlers } from './ipc/metrics.ipc'
 import { registerModHandlers } from './ipc/mod.ipc'
 import { registerTranslationHandlers } from './ipc/translation.ipc'
 import { registerWindowHandlers, setupWindowEvents } from './ipc/window.ipc'
 import { registerXmlHandlers } from './ipc/xml.ipc'
 import { logError } from './services/log.service'
+import { createUsageService } from './services/usage.service'
 
 let mainWindow: BrowserWindow | null = null
 
@@ -68,6 +70,8 @@ app.whenReady().then(() => {
     optimizer.watchWindowShortcuts(window)
   })
 
+  const usageService = createUsageService(repos)
+
   registerWindowHandlers(getWindow)
   registerTranslationHandlers(getWindow)
   registerDictionaryHandlers(repos)
@@ -75,6 +79,7 @@ app.whenReady().then(() => {
   registerLogHandlers()
   registerModHandlers(repos)
   registerMergeHandlers(repos)
+  registerMetricsHandlers(repos, usageService)
   registerConfigHandlers()
   registerFsHandlers()
   registerXmlHandlers(repos)

--- a/src/main/ipc/metrics.ipc.ts
+++ b/src/main/ipc/metrics.ipc.ts
@@ -1,0 +1,131 @@
+import { ipcMain } from 'electron'
+import type { RepositoryRegistry } from '../database/repositories/registry'
+import { logError } from '../services/log.service'
+import type { Service, UsageService } from '../services/usage.service'
+
+const VALID_SERVICES: Service[] = ['deepl', 'google']
+
+function assertService(value: unknown): asserts value is Service {
+  if (!VALID_SERVICES.includes(value as Service)) {
+    throw new Error('invalid service')
+  }
+}
+
+function assertDate(value: unknown, field: string): void {
+  if (typeof value !== 'string' || Number.isNaN(new Date(value).getTime())) {
+    throw new Error(`invalid date: ${field}`)
+  }
+}
+
+export function registerMetricsHandlers(repos: RepositoryRegistry, usage: UsageService): void {
+  ipcMain.handle('metrics:getUsage', (_event, payload: { service: Service }) => {
+    try {
+      assertService(payload?.service)
+      return usage.getUsage(payload.service)
+    } catch (err) {
+      logError('metrics.getUsage', err, payload)
+      throw err
+    }
+  })
+
+  ipcMain.handle('metrics:getAllUsage', (_event) => {
+    try {
+      return [usage.getUsage('deepl'), usage.getUsage('google')]
+    } catch (err) {
+      logError('metrics.getAllUsage', err)
+      throw err
+    }
+  })
+
+  ipcMain.handle('metrics:setLimit', (_event, payload: { service: Service; charLimit: number }) => {
+    try {
+      assertService(payload?.service)
+      return usage.setLimit(payload.service, payload.charLimit)
+    } catch (err) {
+      logError('metrics.setLimit', err, payload)
+      throw err
+    }
+  })
+
+  ipcMain.handle(
+    'metrics:setRenewalAt',
+    (_event, payload: { service: Service; renewalAt: string }) => {
+      try {
+        assertService(payload?.service)
+        assertDate(payload?.renewalAt, 'renewalAt')
+        return usage.setRenewalAt(payload.service, payload.renewalAt)
+      } catch (err) {
+        logError('metrics.setRenewalAt', err, payload)
+        throw err
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'metrics:setConsumed',
+    (_event, payload: { service: Service; consumedChars: number }) => {
+      try {
+        assertService(payload?.service)
+        usage.setConsumed(payload.service, payload.consumedChars)
+        return { success: true }
+      } catch (err) {
+        logError('metrics.setConsumed', err, payload)
+        throw err
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'metrics:listRuns',
+    (_event, payload?: { limit?: number; service?: Service; from?: string; to?: string }) => {
+      try {
+        const { limit = 50, service, from, to } = payload ?? {}
+        if (service !== undefined) assertService(service)
+        if (from !== undefined) assertDate(from, 'from')
+        if (to !== undefined) assertDate(to, 'to')
+        return repos.translationRun.listRecent({ limit, service, from, to })
+      } catch (err) {
+        logError('metrics.listRuns', err, payload)
+        throw err
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'metrics:aggregateByDay',
+    (_event, payload: { from: string; to: string; service?: Service }) => {
+      try {
+        assertDate(payload?.from, 'from')
+        assertDate(payload?.to, 'to')
+        if (payload?.service !== undefined) assertService(payload.service)
+        return repos.translationRun.aggregateByDay({
+          from: payload.from,
+          to: payload.to,
+          service: payload.service
+        })
+      } catch (err) {
+        logError('metrics.aggregateByDay', err, payload)
+        throw err
+      }
+    }
+  )
+
+  ipcMain.handle(
+    'metrics:aggregateByMod',
+    (_event, payload: { from: string; to: string; service?: Service }) => {
+      try {
+        assertDate(payload?.from, 'from')
+        assertDate(payload?.to, 'to')
+        if (payload?.service !== undefined) assertService(payload.service)
+        return repos.translationRun.aggregateByMod({
+          from: payload.from,
+          to: payload.to,
+          service: payload.service
+        })
+      } catch (err) {
+        logError('metrics.aggregateByMod', err, payload)
+        throw err
+      }
+    }
+  )
+}

--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -77,9 +77,10 @@ function gateQuota(
     let acc = 0
     allowedEntries = 0
     for (const e of entries) {
-      if (acc + e.source.length > remaining) break
-      acc += e.source.length
-      allowedEntries++
+      if (acc + e.source.length <= remaining) {
+        acc += e.source.length
+        allowedEntries++
+      }
     }
   }
   throw new QuotaExceededError(service, remaining, requestedChars, allowedEntries)

--- a/src/main/ipc/translation.ipc.ts
+++ b/src/main/ipc/translation.ipc.ts
@@ -1,7 +1,8 @@
-import { randomUUID } from 'crypto'
+import { randomUUID } from 'node:crypto'
 import { eq } from 'drizzle-orm'
 import { type BrowserWindow, ipcMain } from 'electron'
 import { getDb } from '../database/connection'
+import type { RepositoryRegistry } from '../database/repositories/registry'
 import { config } from '../database/schema'
 import type { PipelineOptions } from '../pipelines/base.pipeline'
 import {
@@ -15,6 +16,7 @@ import {
 import { logError } from '../services/log.service'
 import { translateText as translateOpenAI } from '../services/openai.service'
 import { runTranslatePipeline, type TranslatePipelineParams } from '../services/translate.service'
+import type { UsageService } from '../services/usage.service'
 import { decodeEntities } from '../services/xml-entities.service'
 import { getActiveWindow } from '../utils/window'
 
@@ -44,12 +46,50 @@ interface BatchJobContext extends BatchPayload {
   apiKey: string
   signal: AbortSignal
   getWindow: () => BrowserWindow | null
+  charAcc: { value: number }
 }
 
 // Active jobs keyed by jobId - cancel() sends cancel message to the worker
 const activeJobs = new Map<string, { cancel: () => void }>()
 
-export function registerTranslationHandlers(getWindow: () => BrowserWindow | null): void {
+class QuotaExceededError extends Error {
+  constructor(
+    public readonly service: 'deepl' | 'google',
+    public readonly remaining: number,
+    public readonly requested: number,
+    public readonly allowedEntries?: number
+  ) {
+    super(JSON.stringify({ code: 'QUOTA_EXCEEDED', service, remaining, requested, allowedEntries }))
+    this.name = 'QuotaExceededError'
+  }
+}
+
+function gateQuota(
+  service: 'deepl' | 'google',
+  requestedChars: number,
+  usage: UsageService,
+  entries?: { source: string }[]
+): void {
+  const remaining = usage.getRemaining(service)
+  if (requestedChars <= remaining) return
+  let allowedEntries: number | undefined
+  if (entries) {
+    let acc = 0
+    allowedEntries = 0
+    for (const e of entries) {
+      if (acc + e.source.length > remaining) break
+      acc += e.source.length
+      allowedEntries++
+    }
+  }
+  throw new QuotaExceededError(service, remaining, requestedChars, allowedEntries)
+}
+
+export function registerTranslationHandlers(
+  getWindow: () => BrowserWindow | null,
+  repos: RepositoryRegistry,
+  usage: UsageService
+): void {
   ipcMain.handle('translation:start', async (_event, payload: TranslationStartPayload) => {
     try {
       requirePayloadApiKey(payload)
@@ -63,6 +103,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
       throw err
     }
     const jobId = randomUUID()
+    const startedAt = new Date().toISOString()
 
     const { cancel } = runTranslatePipeline({
       jobId,
@@ -76,6 +117,26 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
       },
       onDone: ({ outputPath }) => {
         activeJobs.delete(jobId)
+        const finishedAt = new Date().toISOString()
+        const service = payload.provider
+        if (service === 'deepl' || service === 'google') {
+          try {
+            repos.translationRun.create({
+              jobId,
+              service,
+              modName: payload.modName ?? null,
+              sourceLang: payload.sourceLang,
+              targetLang: payload.targetLang,
+              entriesTotal: 0,
+              entriesTranslated: 0,
+              charsConsumed: 0,
+              startedAt,
+              finishedAt
+            })
+          } catch (runErr) {
+            logError('translation.start.recordRun', runErr, { jobId, service })
+          }
+        }
         const win = getActiveWindow(getWindow)
         if (win) {
           win.webContents.send('translation:done', { jobId, outputPath })
@@ -121,13 +182,24 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         const { provider, text, sourceLang, targetLang } = payload
         const apiKey = requireStoredApiKey(provider)
         if (provider === 'deepl') {
-          return decodeEntities(await translateDeepL(text, sourceLang, targetLang, apiKey))
+          gateQuota('deepl', text.length, usage)
+          return decodeEntities(
+            await translateDeepL(text, sourceLang, targetLang, apiKey, undefined, undefined, (n) =>
+              usage.consume('deepl', n)
+            )
+          )
         }
         if (provider === 'google') {
-          return decodeEntities(await translateGoogle(text, sourceLang, targetLang, apiKey))
+          gateQuota('google', text.length, usage)
+          return decodeEntities(
+            await translateGoogle(text, sourceLang, targetLang, apiKey, undefined, (n) =>
+              usage.consume('google', n)
+            )
+          )
         }
         return decodeEntities(await translateOpenAI(text, sourceLang, targetLang, apiKey))
       } catch (err) {
+        if (err instanceof QuotaExceededError) throw err
         logError('translation.single', err, {
           provider: payload.provider,
           sourceLang: payload.sourceLang,
@@ -141,7 +213,7 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
   ipcMain.handle(
     'translation:batch',
     async (_event, payload: BatchPayload): Promise<{ jobId: string }> => {
-      const { provider, sourceLang, targetLang } = payload
+      const { provider, sourceLang, targetLang, entries } = payload
       let apiKey: string
       try {
         apiKey = requireStoredApiKey(provider)
@@ -150,17 +222,33 @@ export function registerTranslationHandlers(getWindow: () => BrowserWindow | nul
         throw err
       }
 
+      if (provider === 'deepl' || provider === 'google') {
+        const totalChars = entries.reduce((s, e) => s + e.source.length, 0)
+        try {
+          gateQuota(provider, totalChars, usage, entries)
+        } catch (err) {
+          if (err instanceof QuotaExceededError) throw err
+          throw err
+        }
+      }
+
       const jobId = randomUUID()
       const controller = new AbortController()
+      const charAcc = { value: 0 }
       activeJobs.set(jobId, { cancel: () => controller.abort() })
 
-      void runBatchJob({
-        ...payload,
-        jobId,
-        apiKey,
-        signal: controller.signal,
-        getWindow
-      }).finally(() => {
+      void runBatchJob(
+        {
+          ...payload,
+          jobId,
+          apiKey,
+          signal: controller.signal,
+          getWindow,
+          charAcc
+        },
+        repos,
+        usage
+      ).finally(() => {
         activeJobs.delete(jobId)
       })
 
@@ -217,24 +305,51 @@ async function runConcurrent<T>(
   await Promise.all(workers)
 }
 
-async function runBatchJob(ctx: BatchJobContext): Promise<void> {
+async function runBatchJob(
+  ctx: BatchJobContext,
+  repos: RepositoryRegistry,
+  usage: UsageService
+): Promise<void> {
   const summary: BatchSummary = {
     total: ctx.entries.length,
     translated: 0,
     failed: 0
   }
+  const startedAt = new Date().toISOString()
 
   try {
     if (ctx.provider === 'deepl') {
-      await runDeepLBatchJob(ctx, summary)
+      await runDeepLBatchJob(ctx, summary, usage)
     } else if (ctx.provider === 'google') {
-      await runGoogleBatchJob(ctx, summary)
+      await runGoogleBatchJob(ctx, summary, usage)
     } else {
       await runOpenAIBatchJob(ctx, summary)
     }
 
     if (ctx.signal.aborted) {
       summary.failed = summary.total - summary.translated
+    }
+
+    if (ctx.provider === 'deepl' || ctx.provider === 'google') {
+      try {
+        repos.translationRun.create({
+          jobId: ctx.jobId,
+          service: ctx.provider,
+          modName: null,
+          sourceLang: ctx.sourceLang,
+          targetLang: ctx.targetLang,
+          entriesTotal: summary.total,
+          entriesTranslated: summary.translated,
+          charsConsumed: ctx.charAcc.value,
+          startedAt,
+          finishedAt: new Date().toISOString()
+        })
+      } catch (runErr) {
+        logError('translation.batch.recordRun', runErr, {
+          jobId: ctx.jobId,
+          provider: ctx.provider
+        })
+      }
     }
 
     emitBatchDone(ctx.getWindow, {
@@ -245,6 +360,29 @@ async function runBatchJob(ctx: BatchJobContext): Promise<void> {
   } catch (err) {
     if (isAbortError(err) || ctx.signal.aborted) {
       summary.failed = summary.total - summary.translated
+
+      if (ctx.provider === 'deepl' || ctx.provider === 'google') {
+        try {
+          repos.translationRun.create({
+            jobId: ctx.jobId,
+            service: ctx.provider,
+            modName: null,
+            sourceLang: ctx.sourceLang,
+            targetLang: ctx.targetLang,
+            entriesTotal: summary.total,
+            entriesTranslated: summary.translated,
+            charsConsumed: ctx.charAcc.value,
+            startedAt,
+            finishedAt: new Date().toISOString()
+          })
+        } catch (runErr) {
+          logError('translation.batch.recordRun.cancelled', runErr, {
+            jobId: ctx.jobId,
+            provider: ctx.provider
+          })
+        }
+      }
+
       emitBatchDone(ctx.getWindow, {
         jobId: ctx.jobId,
         ...summary,
@@ -267,7 +405,11 @@ async function runBatchJob(ctx: BatchJobContext): Promise<void> {
   }
 }
 
-async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Promise<void> {
+async function runDeepLBatchJob(
+  ctx: BatchJobContext,
+  summary: BatchSummary,
+  usage: UsageService
+): Promise<void> {
   let pendingEntries = [...ctx.entries]
 
   while (pendingEntries.length > 0) {
@@ -278,7 +420,11 @@ async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Pr
       ctx.sourceLang,
       ctx.targetLang,
       ctx.apiKey,
-      ctx.signal
+      ctx.signal,
+      (n) => {
+        ctx.charAcc.value += n
+        usage.consume('deepl', n)
+      }
     )
 
     let roundSuccesses = 0
@@ -339,7 +485,11 @@ async function runDeepLBatchJob(ctx: BatchJobContext, summary: BatchSummary): Pr
   }
 }
 
-async function runGoogleBatchJob(ctx: BatchJobContext, summary: BatchSummary): Promise<void> {
+async function runGoogleBatchJob(
+  ctx: BatchJobContext,
+  summary: BatchSummary,
+  usage: UsageService
+): Promise<void> {
   let pendingEntries = [...ctx.entries]
 
   while (pendingEntries.length > 0) {
@@ -350,7 +500,11 @@ async function runGoogleBatchJob(ctx: BatchJobContext, summary: BatchSummary): P
       ctx.sourceLang,
       ctx.targetLang,
       ctx.apiKey,
-      ctx.signal
+      ctx.signal,
+      (n) => {
+        ctx.charAcc.value += n
+        usage.consume('google', n)
+      }
     )
 
     let roundSuccesses = 0

--- a/src/main/services/deepl.service.ts
+++ b/src/main/services/deepl.service.ts
@@ -122,13 +122,16 @@ export async function translateBatchDetailed(
   sourceLang: string,
   targetLang: string,
   apiKey: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onChars?: (count: number) => void
 ): Promise<BatchTranslationResult[]> {
   const results: BatchTranslationResult[] = []
 
   for (let offset = 0; offset < texts.length; offset += DEEPL_CHUNK_SIZE) {
     const chunk = texts.slice(offset, offset + DEEPL_CHUNK_SIZE)
     try {
+      const chars = chunk.reduce((s, t) => s + t.length, 0)
+      onChars?.(chars)
       const translated = await translateProtectedChunkDetailed(
         chunk,
         sourceLang,
@@ -145,6 +148,7 @@ export async function translateBatchDetailed(
 
       for (let i = 0; i < chunk.length; i++) {
         try {
+          onChars?.(chunk[i].length)
           const translated = await translateText(
             chunk[i],
             sourceLang,
@@ -176,8 +180,10 @@ export async function translateText(
   targetLang: string,
   apiKey: string,
   context?: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onChars?: (count: number) => void
 ): Promise<string> {
+  onChars?.(text.length)
   const { protectedText, tags } = protectTags(text)
   const translated = await requestDeepL(
     [protectedText],

--- a/src/main/services/google.service.ts
+++ b/src/main/services/google.service.ts
@@ -26,8 +26,10 @@ export async function translateText(
   sourceLang: string,
   targetLang: string,
   apiKey: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onChars?: (count: number) => void
 ): Promise<string> {
+  onChars?.(text.length)
   const translated = await requestGoogle([text], sourceLang, targetLang, apiKey, signal)
   const first = translated[0]
   if (first == null) {
@@ -41,22 +43,26 @@ export async function translateBatchDetailed(
   sourceLang: string,
   targetLang: string,
   apiKey: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  onChars?: (count: number) => void
 ): Promise<BatchTranslationResult[]> {
   const results: BatchTranslationResult[] = []
 
   for (let offset = 0; offset < texts.length; offset += GOOGLE_CHUNK_SIZE) {
     const chunk = texts.slice(offset, offset + GOOGLE_CHUNK_SIZE)
     try {
+      const chars = chunk.reduce((s, t) => s + t.length, 0)
+      onChars?.(chars)
       const translated = await requestGoogle(chunk, sourceLang, targetLang, apiKey, signal)
       translated.forEach((value, i) => {
         results.push({ index: offset + i, translated: decodeEntities(value) })
       })
     } catch (err) {
+      const chars = chunk.reduce((s, t) => s + t.length, 0)
       logError('google.batch.chunk', err, {
         offset,
         size: chunk.length,
-        chars: chunk.reduce((s, t) => s + t.length, 0)
+        chars
       })
       if (isFatalBatchError(err)) {
         throw err
@@ -64,6 +70,7 @@ export async function translateBatchDetailed(
 
       for (let i = 0; i < chunk.length; i++) {
         try {
+          onChars?.(chunk[i].length)
           const translated = await translateText(chunk[i], sourceLang, targetLang, apiKey, signal)
           results.push({ index: offset + i, translated })
         } catch (entryErr) {

--- a/src/main/services/usage.service.ts
+++ b/src/main/services/usage.service.ts
@@ -1,0 +1,104 @@
+import type { RepositoryRegistry } from '../database/repositories/registry'
+import type { TranslationUsageRepository } from '../database/repositories/translation-usage.repo'
+import type { TranslationUsage } from '../database/schema'
+
+export type Service = 'deepl' | 'google'
+
+export type UsageRow = TranslationUsage
+
+const DEFAULT_CHAR_LIMIT = 500_000
+
+function defaultRenewalAt(): string {
+  return new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString()
+}
+
+// Advance an ISO UTC timestamp by exactly one calendar month.
+// The day is clamped to the last valid day of the target month
+// (e.g. Jan 31 -> Feb 28/29, Mar 31 -> Apr 30).
+export function advanceOneMonth(isoUtc: string): string {
+  const d = new Date(isoUtc)
+  const originalDay = d.getUTCDate()
+
+  d.setUTCMonth(d.getUTCMonth() + 1)
+
+  // If the day overflowed (e.g. Jan 31 -> Mar 3 in a non-leap year),
+  // set to 0 to get the last day of the intended month.
+  if (d.getUTCDate() < originalDay) {
+    d.setUTCDate(0)
+  }
+
+  return d.toISOString()
+}
+
+export class UsageService {
+  constructor(private repo: TranslationUsageRepository) {}
+
+  getUsage(service: Service): UsageRow {
+    this.applyRenewalIfDue(service)
+    return this.readOrInit(service)
+  }
+
+  setLimit(service: Service, charLimit: number): UsageRow {
+    if (charLimit <= 0) {
+      throw new Error(`charLimit must be > 0, got ${charLimit}`)
+    }
+    this.readOrInit(service)
+    return this.repo.setLimit(service, charLimit)
+  }
+
+  setRenewalAt(service: Service, isoUtc: string): UsageRow {
+    const parsed = new Date(isoUtc)
+    if (Number.isNaN(parsed.getTime())) {
+      throw new Error(`Invalid ISO date string: ${isoUtc}`)
+    }
+    this.readOrInit(service)
+    return this.repo.setRenewalAt(service, isoUtc)
+  }
+
+  setConsumed(service: Service, consumedChars: number): void {
+    if (consumedChars < 0) {
+      throw new Error(`consumedChars must be >= 0, got ${consumedChars}`)
+    }
+    this.readOrInit(service)
+    this.repo.setConsumed(service, consumedChars)
+  }
+
+  getRemaining(service: Service): number {
+    const row = this.getUsage(service)
+    return Math.max(0, row.charLimit - row.consumedChars)
+  }
+
+  consume(service: Service, chars: number): UsageRow {
+    if (chars < 0) {
+      throw new Error(`chars must be >= 0, got ${chars}`)
+    }
+    this.applyRenewalIfDue(service)
+    return this.repo.addConsumed(service, chars)
+  }
+
+  private applyRenewalIfDue(service: Service): void {
+    const row = this.readOrInit(service)
+    const now = Date.now()
+    const renewalTime = new Date(row.renewalAt).getTime()
+
+    if (now < renewalTime) return
+
+    let nextRenewal = row.renewalAt
+    while (new Date(nextRenewal).getTime() <= now) {
+      nextRenewal = advanceOneMonth(nextRenewal)
+    }
+
+    this.repo.reset(service, nextRenewal)
+  }
+
+  private readOrInit(service: Service): UsageRow {
+    return this.repo.upsertDefaults(service, {
+      charLimit: DEFAULT_CHAR_LIMIT,
+      renewalAt: defaultRenewalAt()
+    })
+  }
+}
+
+export function createUsageService(repos: RepositoryRegistry): UsageService {
+  return new UsageService(repos.translationUsage)
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -420,6 +420,69 @@ export interface LogApi {
   write(payload: LogPayload): Promise<{ success: boolean }>
 }
 
+export type MetricsService = 'deepl' | 'google'
+export type MetricsRunService = 'deepl' | 'google' | 'openai' | 'manual'
+
+export interface MetricsUsage {
+  service: MetricsService
+  consumedChars: number
+  charLimit: number
+  renewalAt: string
+  createdAt: string | null
+  updatedAt: string | null
+}
+
+export interface MetricsRun {
+  id: number
+  jobId: string | null
+  service: MetricsRunService
+  modName: string | null
+  sourceLang: string
+  targetLang: string
+  entriesTotal: number
+  entriesTranslated: number
+  charsConsumed: number
+  startedAt: string
+  finishedAt: string
+}
+
+export interface MetricsDailyBucket {
+  date: string
+  entries: number
+  chars: number
+  runs: number
+}
+
+export interface MetricsModBucket {
+  modName: string | null
+  entries: number
+  runs: number
+}
+
+export interface MetricsApi {
+  getUsage(payload: { service: MetricsService }): Promise<MetricsUsage>
+  getAllUsage(): Promise<MetricsUsage[]>
+  setLimit(payload: { service: MetricsService; charLimit: number }): Promise<MetricsUsage>
+  setRenewalAt(payload: { service: MetricsService; renewalAt: string }): Promise<MetricsUsage>
+  setConsumed(payload: { service: MetricsService; consumedChars: number }): Promise<MetricsUsage>
+  listRuns(payload?: {
+    limit?: number
+    service?: MetricsRunService
+    from?: string
+    to?: string
+  }): Promise<MetricsRun[]>
+  aggregateByDay(payload: {
+    from: string
+    to: string
+    service?: MetricsRunService
+  }): Promise<MetricsDailyBucket[]>
+  aggregateByMod(payload: {
+    from: string
+    to: string
+    service?: MetricsRunService
+  }): Promise<MetricsModBucket[]>
+}
+
 export interface AppApi {
   translation: TranslationApi
   dictionary: DictionaryApi
@@ -431,6 +494,7 @@ export interface AppApi {
   xml: XmlApi
   merge: MergeApi
   window: WindowApi
+  metrics: MetricsApi
 }
 
 export interface AppWindow {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -370,6 +370,40 @@ const api: AppApi = {
       stack?: string
       meta?: unknown
     }): Promise<{ success: boolean }> => ipcRenderer.invoke('log:write', payload)
+  },
+
+  metrics: {
+    getUsage: (payload: { service: import('./api-types').MetricsService }) =>
+      ipcRenderer.invoke('metrics:getUsage', payload),
+    getAllUsage: () => ipcRenderer.invoke('metrics:getAllUsage'),
+    setLimit: (payload: {
+      service: import('./api-types').MetricsService
+      charLimit: number
+    }) => ipcRenderer.invoke('metrics:setLimit', payload),
+    setRenewalAt: (payload: {
+      service: import('./api-types').MetricsService
+      renewalAt: string
+    }) => ipcRenderer.invoke('metrics:setRenewalAt', payload),
+    setConsumed: (payload: {
+      service: import('./api-types').MetricsService
+      consumedChars: number
+    }) => ipcRenderer.invoke('metrics:setConsumed', payload),
+    listRuns: (payload?: {
+      limit?: number
+      service?: import('./api-types').MetricsRunService
+      from?: string
+      to?: string
+    }) => ipcRenderer.invoke('metrics:listRuns', payload),
+    aggregateByDay: (payload: {
+      from: string
+      to: string
+      service?: import('./api-types').MetricsRunService
+    }) => ipcRenderer.invoke('metrics:aggregateByDay', payload),
+    aggregateByMod: (payload: {
+      from: string
+      to: string
+      service?: import('./api-types').MetricsRunService
+    }) => ipcRenderer.invoke('metrics:aggregateByMod', payload)
   }
 }
 

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -7,6 +7,7 @@ import { EntryEditPage } from './pages/EntryEditPage'
 import { ExtractPage } from './pages/ExtractPage'
 import { ManageModsPage } from './pages/ManageModsPage'
 import { MergeToolPage } from './pages/MergeToolPage'
+import { MetricsPage } from './pages/MetricsPage'
 import { PackagePage } from './pages/PackagePage'
 import { SettingsPage } from './pages/SettingsPage'
 import { TranslatePage } from './pages/TranslatePage'
@@ -33,6 +34,7 @@ function App(): React.JSX.Element {
           <Route path="/extract" element={<ExtractPage />} />
           <Route path="/package" element={<PackagePage />} />
           <Route path="/merge" element={<MergeToolPage />} />
+          <Route path="/metrics" element={<MetricsPage />} />
           <Route path="/settings" element={<SettingsPage />} />
         </Route>
       </Routes>

--- a/src/renderer/src/components/layout/Sidebar.tsx
+++ b/src/renderer/src/components/layout/Sidebar.tsx
@@ -1,4 +1,4 @@
-import { BookOpen, Boxes, Languages, Merge, Package, PackageOpen, Settings } from 'lucide-react'
+import { BarChart3, BookOpen, Boxes, Languages, Merge, Package, PackageOpen, Settings } from 'lucide-react'
 import { NavLink } from 'react-router-dom'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { cn } from '@/lib/utils'
@@ -9,7 +9,8 @@ const NAV_ITEMS = [
   { to: '/mods', icon: Boxes, labelKey: 'mods', kbd: 'Ctrl 3' },
   { to: '/merge', icon: Merge, labelKey: 'merge', kbd: 'Ctrl 4' },
   { to: '/extract', icon: PackageOpen, labelKey: 'extract', kbd: 'Ctrl 5' },
-  { to: '/package', icon: Package, labelKey: 'package', kbd: 'Ctrl 6' }
+  { to: '/package', icon: Package, labelKey: 'package', kbd: 'Ctrl 6' },
+  { to: '/metrics', icon: BarChart3, labelKey: 'metrics', kbd: 'Ctrl 8' }
 ] as const
 
 const FOOTER_ITEMS = [

--- a/src/renderer/src/components/metrics/MetricsCharts.tsx
+++ b/src/renderer/src/components/metrics/MetricsCharts.tsx
@@ -1,0 +1,188 @@
+import { useMemo } from 'react'
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Line,
+  LineChart,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis
+} from 'recharts'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsDailyBucket, MetricsModBucket } from '@/types'
+
+interface MetricsChartsProps {
+  daily: MetricsDailyBucket[]
+  byMod: MetricsModBucket[]
+  from: string
+  to: string
+  loading: boolean
+}
+
+// Generate all ISO date strings (YYYY-MM-DD) in [from, to] inclusive
+function buildDateRange(from: string, to: string): string[] {
+  const dates: string[] = []
+  const cur = new Date(from)
+  const end = new Date(to)
+  while (cur <= end) {
+    dates.push(cur.toISOString().slice(0, 10))
+    cur.setDate(cur.getDate() + 1)
+  }
+  return dates
+}
+
+// Merge daily data with gap-filled zero rows
+function fillDailyGaps(
+  daily: MetricsDailyBucket[],
+  from: string,
+  to: string
+): MetricsDailyBucket[] {
+  const map = new Map<string, MetricsDailyBucket>()
+  for (const row of daily) {
+    map.set(row.date, row)
+  }
+  return buildDateRange(from, to).map(
+    (date) => map.get(date) ?? { date, entries: 0, chars: 0, runs: 0 }
+  )
+}
+
+const CHART_TOOLTIP_STYLE = {
+  backgroundColor: '#131518',
+  border: '1px solid #1f2329',
+  borderRadius: 8,
+  fontSize: 12,
+  color: '#d4d4d8'
+}
+
+function ChartCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="bg-[#141416] border border-neutral-800/80 rounded-xl overflow-hidden">
+      <div className="px-6 py-4 border-b border-neutral-800/50">
+        <h3 className="text-sm font-medium text-neutral-200">{title}</h3>
+      </div>
+      <div className="p-4">{children}</div>
+    </div>
+  )
+}
+
+export function MetricsCharts({
+  daily,
+  byMod,
+  from,
+  to,
+  loading
+}: MetricsChartsProps): React.JSX.Element {
+  const { t } = useAppTranslation('metrics')
+
+  const filledDaily = useMemo(() => fillDailyGaps(daily, from, to), [daily, from, to])
+
+  const hasData = daily.length > 0 || byMod.length > 0
+
+  if (loading) {
+    return (
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+        {[1, 2, 3].map((i) => (
+          <div
+            key={i}
+            className="bg-[#141416] border border-neutral-800/80 rounded-xl h-48 animate-pulse"
+          />
+        ))}
+      </div>
+    )
+  }
+
+  if (!hasData) {
+    return (
+      <div className="bg-[#141416] border border-neutral-800/80 rounded-xl p-12 text-center">
+        <p className="text-sm text-neutral-500">{t('runs.empty')}</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
+      <ChartCard title={t('charts.dailyChars.title')}>
+        <ResponsiveContainer width="100%" height={180}>
+          <LineChart data={filledDaily} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1f2329" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v: string) => v.slice(5)}
+            />
+            <YAxis tick={{ fontSize: 10, fill: '#71717a' }} tickLine={false} axisLine={false} />
+            <Tooltip contentStyle={CHART_TOOLTIP_STYLE} cursor={{ stroke: '#303641' }} />
+            <Line
+              type="monotone"
+              dataKey="chars"
+              stroke="#f59e0b"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4, fill: '#f59e0b' }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      <ChartCard title={t('charts.dailyEntries.title')}>
+        <ResponsiveContainer width="100%" height={180}>
+          <LineChart data={filledDaily} margin={{ top: 4, right: 8, left: -16, bottom: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" stroke="#1f2329" />
+            <XAxis
+              dataKey="date"
+              tick={{ fontSize: 10, fill: '#71717a' }}
+              tickLine={false}
+              axisLine={false}
+              tickFormatter={(v: string) => v.slice(5)}
+            />
+            <YAxis tick={{ fontSize: 10, fill: '#71717a' }} tickLine={false} axisLine={false} />
+            <Tooltip contentStyle={CHART_TOOLTIP_STYLE} cursor={{ stroke: '#303641' }} />
+            <Line
+              type="monotone"
+              dataKey="entries"
+              stroke="#a78bfa"
+              strokeWidth={2}
+              dot={false}
+              activeDot={{ r: 4, fill: '#a78bfa' }}
+            />
+          </LineChart>
+        </ResponsiveContainer>
+      </ChartCard>
+
+      <div className="lg:col-span-2">
+        <ChartCard title={t('charts.modsTranslated.title')}>
+          <ResponsiveContainer width="100%" height={180}>
+            <BarChart
+              data={byMod}
+              margin={{ top: 4, right: 8, left: -16, bottom: 0 }}
+              layout="vertical"
+            >
+              <CartesianGrid strokeDasharray="3 3" stroke="#1f2329" horizontal={false} />
+              <XAxis
+                type="number"
+                tick={{ fontSize: 10, fill: '#71717a' }}
+                tickLine={false}
+                axisLine={false}
+              />
+              <YAxis
+                type="category"
+                dataKey="modName"
+                tick={{ fontSize: 10, fill: '#71717a' }}
+                tickLine={false}
+                axisLine={false}
+                width={100}
+                tickFormatter={(v: string | null) => v ?? '(unknown)'}
+              />
+              <Tooltip contentStyle={CHART_TOOLTIP_STYLE} cursor={{ fill: '#1f2329' }} />
+              <Bar dataKey="entries" fill="#f59e0b" radius={[0, 4, 4, 0]} />
+            </BarChart>
+          </ResponsiveContainer>
+        </ChartCard>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/metrics/RecentRunsTable.tsx
+++ b/src/renderer/src/components/metrics/RecentRunsTable.tsx
@@ -1,0 +1,87 @@
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsRun } from '@/types'
+
+interface RecentRunsTableProps {
+  runs: MetricsRun[]
+  loading: boolean
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function RecentRunsTable({ runs, loading }: RecentRunsTableProps): React.JSX.Element {
+  const { t } = useAppTranslation('metrics')
+
+  if (loading) {
+    return (
+      <div className="bg-[#141416] border border-neutral-800/80 rounded-xl overflow-hidden">
+        <div className="px-6 py-4 border-b border-neutral-800/50">
+          <h2 className="text-sm font-medium text-neutral-200">{t('runs.section.title')}</h2>
+        </div>
+        <div className="p-8 flex justify-center">
+          <div className="h-5 w-5 rounded-full border-2 border-amber-500/30 border-t-amber-500 animate-spin" />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="bg-[#141416] border border-neutral-800/80 rounded-xl overflow-hidden">
+      <div className="px-6 py-4 border-b border-neutral-800/50">
+        <h2 className="text-sm font-medium text-neutral-200">{t('runs.section.title')}</h2>
+      </div>
+
+      {runs.length === 0 ? (
+        <div className="p-12 text-center">
+          <p className="text-sm text-neutral-500">{t('runs.empty')}</p>
+        </div>
+      ) : (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-neutral-800/50">
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                  {t('runs.column.date')}
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                  {t('runs.column.service')}
+                </th>
+                <th className="px-6 py-3 text-left text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                  {t('runs.column.mod')}
+                </th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                  {t('runs.column.entries')}
+                </th>
+                <th className="px-6 py-3 text-right text-xs font-medium text-neutral-500 uppercase tracking-wider">
+                  {t('runs.column.chars')}
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-neutral-800/50">
+              {runs.map((run) => (
+                <tr key={run.id} className="hover:bg-neutral-800/30 transition-colors">
+                  <td className="px-6 py-3 text-xs text-neutral-400 whitespace-nowrap">
+                    {new Date(run.finishedAt).toLocaleString()}
+                  </td>
+                  <td className="px-6 py-3 text-xs text-neutral-300 whitespace-nowrap">
+                    {capitalize(run.service)}
+                  </td>
+                  <td className="px-6 py-3 text-xs text-neutral-300 max-w-[160px] truncate">
+                    {run.modName ?? '-'}
+                  </td>
+                  <td className="px-6 py-3 text-xs text-neutral-300 text-right tabular-nums whitespace-nowrap">
+                    {run.entriesTranslated.toLocaleString()}
+                  </td>
+                  <td className="px-6 py-3 text-xs text-neutral-300 text-right tabular-nums whitespace-nowrap">
+                    {run.charsConsumed.toLocaleString()}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/renderer/src/components/metrics/UsageCard.tsx
+++ b/src/renderer/src/components/metrics/UsageCard.tsx
@@ -1,0 +1,67 @@
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsUsage } from '@/types'
+
+interface UsageCardProps {
+  usage: MetricsUsage
+  onEdit: () => void
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+export function UsageCard({ usage, onEdit }: UsageCardProps): React.JSX.Element {
+  const { t } = useAppTranslation('metrics')
+
+  const { service, consumedChars, charLimit, renewalAt } = usage
+  const pct = charLimit > 0 ? Math.min(100, (consumedChars / charLimit) * 100) : 0
+  const remaining = Math.max(0, charLimit - consumedChars)
+  const isOverLimit = consumedChars >= charLimit
+  const serviceName = capitalize(service)
+  const renewsOnFormatted = new Date(renewalAt).toLocaleDateString()
+
+  return (
+    <div className="flex-1 bg-[#141416] border border-neutral-800/80 rounded-xl overflow-hidden">
+      <div className="px-6 py-4 border-b border-neutral-800/50 flex items-center justify-between">
+        <h2 className="text-sm font-medium text-neutral-200">
+          {t('usage.card.title', { service: serviceName })}
+        </h2>
+        {isOverLimit && (
+          <span className="rounded-full bg-red-500/15 border border-red-500/30 px-2 py-0.5 text-xs font-medium text-red-400">
+            Limit reached
+          </span>
+        )}
+      </div>
+      <div className="p-6 flex flex-col gap-4">
+        <div className="text-2xl font-semibold text-neutral-100 tabular-nums">
+          {t('usage.card.consumedOfLimit', {
+            consumed: consumedChars.toLocaleString(),
+            limit: charLimit.toLocaleString()
+          })}
+        </div>
+
+        <div className="w-full h-2 rounded-full bg-neutral-800 overflow-hidden">
+          <div
+            className={`h-full rounded-full transition-all ${isOverLimit ? 'bg-red-500' : 'bg-amber-500'}`}
+            style={{ width: `${pct}%` }}
+          />
+        </div>
+
+        <div className="flex items-center justify-between text-xs text-neutral-400">
+          <span>{t('usage.card.remaining', { remaining: remaining.toLocaleString() })}</span>
+          <span>{t('usage.card.renewsOn', { date: renewsOnFormatted })}</span>
+        </div>
+
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onEdit}
+            className="text-xs font-medium text-amber-500 hover:text-amber-400 transition-colors"
+          >
+            {t('usage.card.editButton')}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/metrics/UsageEditDialog.tsx
+++ b/src/renderer/src/components/metrics/UsageEditDialog.tsx
@@ -1,0 +1,156 @@
+import { Pencil } from 'lucide-react'
+import { useState } from 'react'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsService, MetricsUsage } from '@/types'
+
+interface UsageEditDialogProps {
+  open: boolean
+  service: MetricsService
+  usage: MetricsUsage
+  onSave: (data: { charLimit: number; consumedChars: number; renewalAt: string }) => void
+  onClose: () => void
+}
+
+function capitalize(s: string): string {
+  return s.charAt(0).toUpperCase() + s.slice(1)
+}
+
+// Convert ISO UTC string to local datetime-local input value (YYYY-MM-DDTHH:MM)
+function isoToLocalInput(iso: string): string {
+  const d = new Date(iso)
+  const pad = (n: number) => String(n).padStart(2, '0')
+  return (
+    `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}` +
+    `T${pad(d.getHours())}:${pad(d.getMinutes())}`
+  )
+}
+
+export function UsageEditDialog({
+  open,
+  service,
+  usage,
+  onSave,
+  onClose
+}: UsageEditDialogProps): React.JSX.Element | null {
+  const { t } = useAppTranslation('metrics')
+  const serviceName = capitalize(service)
+
+  const [limitDraft, setLimitDraft] = useState(String(usage.charLimit))
+  const [consumedDraft, setConsumedDraft] = useState(String(usage.consumedChars))
+  const [renewalDraft, setRenewalDraft] = useState(isoToLocalInput(usage.renewalAt))
+  const [errors, setErrors] = useState<{ limit?: string; consumed?: string; renewal?: string }>({})
+
+  const validate = (): boolean => {
+    const next: typeof errors = {}
+    const limit = Number(limitDraft)
+    const consumed = Number(consumedDraft)
+
+    if (!limitDraft || Number.isNaN(limit) || limit <= 0) {
+      next.limit = t('usage.editDialog.invalidNumber')
+    }
+    if (consumedDraft === '' || Number.isNaN(consumed) || consumed < 0) {
+      next.consumed = t('usage.editDialog.invalidNumber')
+    }
+    if (!renewalDraft) {
+      next.renewal = t('usage.editDialog.invalidDate')
+    }
+
+    setErrors(next)
+    return Object.keys(next).length === 0
+  }
+
+  const handleSave = () => {
+    if (!validate()) return
+    onSave({
+      charLimit: Number(limitDraft),
+      consumedChars: Number(consumedDraft),
+      renewalAt: new Date(renewalDraft).toISOString()
+    })
+  }
+
+  const footer = (
+    <>
+      <button
+        type="button"
+        onClick={onClose}
+        className="rounded-md border border-neutral-700/50 bg-neutral-800 px-4 py-2 text-sm font-medium text-neutral-300 hover:bg-neutral-700 transition-colors"
+      >
+        {t('usage.editDialog.cancel')}
+      </button>
+      <button
+        type="button"
+        onClick={handleSave}
+        className="rounded-md bg-amber-500 px-4 py-2 text-sm font-medium text-black hover:bg-amber-400 transition-colors"
+      >
+        {t('usage.editDialog.save')}
+      </button>
+    </>
+  )
+
+  return (
+    <ModalShell
+      open={open}
+      title={t('usage.editDialog.title', { service: serviceName })}
+      icon={<Pencil size={16} />}
+      sizeClassName="max-w-md"
+      onClose={onClose}
+      footer={footer}
+    >
+      <div className="flex flex-col gap-5">
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="edit-char-limit" className="text-xs font-medium text-neutral-300">
+            {t('usage.editDialog.limitLabel')}
+          </label>
+          <input
+            id="edit-char-limit"
+            type="number"
+            min={1}
+            value={limitDraft}
+            onChange={(e) => {
+              setLimitDraft(e.target.value)
+              setErrors((prev) => ({ ...prev, limit: undefined }))
+            }}
+            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all"
+          />
+          {errors.limit && <p className="text-xs text-red-400">{errors.limit}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="edit-consumed-chars" className="text-xs font-medium text-neutral-300">
+            {t('usage.editDialog.consumedLabel')}
+          </label>
+          <input
+            id="edit-consumed-chars"
+            type="number"
+            min={0}
+            value={consumedDraft}
+            onChange={(e) => {
+              setConsumedDraft(e.target.value)
+              setErrors((prev) => ({ ...prev, consumed: undefined }))
+            }}
+            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all"
+          />
+          {errors.consumed && <p className="text-xs text-red-400">{errors.consumed}</p>}
+        </div>
+
+        <div className="flex flex-col gap-1.5">
+          <label htmlFor="edit-renewal-at" className="text-xs font-medium text-neutral-300">
+            {t('usage.editDialog.renewalLabel')}
+          </label>
+          <input
+            id="edit-renewal-at"
+            type="datetime-local"
+            value={renewalDraft}
+            onChange={(e) => {
+              setRenewalDraft(e.target.value)
+              setErrors((prev) => ({ ...prev, renewal: undefined }))
+            }}
+            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all [color-scheme:dark]"
+          />
+          {errors.renewal && <p className="text-xs text-red-400">{errors.renewal}</p>}
+        </div>
+      </div>
+    </ModalShell>
+  )
+}

--- a/src/renderer/src/components/metrics/UsageEditDialog.tsx
+++ b/src/renderer/src/components/metrics/UsageEditDialog.tsx
@@ -111,7 +111,7 @@ export function UsageEditDialog({
               setLimitDraft(e.target.value)
               setErrors((prev) => ({ ...prev, limit: undefined }))
             }}
-            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all"
+            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
           {errors.limit && <p className="text-xs text-red-400">{errors.limit}</p>}
         </div>
@@ -129,7 +129,7 @@ export function UsageEditDialog({
               setConsumedDraft(e.target.value)
               setErrors((prev) => ({ ...prev, consumed: undefined }))
             }}
-            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all"
+            className="rounded-md border border-neutral-800 bg-[#0a0a0c] px-3 py-2 text-sm text-neutral-200 placeholder-neutral-600 focus:border-amber-500 focus:ring-1 focus:ring-amber-500/20 focus:outline-none transition-all [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
           />
           {errors.consumed && <p className="text-xs text-red-400">{errors.consumed}</p>}
         </div>

--- a/src/renderer/src/components/translation/QuotaExceededDialog.tsx
+++ b/src/renderer/src/components/translation/QuotaExceededDialog.tsx
@@ -1,0 +1,65 @@
+import { AlertTriangle } from 'lucide-react'
+import { ModalShell } from '@/components/shared/ModalShell'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+
+interface QuotaExceededDialogProps {
+  open: boolean
+  service: string
+  remaining: number
+  requested: number
+  allowedEntries?: number
+  renewalAt?: string
+  onConfirmPartial?: () => void
+  onClose: () => void
+}
+
+export function QuotaExceededDialog({
+  open,
+  service,
+  remaining,
+  requested,
+  allowedEntries,
+  renewalAt,
+  onConfirmPartial,
+  onClose
+}: QuotaExceededDialogProps): React.JSX.Element | null {
+  const { t } = useAppTranslation('metrics')
+
+  const hasPartialOption = allowedEntries != null && allowedEntries > 0
+
+  return (
+    <ModalShell
+      open={open}
+      title={t('quotaModal.title', { service })}
+      sizeClassName="max-w-md"
+      icon={<AlertTriangle size={16} />}
+      onClose={onClose}
+      footer={
+        <>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 cursor-pointer items-center rounded-md border border-neutral-700 bg-[#131518] px-3 text-xs font-medium text-neutral-200 transition-colors hover:bg-neutral-800"
+          >
+            {t('quotaModal.dismiss')}
+          </button>
+          {hasPartialOption && onConfirmPartial && (
+            <button
+              type="button"
+              onClick={onConfirmPartial}
+              className="inline-flex h-8 cursor-pointer items-center rounded-md border border-amber-500 bg-amber-500 px-3 text-xs font-semibold text-neutral-950 transition-colors hover:border-amber-400 hover:bg-amber-400"
+            >
+              {t('quotaModal.confirm')}
+            </button>
+          )}
+        </>
+      }
+    >
+      <p className="text-sm leading-6 text-neutral-300">
+        {hasPartialOption
+          ? t('quotaModal.body', { requested, remaining, allowedEntries })
+          : t('quotaModal.fullBlockBody', { service, renewalAt: renewalAt ?? '' })}
+      </p>
+    </ModalShell>
+  )
+}

--- a/src/renderer/src/components/translation/QuotaExceededDialog.tsx
+++ b/src/renderer/src/components/translation/QuotaExceededDialog.tsx
@@ -8,6 +8,7 @@ interface QuotaExceededDialogProps {
   remaining: number
   requested: number
   allowedEntries?: number
+  totalEntries?: number
   renewalAt?: string
   onConfirmPartial?: () => void
   onClose: () => void
@@ -19,6 +20,7 @@ export function QuotaExceededDialog({
   remaining,
   requested,
   allowedEntries,
+  totalEntries,
   renewalAt,
   onConfirmPartial,
   onClose
@@ -57,7 +59,7 @@ export function QuotaExceededDialog({
     >
       <p className="text-sm leading-6 text-neutral-300">
         {hasPartialOption
-          ? t('quotaModal.body', { requested, remaining, allowedEntries })
+          ? t('quotaModal.body', { requested, remaining, allowedEntries, totalEntries })
           : t('quotaModal.fullBlockBody', { service, renewalAt: renewalAt ?? '' })}
       </p>
     </ModalShell>

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -1,14 +1,15 @@
 import { useCallback, useEffect, useState } from 'react'
+import { AlreadyTranslatedDialog } from '@/components/translation/AlreadyTranslatedDialog'
 import { BatchActionBar } from '@/components/translation/BatchActionBar'
-import { useAppTranslation } from '@/i18n/useAppTranslation'
+import { QuotaExceededDialog } from '@/components/translation/QuotaExceededDialog'
 import { TranslationGrid } from '@/components/translation/TranslationGrid'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
 import type { Language } from '@/types'
 import { useBatchTranslation } from '../hooks/useBatchTranslation'
 import { useDictionarySave } from '../hooks/useDictionarySave'
 import { useLoadedEditorShortcuts } from '../hooks/useLoadedEditorShortcuts'
 import { useTranslationExport } from '../hooks/useTranslationExport'
 import type { TranslationSession } from '../types'
-import { AlreadyTranslatedDialog } from '@/components/translation/AlreadyTranslatedDialog'
 import { EditorHeader } from './EditorHeader'
 import { PackageExportModal } from './PackageExportModal'
 
@@ -114,6 +115,21 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
           onSubmit={exportFlow.submitPackageExport}
         />
       )}
+
+      <QuotaExceededDialog
+        open={batch.quotaExceeded !== null}
+        service={batch.quotaExceeded?.service ?? ''}
+        remaining={batch.quotaExceeded?.remaining ?? 0}
+        requested={batch.quotaExceeded?.requested ?? 0}
+        allowedEntries={batch.quotaExceeded?.allowedEntries}
+        renewalAt={batch.quotaExceeded?.renewalAt}
+        onConfirmPartial={
+          batch.quotaExceeded && batch.quotaExceeded.allowedEntries > 0
+            ? batch.confirmPartialBatch
+            : undefined
+        }
+        onClose={batch.dismissQuotaExceeded}
+      />
     </div>
   )
 }

--- a/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
+++ b/src/renderer/src/features/translate/components/TranslateLoadedScreen.tsx
@@ -122,6 +122,7 @@ export function TranslateLoadedScreen({ session }: TranslateLoadedScreenProps): 
         remaining={batch.quotaExceeded?.remaining ?? 0}
         requested={batch.quotaExceeded?.requested ?? 0}
         allowedEntries={batch.quotaExceeded?.allowedEntries}
+        totalEntries={batch.quotaExceeded?.totalEntries}
         renewalAt={batch.quotaExceeded?.renewalAt}
         onConfirmPartial={
           batch.quotaExceeded && batch.quotaExceeded.allowedEntries > 0

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -264,23 +264,24 @@ export function useBatchTranslation(session: TranslationSession) {
           const requestedChars = entriesToSend.reduce((sum, e) => sum + e.source.length, 0)
 
           if (requestedChars > remaining) {
-            // find the longest prefix that fits within the remaining quota
+            // collect all entries that fit within the remaining quota (greedy, preserves order)
             let accumulated = 0
-            let allowedCount = 0
+            const allowedEntriesList: BatchEntry[] = []
             for (const entry of entriesToSend) {
-              if (accumulated + entry.source.length > remaining) break
-              accumulated += entry.source.length
-              allowedCount++
+              if (accumulated + entry.source.length <= remaining) {
+                accumulated += entry.source.length
+                allowedEntriesList.push(entry)
+              }
             }
 
             setQuotaExceeded({
               service: provider === 'deepl' ? 'DeepL' : 'Google',
               remaining,
               requested: requestedChars,
-              allowedEntries: allowedCount,
+              allowedEntries: allowedEntriesList.length,
               totalEntries: entriesToSend.length,
               renewalAt: usage.renewalAt,
-              allowedEntriesList: entriesToSend.slice(0, allowedCount),
+              allowedEntriesList,
               provider
             })
             return

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -12,6 +12,16 @@ import type { TranslationSession } from '../types'
 
 type BatchEntry = { uid: string; source: string }
 
+export interface QuotaExceededState {
+  service: string
+  remaining: number
+  requested: number
+  allowedEntries: number
+  renewalAt: string
+  allowedEntriesList: BatchEntry[]
+  provider: 'deepl' | 'google'
+}
+
 export function useBatchTranslation(session: TranslationSession) {
   const { t } = useAppTranslation(['translate', 'toasts', 'common', 'errors'])
   const [isBatchTranslating, setIsBatchTranslating] = useState(false)
@@ -21,6 +31,7 @@ export function useBatchTranslation(session: TranslationSession) {
   const [pendingDecision, setPendingDecision] = useState(false)
   const [pendingTranslatedCount, setPendingTranslatedCount] = useState(0)
   const [pendingUntranslatedCount, setPendingUntranslatedCount] = useState(0)
+  const [quotaExceeded, setQuotaExceeded] = useState<QuotaExceededState | null>(null)
   const batchCleanupRef = useRef<(() => void) | null>(null)
   const activeJobIdRef = useRef<string | null>(null)
   const pendingUidsRef = useRef<Set<string>>(new Set())
@@ -181,6 +192,40 @@ export function useBatchTranslation(session: TranslationSession) {
         activeJobIdRef.current = jobId
         setActiveJobId(jobId)
       } catch (err) {
+        // check for server-side QUOTA_EXCEEDED backstop
+        const rawMessage = err instanceof Error ? err.message : String(err)
+        if (rawMessage.startsWith('{')) {
+          try {
+            const parsed = JSON.parse(rawMessage) as {
+              code?: string
+              service?: string
+              remaining?: number
+              requested?: number
+              renewalAt?: string
+            }
+            if (parsed.code === 'QUOTA_EXCEEDED') {
+              clearListeners()
+              activeJobIdRef.current = null
+              setActiveJobId(null)
+              setBatchCompleted(0)
+              setBatchTotal(0)
+              setIsBatchTranslating(false)
+              setQuotaExceeded({
+                service: parsed.service ?? provider,
+                remaining: parsed.remaining ?? 0,
+                requested: parsed.requested ?? 0,
+                allowedEntries: 0,
+                renewalAt: parsed.renewalAt ?? '',
+                allowedEntriesList: [],
+                provider: provider === 'google' ? 'google' : 'deepl'
+              })
+              return
+            }
+          } catch {
+            // not JSON - fall through to default error handling
+          }
+        }
+
         const message = getLocalizedErrorMessage(err, t)
         clearListeners()
         activeJobIdRef.current = null
@@ -191,7 +236,7 @@ export function useBatchTranslation(session: TranslationSession) {
         toast.error(message)
         void window.api.log.write({
           scope: 'renderer.batchTranslation',
-          message: err instanceof Error ? err.message : String(err),
+          message: rawMessage,
           stack: err instanceof Error ? err.stack : undefined,
           meta: { provider, sourceLang, targetLang, total: entriesToSend.length }
         })
@@ -207,6 +252,56 @@ export function useBatchTranslation(session: TranslationSession) {
       updateEntry
     ]
   )
+
+  const checkQuotaAndDispatch = useCallback(
+    async (entriesToSend: BatchEntry[], provider: 'openai' | 'deepl' | 'google') => {
+      if (provider === 'deepl' || provider === 'google') {
+        try {
+          const usage = await window.api.metrics.getUsage({ service: provider })
+          const remaining = usage.charLimit - usage.consumedChars
+          const requestedChars = entriesToSend.reduce((sum, e) => sum + e.source.length, 0)
+
+          if (requestedChars > remaining) {
+            // find the longest prefix that fits within the remaining quota
+            let accumulated = 0
+            let allowedCount = 0
+            for (const entry of entriesToSend) {
+              if (accumulated + entry.source.length > remaining) break
+              accumulated += entry.source.length
+              allowedCount++
+            }
+
+            setQuotaExceeded({
+              service: provider === 'deepl' ? 'DeepL' : 'Google',
+              remaining,
+              requested: requestedChars,
+              allowedEntries: allowedCount,
+              renewalAt: usage.renewalAt,
+              allowedEntriesList: entriesToSend.slice(0, allowedCount),
+              provider
+            })
+            return
+          }
+        } catch {
+          // if quota check fails, proceed anyway - server will enforce
+        }
+      }
+
+      await dispatchBatchEntries(entriesToSend, provider)
+    },
+    [dispatchBatchEntries]
+  )
+
+  const dismissQuotaExceeded = useCallback(() => {
+    setQuotaExceeded(null)
+  }, [])
+
+  const confirmPartialBatch = useCallback(async () => {
+    if (!quotaExceeded) return
+    const { allowedEntriesList, provider } = quotaExceeded
+    setQuotaExceeded(null)
+    await dispatchBatchEntries(allowedEntriesList, provider)
+  }, [quotaExceeded, dispatchBatchEntries])
 
   const clearPending = useCallback(() => {
     setPendingDecision(false)
@@ -235,7 +330,7 @@ export function useBatchTranslation(session: TranslationSession) {
       const untranslated = materialized.filter((e) => e.target.trim() === '')
 
       if (translated.length === 0) {
-        await dispatchBatchEntries(materialized.map(toEntry), provider)
+        await checkQuotaAndDispatch(materialized.map(toEntry), provider)
         return
       }
 
@@ -247,15 +342,15 @@ export function useBatchTranslation(session: TranslationSession) {
       setPendingUntranslatedCount(untranslated.length)
       setPendingDecision(true)
     },
-    [isBatchTranslating, session, dispatchBatchEntries]
+    [isBatchTranslating, session, checkQuotaAndDispatch]
   )
 
   const confirmProceedAll = useCallback(async () => {
     const entriesToSend = pendingAllEntriesRef.current
     const provider = pendingProviderRef.current
     clearPending()
-    await dispatchBatchEntries(entriesToSend, provider)
-  }, [clearPending, dispatchBatchEntries])
+    await checkQuotaAndDispatch(entriesToSend, provider)
+  }, [clearPending, checkQuotaAndDispatch])
 
   const confirmSendOnlyUntranslated = useCallback(async () => {
     const entriesToSend = pendingUntranslatedEntriesRef.current
@@ -265,8 +360,8 @@ export function useBatchTranslation(session: TranslationSession) {
       toast.info(t('batchBar.noSelection', { ns: 'translate' }))
       return
     }
-    await dispatchBatchEntries(entriesToSend, provider)
-  }, [clearPending, dispatchBatchEntries])
+    await checkQuotaAndDispatch(entriesToSend, provider)
+  }, [clearPending, checkQuotaAndDispatch])
 
   const cancelPending = useCallback(() => {
     clearPending()
@@ -289,6 +384,9 @@ export function useBatchTranslation(session: TranslationSession) {
     pendingUntranslatedCount,
     confirmProceedAll,
     confirmSendOnlyUntranslated,
-    cancelPending
+    cancelPending,
+    quotaExceeded,
+    dismissQuotaExceeded,
+    confirmPartialBatch
   }
 }

--- a/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
+++ b/src/renderer/src/features/translate/hooks/useBatchTranslation.ts
@@ -17,6 +17,7 @@ export interface QuotaExceededState {
   remaining: number
   requested: number
   allowedEntries: number
+  totalEntries: number
   renewalAt: string
   allowedEntriesList: BatchEntry[]
   provider: 'deepl' | 'google'
@@ -215,6 +216,7 @@ export function useBatchTranslation(session: TranslationSession) {
                 remaining: parsed.remaining ?? 0,
                 requested: parsed.requested ?? 0,
                 allowedEntries: 0,
+                totalEntries: 0,
                 renewalAt: parsed.renewalAt ?? '',
                 allowedEntriesList: [],
                 provider: provider === 'google' ? 'google' : 'deepl'
@@ -276,6 +278,7 @@ export function useBatchTranslation(session: TranslationSession) {
               remaining,
               requested: requestedChars,
               allowedEntries: allowedCount,
+              totalEntries: entriesToSend.length,
               renewalAt: usage.renewalAt,
               allowedEntriesList: entriesToSend.slice(0, allowedCount),
               provider

--- a/src/renderer/src/hooks/useMetricsRuns.ts
+++ b/src/renderer/src/hooks/useMetricsRuns.ts
@@ -1,0 +1,58 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsDailyBucket, MetricsModBucket, MetricsRun, MetricsRunService } from '@/types'
+
+interface MetricsRunsInputs {
+  from: string
+  to: string
+  service?: MetricsRunService
+}
+
+interface MetricsRunsState {
+  runs: MetricsRun[]
+  daily: MetricsDailyBucket[]
+  byMod: MetricsModBucket[]
+  loading: boolean
+  error: string | null
+}
+
+export function useMetricsRuns({ from, to, service }: MetricsRunsInputs) {
+  const { t } = useAppTranslation('metrics')
+  const [state, setState] = useState<MetricsRunsState>({
+    runs: [],
+    daily: [],
+    byMod: [],
+    loading: true,
+    error: null
+  })
+
+  const refresh = useCallback(async () => {
+    setState((prev) => ({ ...prev, loading: true, error: null }))
+    try {
+      const [runs, daily, byMod] = await Promise.all([
+        window.api.metrics.listRuns({ from, to, service }),
+        window.api.metrics.aggregateByDay({ from, to, service }),
+        window.api.metrics.aggregateByMod({ from, to, service })
+      ])
+      setState({ runs, daily, byMod, loading: false, error: null })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setState((prev) => ({ ...prev, loading: false, error: message }))
+      toast.error(t('errors.loadFailed'))
+    }
+  }, [from, to, service, t])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  return {
+    runs: state.runs,
+    daily: state.daily,
+    byMod: state.byMod,
+    loading: state.loading,
+    error: state.error,
+    refresh
+  }
+}

--- a/src/renderer/src/hooks/useMetricsUsage.ts
+++ b/src/renderer/src/hooks/useMetricsUsage.ts
@@ -1,0 +1,74 @@
+import { useCallback, useEffect, useState } from 'react'
+import { toast } from 'sonner'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsService, MetricsUsage } from '@/types'
+
+interface MetricsUsageState {
+  deepl: MetricsUsage | null
+  google: MetricsUsage | null
+  loading: boolean
+  error: string | null
+}
+
+export function useMetricsUsage() {
+  const { t } = useAppTranslation('metrics')
+  const [state, setState] = useState<MetricsUsageState>({
+    deepl: null,
+    google: null,
+    loading: true,
+    error: null
+  })
+
+  const refresh = useCallback(async () => {
+    setState((prev) => ({ ...prev, loading: true, error: null }))
+    try {
+      const all = await window.api.metrics.getAllUsage()
+      const deepl = all.find((u) => u.service === 'deepl') ?? null
+      const google = all.find((u) => u.service === 'google') ?? null
+      setState({ deepl, google, loading: false, error: null })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err)
+      setState((prev) => ({ ...prev, loading: false, error: message }))
+      toast.error(t('errors.loadFailed'))
+    }
+  }, [t])
+
+  useEffect(() => {
+    refresh()
+  }, [refresh])
+
+  const setLimit = useCallback(
+    async (service: MetricsService, charLimit: number) => {
+      await window.api.metrics.setLimit({ service, charLimit })
+      await refresh()
+    },
+    [refresh]
+  )
+
+  const setRenewalAt = useCallback(
+    async (service: MetricsService, isoUtc: string) => {
+      await window.api.metrics.setRenewalAt({ service, renewalAt: isoUtc })
+      await refresh()
+    },
+    [refresh]
+  )
+
+  const setConsumed = useCallback(
+    async (service: MetricsService, n: number) => {
+      await window.api.metrics.setConsumed({ service, consumedChars: n })
+      await refresh()
+    },
+    [refresh]
+  )
+
+  return {
+    deepl: state.deepl,
+    google: state.google,
+    loading: state.loading,
+    error: state.error,
+    refresh,
+    setLimit,
+    setRenewalAt,
+    setConsumed
+  }
+}

--- a/src/renderer/src/i18n/resources.ts
+++ b/src/renderer/src/i18n/resources.ts
@@ -3,6 +3,7 @@ import dictionaryEn from '@/locales/en/dictionary.json'
 import errorsEn from '@/locales/en/errors.json'
 import extractEn from '@/locales/en/extract.json'
 import mergeEn from '@/locales/en/merge.json'
+import metricsEn from '@/locales/en/metrics.json'
 import modsEn from '@/locales/en/mods.json'
 import packageEn from '@/locales/en/package.json'
 import settingsEn from '@/locales/en/settings.json'
@@ -14,6 +15,7 @@ import dictionaryPtBr from '@/locales/pt-BR/dictionary.json'
 import errorsPtBr from '@/locales/pt-BR/errors.json'
 import extractPtBr from '@/locales/pt-BR/extract.json'
 import mergePtBr from '@/locales/pt-BR/merge.json'
+import metricsPtBr from '@/locales/pt-BR/metrics.json'
 import modsPtBr from '@/locales/pt-BR/mods.json'
 import packagePtBr from '@/locales/pt-BR/package.json'
 import settingsPtBr from '@/locales/pt-BR/settings.json'
@@ -32,7 +34,8 @@ export const translationNamespaces = [
   'package',
   'extract',
   'errors',
-  'toasts'
+  'toasts',
+  'metrics'
 ] as const
 
 export const resources = {
@@ -47,7 +50,8 @@ export const resources = {
     package: packageEn,
     extract: extractEn,
     errors: errorsEn,
-    toasts: toastsEn
+    toasts: toastsEn,
+    metrics: metricsEn
   },
   'pt-BR': {
     common: commonPtBr,
@@ -60,6 +64,7 @@ export const resources = {
     package: packagePtBr,
     extract: extractPtBr,
     errors: errorsPtBr,
-    toasts: toastsPtBr
+    toasts: toastsPtBr,
+    metrics: metricsPtBr
   }
 } as const

--- a/src/renderer/src/locales/en/metrics.json
+++ b/src/renderer/src/locales/en/metrics.json
@@ -24,7 +24,7 @@
   },
   "quotaModal": {
     "title": "{{service}} quota would be exceeded",
-    "body": "This batch needs {{requested}} chars but only {{remaining}} are available. You can translate the first {{allowedEntries}} entries that fit within the limit.",
+    "body": "This batch needs {{requested}} chars but only {{remaining}} are available. You can translate {{allowedEntries}} / {{totalEntries}} entries that fit within the limit.",
     "fullBlockBody": "{{service}} has no characters remaining. Update the limit or wait until {{renewalAt}}.",
     "confirm": "Translate within limit",
     "dismiss": "Cancel"

--- a/src/renderer/src/locales/en/metrics.json
+++ b/src/renderer/src/locales/en/metrics.json
@@ -1,0 +1,65 @@
+{
+  "page": {
+    "title": "Metrics",
+    "subtitle": "Track your translation usage and activity over time."
+  },
+  "usage": {
+    "card": {
+      "title": "{{service}} Usage",
+      "consumedOfLimit": "{{consumed}} / {{limit}}",
+      "remaining": "{{remaining}} remaining",
+      "renewsOn": "Renews on {{date}}",
+      "editButton": "Edit"
+    },
+    "editDialog": {
+      "title": "Edit {{service}} Usage",
+      "limitLabel": "Monthly character limit",
+      "consumedLabel": "Consumed characters",
+      "renewalLabel": "Renewal date and time",
+      "save": "Save",
+      "cancel": "Cancel",
+      "invalidNumber": "Must be a positive number",
+      "invalidDate": "Pick a valid future date and time"
+    }
+  },
+  "quotaModal": {
+    "title": "{{service}} quota would be exceeded",
+    "body": "This batch needs {{requested}} chars but only {{remaining}} are available. You can translate the first {{allowedEntries}} entries that fit within the limit.",
+    "fullBlockBody": "{{service}} has no characters remaining. Update the limit or wait until {{renewalAt}}.",
+    "confirm": "Translate within limit",
+    "dismiss": "Cancel"
+  },
+  "runs": {
+    "section": {
+      "title": "Recent Translations"
+    },
+    "column": {
+      "date": "Date",
+      "service": "Service",
+      "mod": "Mod",
+      "entries": "Entries",
+      "chars": "Chars"
+    },
+    "empty": "No translations recorded yet."
+  },
+  "charts": {
+    "dailyChars": {
+      "title": "Characters per Day"
+    },
+    "dailyEntries": {
+      "title": "Entries per Day"
+    },
+    "modsTranslated": {
+      "title": "Mods Translated"
+    },
+    "range": {
+      "7d": "Last 7 days",
+      "30d": "Last 30 days",
+      "90d": "Last 90 days"
+    }
+  },
+  "errors": {
+    "loadFailed": "Failed to load metrics.",
+    "saveFailed": "Failed to save changes."
+  }
+}

--- a/src/renderer/src/locales/en/sidebar.json
+++ b/src/renderer/src/locales/en/sidebar.json
@@ -5,5 +5,6 @@
   "merge": "Merge translations",
   "extract": "Extract mod",
   "package": "Create package",
-  "settings": "Settings"
+  "settings": "Settings",
+  "metrics": "Metrics"
 }

--- a/src/renderer/src/locales/pt-BR/metrics.json
+++ b/src/renderer/src/locales/pt-BR/metrics.json
@@ -1,0 +1,65 @@
+{
+  "page": {
+    "title": "Métricas",
+    "subtitle": "Acompanhe o uso de tradução e a atividade ao longo do tempo."
+  },
+  "usage": {
+    "card": {
+      "title": "Uso {{service}}",
+      "consumedOfLimit": "{{consumed}} / {{limit}}",
+      "remaining": "{{remaining}} restantes",
+      "renewsOn": "Renova em {{date}}",
+      "editButton": "Editar"
+    },
+    "editDialog": {
+      "title": "Editar uso {{service}}",
+      "limitLabel": "Limite mensal de caracteres",
+      "consumedLabel": "Caracteres consumidos",
+      "renewalLabel": "Data e hora de renovação",
+      "save": "Salvar",
+      "cancel": "Cancelar",
+      "invalidNumber": "Deve ser um número positivo",
+      "invalidDate": "Escolha uma data e hora futura válida"
+    }
+  },
+  "quotaModal": {
+    "title": "Cota do {{service}} seria excedida",
+    "body": "Este lote precisa de {{requested}} caracteres, mas apenas {{remaining}} estão disponíveis. Você pode traduzir as primeiras {{allowedEntries}} entradas que cabem no limite.",
+    "fullBlockBody": "O {{service}} não tem caracteres restantes. Atualize o limite ou aguarde até {{renewalAt}}.",
+    "confirm": "Traduzir dentro do limite",
+    "dismiss": "Cancelar"
+  },
+  "runs": {
+    "section": {
+      "title": "Traduções Recentes"
+    },
+    "column": {
+      "date": "Data",
+      "service": "Serviço",
+      "mod": "Mod",
+      "entries": "Entradas",
+      "chars": "Chars"
+    },
+    "empty": "Nenhuma tradução registrada ainda."
+  },
+  "charts": {
+    "dailyChars": {
+      "title": "Caracteres por Dia"
+    },
+    "dailyEntries": {
+      "title": "Entradas por Dia"
+    },
+    "modsTranslated": {
+      "title": "Mods Traduzidos"
+    },
+    "range": {
+      "7d": "Últimos 7 dias",
+      "30d": "Últimos 30 dias",
+      "90d": "Últimos 90 dias"
+    }
+  },
+  "errors": {
+    "loadFailed": "Falha ao carregar métricas.",
+    "saveFailed": "Falha ao salvar alterações."
+  }
+}

--- a/src/renderer/src/locales/pt-BR/metrics.json
+++ b/src/renderer/src/locales/pt-BR/metrics.json
@@ -24,7 +24,7 @@
   },
   "quotaModal": {
     "title": "Cota do {{service}} seria excedida",
-    "body": "Este lote precisa de {{requested}} caracteres, mas apenas {{remaining}} estão disponíveis. Você pode traduzir as primeiras {{allowedEntries}} entradas que cabem no limite.",
+    "body": "Este lote precisa de {{requested}} caracteres, mas apenas {{remaining}} estão disponíveis. Você pode traduzir {{allowedEntries}} / {{totalEntries}} entradas que cabem no limite.",
     "fullBlockBody": "O {{service}} não tem caracteres restantes. Atualize o limite ou aguarde até {{renewalAt}}.",
     "confirm": "Traduzir dentro do limite",
     "dismiss": "Cancelar"

--- a/src/renderer/src/locales/pt-BR/sidebar.json
+++ b/src/renderer/src/locales/pt-BR/sidebar.json
@@ -5,5 +5,6 @@
   "merge": "Mesclar traduções",
   "extract": "Extrair mod",
   "package": "Criar pacote",
-  "settings": "Configurações"
+  "settings": "Configurações",
+  "metrics": "Métricas"
 }

--- a/src/renderer/src/pages/EntryEditPage.tsx
+++ b/src/renderer/src/pages/EntryEditPage.tsx
@@ -2,11 +2,9 @@ import { ArrowLeft, Loader2 } from 'lucide-react'
 import { useState } from 'react'
 import { Navigate, useNavigate, useParams } from 'react-router-dom'
 import { toast } from 'sonner'
-import {
-  type TranslationSessionEntry,
-  useTranslationSession
-} from '@/context/TranslationSession'
 import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
+import { QuotaExceededDialog } from '@/components/translation/QuotaExceededDialog'
+import { type TranslationSessionEntry, useTranslationSession } from '@/context/TranslationSession'
 import { getLocalizedErrorMessage } from '@/i18n/errors'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { renderSource } from '@/utils/renderSource'
@@ -35,8 +33,33 @@ function EntryEditor({
 
   const [target, setTarget] = useState(entry.target ?? '')
   const [translating, setTranslating] = useState<'deepl' | 'openai' | null>(null)
+  const [quotaBlock, setQuotaBlock] = useState<{
+    service: string
+    remaining: number
+    requested: number
+    renewalAt: string
+  } | null>(null)
 
   const handleTranslate = async (provider: 'deepl' | 'openai') => {
+    // quota pre-check for metered providers
+    if (provider === 'deepl') {
+      try {
+        const usage = await window.api.metrics.getUsage({ service: 'deepl' })
+        const remaining = usage.charLimit - usage.consumedChars
+        if (entry.source.length > remaining) {
+          setQuotaBlock({
+            service: 'DeepL',
+            remaining,
+            requested: entry.source.length,
+            renewalAt: usage.renewalAt
+          })
+          return
+        }
+      } catch {
+        // if quota check fails, proceed - server will enforce
+      }
+    }
+
     setTranslating(provider)
     try {
       const result = await window.api.translation.single({
@@ -48,6 +71,30 @@ function EntryEditor({
       setTarget(result)
       updateEntry(entry.rowId, result)
     } catch (err) {
+      // check for server-side QUOTA_EXCEEDED backstop
+      const rawMessage = err instanceof Error ? err.message : String(err)
+      if (rawMessage.startsWith('{')) {
+        try {
+          const parsed = JSON.parse(rawMessage) as {
+            code?: string
+            service?: string
+            remaining?: number
+            requested?: number
+            renewalAt?: string
+          }
+          if (parsed.code === 'QUOTA_EXCEEDED') {
+            setQuotaBlock({
+              service: parsed.service ?? provider,
+              remaining: parsed.remaining ?? 0,
+              requested: parsed.requested ?? 0,
+              renewalAt: parsed.renewalAt ?? ''
+            })
+            return
+          }
+        } catch {
+          // not JSON - fall through to default error handling
+        }
+      }
       toast.error(getLocalizedErrorMessage(err, t))
     } finally {
       setTranslating(null)
@@ -61,64 +108,73 @@ function EntryEditor({
   }
 
   return (
-    <div className="mx-auto flex h-full max-w-4xl flex-col gap-6 p-6">
-      <div className="flex items-center gap-3">
-        <button
-          type="button"
-          onClick={() => navigate(-1)}
-          className="flex cursor-pointer items-center gap-1.5 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
-        >
-          <ArrowLeft size={16} />
-          {t('actions.back', { ns: 'common' })}
-        </button>
-        <span className="truncate font-mono text-xs text-neutral-600">{entry.uid}</span>
-      </div>
+    <>
+      <QuotaExceededDialog
+        open={quotaBlock !== null}
+        service={quotaBlock?.service ?? ''}
+        remaining={quotaBlock?.remaining ?? 0}
+        requested={quotaBlock?.requested ?? 0}
+        renewalAt={quotaBlock?.renewalAt}
+        onClose={() => setQuotaBlock(null)}
+      />
+      <div className="mx-auto flex h-full max-w-4xl flex-col gap-6 p-6">
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => navigate(-1)}
+            className="flex cursor-pointer items-center gap-1.5 text-sm text-neutral-400 transition-colors hover:text-neutral-200"
+          >
+            <ArrowLeft size={16} />
+            {t('actions.back', { ns: 'common' })}
+          </button>
+          <span className="truncate font-mono text-xs text-neutral-600">{entry.uid}</span>
+        </div>
 
-      <div className="grid min-h-0 flex-1 grid-cols-2 gap-4">
-        <div className="flex flex-col gap-2">
-          <span className="text-xs font-medium tracking-wide text-neutral-400 uppercase">
-            {t('entryEdit.originalText', { ns: 'translate', language: sourceLang })}
-          </span>
-          <div className="flex-1 overflow-y-auto rounded-md border border-neutral-700 bg-neutral-900/50 p-4 text-sm leading-relaxed text-neutral-300 whitespace-pre-wrap">
-            {entry.source ? (
-              renderSource(entry.source)
-            ) : (
-              <span className="italic text-neutral-600">
-                {t('entryEdit.empty', { ns: 'translate' })}
-              </span>
-            )}
+        <div className="grid min-h-0 flex-1 grid-cols-2 gap-4">
+          <div className="flex flex-col gap-2">
+            <span className="text-xs font-medium tracking-wide text-neutral-400 uppercase">
+              {t('entryEdit.originalText', { ns: 'translate', language: sourceLang })}
+            </span>
+            <div className="flex-1 overflow-y-auto rounded-md border border-neutral-700 bg-neutral-900/50 p-4 text-sm leading-relaxed text-neutral-300 whitespace-pre-wrap">
+              {entry.source ? (
+                renderSource(entry.source)
+              ) : (
+                <span className="italic text-neutral-600">
+                  {t('entryEdit.empty', { ns: 'translate' })}
+                </span>
+              )}
+            </div>
+          </div>
+
+          <div className="flex flex-col gap-2">
+            <label
+              htmlFor="entry-target"
+              className="text-xs font-medium tracking-wide text-neutral-400 uppercase"
+            >
+              {t('entryEdit.translation', { ns: 'translate', language: targetLang })}
+            </label>
+            <HighlightedTextarea
+              id="entry-target"
+              value={target}
+              onChange={(event) => setTarget(event.target.value)}
+              containerClassName="flex-1 min-h-0 rounded-md border-neutral-700 bg-neutral-900 focus-within:border-neutral-500 focus-within:shadow-none"
+              overlayClassName="p-4 text-sm leading-relaxed"
+              className="flex-1 min-h-0 p-4 text-sm leading-relaxed"
+            />
           </div>
         </div>
 
-        <div className="flex flex-col gap-2">
-          <label
-            htmlFor="entry-target"
-            className="text-xs font-medium tracking-wide text-neutral-400 uppercase"
+        <div className="flex shrink-0 items-center gap-3">
+          <button
+            type="button"
+            onClick={() => handleTranslate('deepl')}
+            disabled={translating !== null}
+            className="flex cursor-pointer items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            {t('entryEdit.translation', { ns: 'translate', language: targetLang })}
-          </label>
-          <HighlightedTextarea
-            id="entry-target"
-            value={target}
-            onChange={(event) => setTarget(event.target.value)}
-            containerClassName="flex-1 min-h-0 rounded-md border-neutral-700 bg-neutral-900 focus-within:border-neutral-500 focus-within:shadow-none"
-            overlayClassName="p-4 text-sm leading-relaxed"
-            className="flex-1 min-h-0 p-4 text-sm leading-relaxed"
-          />
-        </div>
-      </div>
-
-      <div className="flex shrink-0 items-center gap-3">
-        <button
-          type="button"
-          onClick={() => handleTranslate('deepl')}
-          disabled={translating !== null}
-          className="flex cursor-pointer items-center gap-2 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
-        >
-          {translating === 'deepl' && <Loader2 size={14} className="animate-spin" />}
-          {t('entryEdit.translateWithDeepL', { ns: 'translate' })}
-        </button>
-        {/* <button
+            {translating === 'deepl' && <Loader2 size={14} className="animate-spin" />}
+            {t('entryEdit.translateWithDeepL', { ns: 'translate' })}
+          </button>
+          {/* <button
           type="button"
           onClick={() => handleTranslate('openai')}
           disabled={translating !== null}
@@ -128,23 +184,24 @@ function EntryEditor({
           Translate with OpenAI
         </button> */}
 
-        <div className="ml-auto flex gap-2">
-          <button
-            type="button"
-            onClick={() => navigate(-1)}
-            className="cursor-pointer rounded-md bg-neutral-800 px-4 py-2 text-sm text-neutral-300 transition-colors hover:bg-neutral-700"
-          >
-            {t('actions.cancel', { ns: 'common' })}
-          </button>
-          <button
-            type="button"
-            onClick={handleSave}
-            className="cursor-pointer rounded-md bg-neutral-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-500"
-          >
-            {t('actions.save', { ns: 'common' })}
-          </button>
+          <div className="ml-auto flex gap-2">
+            <button
+              type="button"
+              onClick={() => navigate(-1)}
+              className="cursor-pointer rounded-md bg-neutral-800 px-4 py-2 text-sm text-neutral-300 transition-colors hover:bg-neutral-700"
+            >
+              {t('actions.cancel', { ns: 'common' })}
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              className="cursor-pointer rounded-md bg-neutral-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-neutral-500"
+            >
+              {t('actions.save', { ns: 'common' })}
+            </button>
+          </div>
         </div>
       </div>
-    </div>
+    </>
   )
 }

--- a/src/renderer/src/pages/MetricsPage.tsx
+++ b/src/renderer/src/pages/MetricsPage.tsx
@@ -1,0 +1,133 @@
+import { BarChart2 } from 'lucide-react'
+import { useState } from 'react'
+import { toast } from 'sonner'
+import { MetricsCharts } from '@/components/metrics/MetricsCharts'
+import { RecentRunsTable } from '@/components/metrics/RecentRunsTable'
+import { UsageCard } from '@/components/metrics/UsageCard'
+import { UsageEditDialog } from '@/components/metrics/UsageEditDialog'
+import { useMetricsRuns } from '@/hooks/useMetricsRuns'
+import { useMetricsUsage } from '@/hooks/useMetricsUsage'
+import { useAppTranslation } from '@/i18n/useAppTranslation'
+import type { MetricsService } from '@/types'
+
+type RangeKey = '7d' | '30d' | '90d'
+
+const RANGE_DAYS: Record<RangeKey, number> = { '7d': 7, '30d': 30, '90d': 90 }
+
+function buildRange(days: number): { from: string; to: string } {
+  const to = new Date()
+  const from = new Date()
+  from.setDate(from.getDate() - (days - 1))
+  return {
+    from: from.toISOString().slice(0, 10),
+    to: to.toISOString().slice(0, 10)
+  }
+}
+
+export function MetricsPage(): React.JSX.Element {
+  const { t } = useAppTranslation('metrics')
+  const [range, setRange] = useState<RangeKey>('30d')
+  const [editingService, setEditingService] = useState<MetricsService | null>(null)
+
+  const { from, to } = buildRange(RANGE_DAYS[range])
+
+  const usage = useMetricsUsage()
+  const runsData = useMetricsRuns({ from, to })
+
+  const handleSaveUsage = async (data: {
+    charLimit: number
+    consumedChars: number
+    renewalAt: string
+  }) => {
+    if (!editingService) return
+    try {
+      await usage.setLimit(editingService, data.charLimit)
+      await usage.setConsumed(editingService, data.consumedChars)
+      await usage.setRenewalAt(editingService, data.renewalAt)
+      setEditingService(null)
+    } catch {
+      toast.error(t('errors.saveFailed'))
+    }
+  }
+
+  const rangeKeys: RangeKey[] = ['7d', '30d', '90d']
+  const editingUsage = editingService !== null ? (usage[editingService] ?? null) : null
+
+  return (
+    <div className="p-8">
+      <div className="max-w-6xl mx-auto space-y-6">
+        <div className="mb-8">
+          <h1 className="text-2xl font-semibold text-neutral-100 flex items-center gap-3">
+            <BarChart2 className="w-6 h-6 text-amber-500" />
+            {t('page.title')}
+          </h1>
+          <p className="text-neutral-500 text-sm mt-1">{t('page.subtitle')}</p>
+        </div>
+
+        {/* Usage cards */}
+        {usage.loading ? (
+          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+            {[1, 2].map((i) => (
+              <div
+                key={i}
+                className="bg-[#141416] border border-neutral-800/80 rounded-xl h-44 animate-pulse"
+              />
+            ))}
+          </div>
+        ) : (
+          <div className="flex flex-col md:flex-row gap-4">
+            {usage.deepl && (
+              <UsageCard usage={usage.deepl} onEdit={() => setEditingService('deepl')} />
+            )}
+            {usage.google && (
+              <UsageCard usage={usage.google} onEdit={() => setEditingService('google')} />
+            )}
+          </div>
+        )}
+
+        {/* Date range selector */}
+        <div className="flex items-center gap-1">
+          {rangeKeys.map((key) => (
+            <button
+              key={key}
+              type="button"
+              onClick={() => setRange(key)}
+              className={`px-3 py-1.5 rounded-md text-xs font-medium transition-colors ${
+                range === key
+                  ? 'bg-amber-500/15 text-amber-400 border border-amber-500/30'
+                  : 'text-neutral-400 hover:text-neutral-200 hover:bg-neutral-800 border border-transparent'
+              }`}
+            >
+              {t(`charts.range.${key}`)}
+            </button>
+          ))}
+        </div>
+
+        {/* Charts */}
+        <MetricsCharts
+          daily={runsData.daily}
+          byMod={runsData.byMod}
+          from={from}
+          to={to}
+          loading={runsData.loading}
+        />
+
+        {/* Recent runs table */}
+        <RecentRunsTable runs={runsData.runs} loading={runsData.loading} />
+
+        <div className="h-4" />
+      </div>
+
+      {/* Edit dialogs */}
+      {editingService !== null && editingUsage !== null && (
+        <UsageEditDialog
+          open={true}
+          service={editingService}
+          usage={editingUsage}
+          onSave={handleSaveUsage}
+          onClose={() => setEditingService(null)}
+        />
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- Adds a `/metrics` page showing per-service character consumption (DeepL, Google) against an editable monthly limit with auto-renewal. Usage cards display consumed/limit, a progress bar, remaining chars, and renewal date — all editable via a dialog.
- Gates `translation:batch` and `translation:single` against the remaining quota before dispatching. When the limit would be exceeded, a `QuotaExceededDialog` offers a partial batch (entries that fit, selected greedily — not just the first prefix) or blocks entirely if nothing fits.
- Records a `translation_run` row on every finished batch or pipeline job. The Metrics page visualises these as daily chars/entries line charts and a per-mod bar chart (recharts), plus a recent-runs table. Date range is selectable (7 / 30 / 90 days).
- Auto-renewal is idempotent: calling `applyRenewalIfDue` twice cannot double-advance the renewal date.

## Version
- v1.7.0 (bump reason: new user-visible feature)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] `pnpm dev` boots without migration errors; "Metrics" entry appears in the sidebar (BarChart3 icon, Ctrl+8)
- [x] `/metrics` shows two usage cards (DeepL, Google) at `0 / 500 000`, renewal ~30 days ahead
- [x] Edit dialog persists charLimit, consumedChars, renewalAt across app restart
- [x] Set DeepL consumed to 499 900; select a batch whose first entry is >100 chars but whose 2nd and 3rd entries are ≤50 chars each — dialog should offer those smaller entries (greedy skip, not prefix)
- [x] With DeepL at limit, any further batch or single-entry attempt shows the hard-block variant (no confirm button)
- [x] After one finished translation, daily-chars and daily-entries line charts render a data point
- [x] Switching language to pt-BR shows "Métricas" in sidebar and all dialog strings in Portuguese