### PR TITLE
fix(translate): keep current page when editing entries

### DIFF
--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -1,6 +1,6 @@
 appId: com.icosa.bg3-mod-translator
 productName: Icosa
-buildVersion: 1.7.1
+buildVersion: 1.7.2
 copyright: Copyright © 2026 kaironn
 directories:
   buildResources: build

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icosa",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "private": true,
   "description": "Desktop translator for Baldur's Gate 3 mod localization.",
   "main": "./out/main/index.js",

--- a/src/renderer/src/components/translation/TranslationGrid.tsx
+++ b/src/renderer/src/components/translation/TranslationGrid.tsx
@@ -134,7 +134,7 @@ export function TranslationGrid({
 
   useEffect(() => {
     setCurrentPage(1)
-  }, [deferredFilter, deferredSearch, entries])
+  }, [deferredFilter, deferredSearch])
 
   // clear selection and sticky rows when filter or search changes
   useEffect(() => {
@@ -146,6 +146,11 @@ export function TranslationGrid({
   const currentFilter: FilterSpec = { mode: deferredFilter, search: deferredSearch }
 
   const totalPages = Math.max(1, Math.ceil(filteredEntries.length / pageSize))
+
+  useEffect(() => {
+    if (currentPage > totalPages) setCurrentPage(totalPages)
+  }, [currentPage, totalPages])
+
   const pageEntries = filteredEntries.slice((currentPage - 1) * pageSize, currentPage * pageSize)
 
   const sideVirtualizer = useVirtualizer({


### PR DESCRIPTION
@
## Summary
- TranslationGrid no longer resets pagination to page 1 on every entry edit. The reset effect dropped `entries` from its dependency array, since `session.entries` is a fresh array on every `UPDATE_ENTRY` from the reducer.
- Added a clamp effect that lowers `currentPage` to `totalPages` whenever the filtered entry count shrinks - so translating rows out of the "untranslated" filter no longer leaves the user on an empty page.
- Filter and search changes still reset to page 1 (intended behavior preserved).

## Version
- v1.7.2 (bump reason: fix)

## Test plan
- [x] `pnpm typecheck` passes
- [x] `pnpm lint` passes (no new findings in `TranslationGrid.tsx`)
- [x] `pnpm dev`: open a mod that produces 2+ pages, navigate to page 2, edit a target cell - grid stays on page 2
- [x] Filter the grid to "untranslated" on the last page, translate enough rows that the filtered list shortens past the page start - `currentPage` clamps to the new last valid page
- [x] Change filter (all -> untranslated) or type in search - pagination resets to page 1
@