### PR TITLE
feat(translate): copy-source button and sticky rows in translation grid

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.7.0
+buildVersion: 1.7.1
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.7.0",
+  "version": "1.7.1",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual'
-import { AlertTriangle, BookOpen, Check, Copy, Search, X } from 'lucide-react'
+import { AlertTriangle, BookOpen, Check, Copy, RefreshCw, Search, X } from 'lucide-react'
 import {
   startTransition,
   useDeferredValue,
@@ -92,6 +92,7 @@ export function TranslationGrid({
   const [isPending, startFilterTransition] = useTransition()
   const [pageSize, setPageSize] = useState<100 | 250 | 500 | 1000>(250)
   const [currentPage, setCurrentPage] = useState(1)
+  const [stickyRowIds, setStickyRowIds] = useState<Set<string>>(() => new Set())
   const searchInputRef = useRef<HTMLInputElement>(null)
   const textareaRefs = useRef<Map<string, HTMLTextAreaElement>>(new Map())
   const savedByEnterRef = useRef<Set<string>>(new Set())
@@ -116,6 +117,7 @@ export function TranslationGrid({
 
   const filteredEntries = useMemo(() => {
     return entries.filter((entry) => {
+      if (stickyRowIds.has(entry.rowId)) return true
       if (deferredFilter === 'untranslated' && entry.target.trim()) return false
       if (deferredFilter === 'translated' && !entry.target.trim()) return false
       if (deferredFilter === 'dictionary' && getCategory(entry) !== 'dictionary') return false
@@ -128,15 +130,16 @@ export function TranslationGrid({
       }
       return true
     })
-  }, [deferredFilter, deferredSearch, entries])
+  }, [deferredFilter, deferredSearch, entries, stickyRowIds])
 
   useEffect(() => {
     setCurrentPage(1)
   }, [deferredFilter, deferredSearch, entries])
 
-  // clear selection when filter or search changes so count never disagrees with checkbox
+  // clear selection and sticky rows when filter or search changes
   useEffect(() => {
     clearSelection()
+    setStickyRowIds(new Set())
   }, [deferredFilter, deferredSearch, clearSelection])
 
   // single source of truth for which entries "select-all" covers
@@ -215,12 +218,23 @@ export function TranslationGrid({
     }
   }
 
+  const markSticky = (rowId: string) => {
+    if (deferredFilter === 'all' && !deferredSearch) return
+    setStickyRowIds((prev) => {
+      if (prev.has(rowId)) return prev
+      const next = new Set(prev)
+      next.add(rowId)
+      return next
+    })
+  }
+
   const handleEntryBlur = (entry: TranslationSessionEntry, value: string) => {
     if (savedByEnterRef.current.has(entry.rowId)) {
       savedByEnterRef.current.delete(entry.rowId)
       return
     }
     updateEntryTarget(entry, value)
+    markSticky(entry.rowId)
   }
 
   const handleEnterKey = (
@@ -232,6 +246,7 @@ export function TranslationGrid({
 
     const value = event.currentTarget.value
     updateEntryTarget(entry, value)
+    markSticky(entry.rowId)
     savedByEnterRef.current.add(entry.rowId)
 
     if (value.trim()) onEntrySave(entry.rowId, value)
@@ -410,6 +425,22 @@ export function TranslationGrid({
             </button>
           )
         })}
+
+        <button
+          type="button"
+          aria-label={t('grid.refreshView', { ns: 'translate' })}
+          title={t('grid.refreshView', { ns: 'translate' })}
+          disabled={stickyRowIds.size === 0}
+          onClick={() => setStickyRowIds(new Set())}
+          className={cn(btnBase, 'gap-1.5 disabled:cursor-not-allowed disabled:opacity-40')}
+        >
+          <RefreshCw size={12} />
+          {stickyRowIds.size > 0 && (
+            <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 font-mono text-[10px] tabular-nums text-amber-400">
+              {t('grid.refreshViewHidden', { ns: 'translate', count: stickyRowIds.size })}
+            </span>
+          )}
+        </button>
       </div>
 
       <div className="ml-auto flex items-center gap-3 text-xs font-semibold text-neutral-400">

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -1,4 +1,5 @@
-import { AlertTriangle, BookOpen, Check, Search, X } from 'lucide-react'
+import { useVirtualizer } from '@tanstack/react-virtual'
+import { AlertTriangle, BookOpen, Check, Copy, Search, X } from 'lucide-react'
 import {
   startTransition,
   useDeferredValue,
@@ -8,14 +9,15 @@ import {
   useState,
   useTransition
 } from 'react'
-import { useVirtualizer } from '@tanstack/react-virtual'
+import { toast } from 'sonner'
+import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
 import {
   type FilterSpec,
-  type TranslationSessionEntry,
   materializeSelectedEntries,
+  type TranslationSessionEntry,
   useTranslationSession
 } from '@/context/TranslationSession'
-import { HighlightedTextarea } from '@/components/shared/HighlightedTextarea'
+import { getLocalizedErrorMessage } from '@/i18n/errors'
 import { useAppTranslation } from '@/i18n/useAppTranslation'
 import { cn } from '@/lib/utils'
 import { renderSource } from '@/utils/renderSource'
@@ -72,10 +74,17 @@ export function TranslationGrid({
   onEntrySave,
   viewMode
 }: TranslationGridProps): React.JSX.Element {
-  const { t } = useAppTranslation(['translate', 'common'])
+  const { t } = useAppTranslation(['translate', 'common', 'toasts'])
   const session = useTranslationSession()
-  const { selection, isSelected, selectAllMatching, toggleEntry, clearSelection, sourceLang, targetLang } =
-    session
+  const {
+    selection,
+    isSelected,
+    selectAllMatching,
+    toggleEntry,
+    clearSelection,
+    sourceLang,
+    targetLang
+  } = session
   const [search, setSearch] = useState('')
   const [filter, setFilter] = useState<FilterMode>('all')
   const deferredSearch = useDeferredValue(search)
@@ -140,14 +149,14 @@ export function TranslationGrid({
     count: pageEntries.length,
     getScrollElement: () => sideParentRef.current,
     estimateSize: () => 72,
-    overscan: 10,
+    overscan: 10
   })
 
   const stackedVirtualizer = useVirtualizer({
     count: pageEntries.length,
     getScrollElement: () => stackedParentRef.current,
     estimateSize: () => 220,
-    overscan: 10,
+    overscan: 10
   })
 
   const selectedStats = useMemo(() => {
@@ -187,6 +196,16 @@ export function TranslationGrid({
 
   const focusEntry = (rowId: string) => {
     textareaRefs.current.get(rowId)?.focus()
+  }
+
+  const handleCopySource = async (event: React.MouseEvent, source: string) => {
+    event.stopPropagation()
+    try {
+      await navigator.clipboard.writeText(source)
+      toast.success(t('translate.sourceCopied', { ns: 'toasts' }))
+    } catch (err) {
+      toast.error(getLocalizedErrorMessage(err, t))
+    }
   }
 
   const updateEntryTarget = (entry: TranslationSessionEntry, value: string) => {
@@ -343,11 +362,7 @@ export function TranslationGrid({
           className="min-w-0 flex-1 bg-transparent text-xs font-medium text-neutral-300 placeholder:text-neutral-600 focus:outline-none"
         />
         {search && (
-          <button
-            type="button"
-            onClick={() => setSearch('')}
-            className="shrink-0 cursor-pointer"
-          >
+          <button type="button" onClick={() => setSearch('')} className="shrink-0 cursor-pointer">
             <X size={13} className="text-neutral-500 transition-colors hover:text-neutral-300" />
           </button>
         )}
@@ -474,7 +489,7 @@ export function TranslationGrid({
                     left: 0,
                     width: '100%',
                     transform: `translateY(${virtualItem.start}px)`,
-                    gridTemplateColumns: '80px 1fr 1fr',
+                    gridTemplateColumns: '80px 1fr 1fr'
                   }}
                 >
                   <div
@@ -499,10 +514,7 @@ export function TranslationGrid({
                     />
                   </div>
 
-                  <div
-                    className="flex min-w-0 cursor-pointer flex-col gap-2 px-4 py-3"
-                    onClick={() => focusEntry(entry.rowId)}
-                  >
+                  <div className="flex min-w-0 cursor-text flex-col gap-2 px-4 py-3">
                     <div className="wrap-break-word font-mono text-[13px] leading-[1.6] text-neutral-200 whitespace-pre-wrap">
                       {entry.source ? (
                         renderSource(entry.source)
@@ -520,6 +532,17 @@ export function TranslationGrid({
                       )}
                       <span className="font-mono text-[10px] text-neutral-600">
                         {t('grid.charCount', { ns: 'translate', count: charCount })}
+                      </span>
+                      <span className="ml-auto">
+                        <button
+                          type="button"
+                          aria-label={t('grid.copySource', { ns: 'translate' })}
+                          title={t('grid.copySource', { ns: 'translate' })}
+                          className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
+                          onClick={(event) => handleCopySource(event, entry.source)}
+                        >
+                          <Copy size={11} />
+                        </button>
                       </span>
                     </div>
                   </div>
@@ -618,13 +641,13 @@ export function TranslationGrid({
                   transform: `translateY(${virtualItem.start + 20}px)`,
                   paddingLeft: '28px',
                   paddingRight: '28px',
-                  paddingBottom: '14px',
+                  paddingBottom: '14px'
                 }}
               >
                 <div className="mx-auto max-w-275">
                   <div
                     className={cn(
-                      'group grid cursor-pointer overflow-hidden rounded-xl border transition-all duration-120',
+                      'group grid cursor-default overflow-hidden rounded-xl border transition-all duration-120',
                       'border-[#1f2329] bg-[#0f1114]',
                       'hover:-translate-y-px hover:border-[#2a2f37] hover:shadow-[0_4px_16px_rgba(0,0,0,0.18)]',
                       'focus-within:border-amber-500 focus-within:shadow-[0_0_0_3px_rgba(245,158,11,0.25),0_8px_24px_rgba(0,0,0,0.24)]',
@@ -689,9 +712,19 @@ export function TranslationGrid({
                         )}
                         {hasTags && (
                           <span className="inline-flex items-center gap-1 rounded bg-purple-500/14 px-2 py-0.5 text-[11px] font-medium text-purple-300">
-                            <AlertTriangle size={11} /> {t('grid.containsTags', { ns: 'translate' })}
+                            <AlertTriangle size={11} />{' '}
+                            {t('grid.containsTags', { ns: 'translate' })}
                           </span>
                         )}
+                        <button
+                          type="button"
+                          aria-label={t('grid.copySource', { ns: 'translate' })}
+                          title={t('grid.copySource', { ns: 'translate' })}
+                          className="inline-flex h-6 cursor-pointer items-center gap-1 rounded bg-transparent px-2 text-[11px] text-neutral-400 transition-colors hover:bg-[#1c1f24] hover:text-neutral-200"
+                          onClick={(event) => handleCopySource(event, entry.source)}
+                        >
+                          <Copy size={11} />
+                        </button>
                       </div>
 
                       <div className="wrap-break-word font-mono text-[14px] leading-[1.65] text-neutral-200 whitespace-pre-wrap">

--- a/src/renderer/src/locales/en/toasts.json
+++ b/src/renderer/src/locales/en/toasts.json
@@ -22,6 +22,7 @@
   },
   "translate": {
     "entrySaved": "Entry saved to dictionary",
+    "sourceCopied": "Source text copied",
     "nothingToSave": "No translation to save",
     "savedCount": "{{count}} translations saved to the dictionary",
     "xmlExported": "XML exported successfully",

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -74,6 +74,7 @@
     "translationPlaceholder": "Translation...",
     "startTyping": "Start typing the translation...",
     "applyDictionary": "Apply dictionary",
+    "copySource": "Copy source",
     "markTranslated": "Mark as translated",
     "next": "next",
     "newLine": "new line",

--- a/src/renderer/src/locales/en/translate.json
+++ b/src/renderer/src/locales/en/translate.json
@@ -83,6 +83,8 @@
     "dictionarySuggestion": "Dictionary suggests:",
     "dictionaryTagMod": "1 term (mod)",
     "dictionaryTag": "1 term",
+    "refreshView": "Refresh list",
+    "refreshViewHidden": "{{count}} pending",
     "pagination": {
       "pageSizeLabel": "Rows per page",
       "pageOf": "Page {{current}} of {{total}}",

--- a/src/renderer/src/locales/pt-BR/toasts.json
+++ b/src/renderer/src/locales/pt-BR/toasts.json
@@ -22,6 +22,7 @@
   },
   "translate": {
     "entrySaved": "Entrada salva no dicionário",
+    "sourceCopied": "Texto de origem copiado",
     "nothingToSave": "Nenhuma tradução para salvar",
     "savedCount": "{{count}} traduções salvas no dicionário",
     "xmlExported": "XML exportado com sucesso",

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -83,6 +83,8 @@
     "dictionarySuggestion": "Dicionário sugere:",
     "dictionaryTagMod": "1 termo (mod)",
     "dictionaryTag": "1 termo",
+    "refreshView": "Atualizar lista",
+    "refreshViewHidden": "{{count}} pendente(s)",
     "pagination": {
       "pageSizeLabel": "Linhas por página",
       "pageOf": "Página {{current}} de {{total}}",

--- a/src/renderer/src/locales/pt-BR/translate.json
+++ b/src/renderer/src/locales/pt-BR/translate.json
@@ -74,6 +74,7 @@
     "translationPlaceholder": "Tradução...",
     "startTyping": "Comece a digitar a tradução...",
     "applyDictionary": "Aplicar dicionário",
+    "copySource": "Copiar origem",
     "markTranslated": "Marcar como traduzida",
     "next": "próxima",
     "newLine": "nova linha",


### PR DESCRIPTION
## Summary
- Add a Copy button to the source-text column in both side-by-side and stacked views, so users can copy source text without stealing focus from the translation textarea. Also removes the click-to-focus behaviour from the source column and fixes the cursor affordance.
- Add sticky-row tracking: when a filter or search is active, edited entries are no longer instantly hidden after blur. A Refresh button with a pending-count badge lets the user manually flush them from the list. Sticky state auto-resets on filter/search change.

## Version
- v1.7.1 (bump reason: UX fix on existing translate feature)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes
- [x] Side-by-side: click source text → text cursor appears, translation textarea does NOT focus
- [x] Side-by-side: hover row → Copy icon button visible; click copies source text and shows "Source text copied" toast
- [x] Stacked: cursor over source text is `default`; Copy button works the same way
- [x] Filter = `Untranslated`: edit a row, Tab away → row stays visible; Refresh button shows "1 pending" badge
- [x] Click Refresh → sticky rows disappear, button disables
- [x] Change filter or search → sticky rows clear automatically
- [x] Filter = `All`: Refresh button stays disabled after edits (markSticky is a no-op)
- [x] Enter key on a filtered row keeps the row visible and advances focus correctly